### PR TITLE
docs: fix incorrect hasOne example

### DIFF
--- a/docs/src/guide/relations.md
+++ b/docs/src/guide/relations.md
@@ -40,7 +40,7 @@ export class ProfileTable extends BaseTable {
   }));
 
   relations = {
-    profile: this.hasOne(() => UserTable, {
+    profile: this.belongsTo(() => UserTable, {
       required: true,
       primaryKey: 'id',
       foreignKey: 'userId',


### PR DESCRIPTION
I believe the very first example in relations documentation is incorrect. As Profile has a foreign key to User, the respective relation should be declared with `belongsTo` rather than `hasOne`?