### PR TITLE
Fix broken link in ORM readme

### DIFF
--- a/packages/orm/README.md
+++ b/packages/orm/README.md
@@ -2,4 +2,4 @@
 
 Another ORM focused on type safety, easiness of use, flexibility and performance.
 
-[Read docs here](https://orchid-orm.netlify.app/guide/orm-setup-and-overview.html).
+[Read docs here](https://orchid-orm.netlify.app/guide/).


### PR DESCRIPTION
["Read docs here"](https://orchid-orm.netlify.app/guide/orm-setup-and-overview.html) at [orm package page](https://github.com/romeerez/orchid-orm/tree/071b3999d7fced2cf7cfdaaeb3c282eeaf5c623e/packages/orm) is broken.

I linked it to the guide home page which still makes sense but is much more future-proof.