### PR TITLE
Simplify raw sql types

### DIFF
--- a/packages/core/src/raw.ts
+++ b/packages/core/src/raw.ts
@@ -16,14 +16,15 @@ export type RawExpression<C extends ColumnTypeBase = ColumnTypeBase> = {
   __column: C;
 };
 
-export const raw = (
+export const raw = <C extends ColumnTypeBase = ColumnTypeBase>(
   sql: string | TemplateLiteralArgs,
   values?: Record<string, unknown> | false,
-): RawExpression =>
-  ({
-    __raw: sql,
-    __values: values,
-  } as RawExpression);
+  column?: C,
+): RawExpression<C> => ({
+  __raw: sql,
+  __values: values,
+  __column: column as C,
+});
 
 export const isRaw = (obj: object): obj is RawExpression => '__raw' in obj;
 

--- a/packages/core/src/raw.ts
+++ b/packages/core/src/raw.ts
@@ -1,18 +1,23 @@
 import { ColumnTypeBase } from './columns/columnType';
 
+export type TemplateLiteralArgs = [
+  strings: TemplateStringsArray,
+  ...values: unknown[],
+];
+
 export type Sql = {
   text: string;
   values: unknown[];
 };
 
 export type RawExpression<C extends ColumnTypeBase = ColumnTypeBase> = {
-  __raw: string | [TemplateStringsArray, ...unknown[]];
+  __raw: string | TemplateLiteralArgs;
   __values?: Record<string, unknown> | false;
   __column: C;
 };
 
 export const raw = (
-  sql: string | [TemplateStringsArray, ...unknown[]],
+  sql: string | TemplateLiteralArgs,
   values?: Record<string, unknown> | false,
 ): RawExpression =>
   ({

--- a/packages/qb/pqb/src/columns/columnTypes.ts
+++ b/packages/qb/pqb/src/columns/columnTypes.ts
@@ -57,6 +57,7 @@ import {
   raw,
   RawExpression,
   setDefaultNowFn,
+  TemplateLiteralArgs,
   toArray,
 } from 'orchid-core';
 import { ArrayColumn } from './array';
@@ -172,18 +173,16 @@ function sql(sql: string): RawExpression;
 function sql(values: Record<string, unknown>, sql: string): RawExpression;
 function sql(
   values: Record<string, unknown>,
-): (...sql: [TemplateStringsArray, ...unknown[]]) => RawExpression;
+): (...sql: TemplateLiteralArgs) => RawExpression;
 function sql(
   ...args:
     | [sql: TemplateStringsArray, ...values: unknown[]]
     | [sql: string]
     | [values: Record<string, unknown>, sql?: string]
-):
-  | ((...sql: [TemplateStringsArray, ...unknown[]]) => RawExpression)
-  | RawExpression {
+): ((...sql: TemplateLiteralArgs) => RawExpression) | RawExpression {
   const arg = args[0];
   if (Array.isArray(arg)) {
-    return raw(args as [TemplateStringsArray, ...unknown[]]);
+    return raw(args as TemplateLiteralArgs);
   }
 
   if (typeof args[0] === 'string') {

--- a/packages/qb/pqb/src/queryMethods/from.ts
+++ b/packages/qb/pqb/src/queryMethods/from.ts
@@ -8,7 +8,14 @@ import {
 } from '../query';
 import { SelectQueryData } from '../sql';
 import { AliasOrTable } from '../utils';
-import { isRaw, QueryCatch, QueryThen, raw, RawExpression } from 'orchid-core';
+import {
+  isRaw,
+  QueryCatch,
+  QueryThen,
+  raw,
+  RawExpression,
+  TemplateLiteralArgs,
+} from 'orchid-core';
 import { getShapeFromSelect } from './select';
 
 export type FromArgs<T extends Query> =
@@ -19,7 +26,7 @@ export type FromArgs<T extends Query> =
         | Exclude<keyof T['withData'], symbol | number>,
       second?: { only?: boolean },
     ]
-  | [TemplateStringsArray, ...unknown[]];
+  | TemplateLiteralArgs;
 
 export type FromResult<
   T extends Query,
@@ -110,9 +117,10 @@ export class From {
     ...args: Args
   ): FromResult<T, Args> {
     if (Array.isArray(args[0])) {
-      return this._from(
-        raw(args as [TemplateStringsArray, ...unknown[]]),
-      ) as FromResult<T, Args>;
+      return this._from(raw(args as TemplateLiteralArgs)) as FromResult<
+        T,
+        Args
+      >;
     }
 
     if (typeof args[0] === 'string') {

--- a/packages/qb/pqb/src/queryMethods/having.ts
+++ b/packages/qb/pqb/src/queryMethods/having.ts
@@ -8,7 +8,7 @@ import {
 } from '../sql';
 import { pushQueryArray } from '../queryDataUtils';
 import { Aggregate1ArgumentTypes, AggregateOptions } from './aggregate';
-import { isRaw, raw, RawExpression } from 'orchid-core';
+import { isRaw, raw, RawExpression, TemplateLiteralArgs } from 'orchid-core';
 
 type HavingArgObject<
   T extends Query,
@@ -30,7 +30,7 @@ export type HavingArg<T extends Query = Query> =
 
 export type HavingArgs<T extends Query> =
   | [...args: HavingArg<T>[]]
-  | [TemplateStringsArray, ...unknown[]];
+  | TemplateLiteralArgs;
 
 const processHavingArg = <T extends Query>(arg: HavingArg<T>): HavingItem => {
   if ('baseQuery' in arg || isRaw(arg)) {
@@ -81,7 +81,7 @@ const processHavingArgs = <T extends Query>(
   processArg: (arg: HavingArg<T>) => HavingItem | HavingItem[],
 ): (HavingItem | HavingItem[])[] => {
   if (Array.isArray(args[0])) {
-    return [processArg(raw(args as [TemplateStringsArray, ...unknown[]]))];
+    return [processArg(raw(args as TemplateLiteralArgs))];
   } else {
     return args.map((arg) => processArg(arg as HavingArg<T>));
   }

--- a/packages/qb/pqb/src/queryMethods/queryMethods.ts
+++ b/packages/qb/pqb/src/queryMethods/queryMethods.ts
@@ -53,6 +53,7 @@ import {
   Sql,
   QueryThen,
   ColumnsShapeBase,
+  TemplateLiteralArgs,
 } from 'orchid-core';
 import { AsMethods } from './as';
 import { QueryBase } from '../queryBase';
@@ -96,13 +97,11 @@ export type OrderArg<
     }
   | RawExpression;
 
-export type OrderArgs<T extends Query> =
-  | OrderArg<T>[]
-  | [TemplateStringsArray, ...unknown[]];
+export type OrderArgs<T extends Query> = OrderArg<T>[] | TemplateLiteralArgs;
 
 type FindArgs<T extends Query> =
   | [T['shape'][T['singlePrimaryKey']]['type'] | RawExpression]
-  | [TemplateStringsArray, ...unknown[]];
+  | TemplateLiteralArgs;
 
 type QueryHelper<T extends Query, Args extends unknown[], Result> = <
   Q extends {
@@ -315,7 +314,7 @@ export class QueryMethods {
   ): SetQueryReturnsOne<WhereResult<T>> {
     const [value] = args;
     if (Array.isArray(value)) {
-      return this._find(raw(args as [TemplateStringsArray, ...unknown[]]));
+      return this._find(raw(args as TemplateLiteralArgs));
     }
 
     if (value === null || value === undefined) {
@@ -527,7 +526,7 @@ export class QueryMethods {
   }
   _order<T extends Query>(this: T, ...args: OrderArgs<T>): T {
     if (Array.isArray(args[0])) {
-      return this._order(raw(args as [TemplateStringsArray, ...unknown[]]));
+      return this._order(raw(args as TemplateLiteralArgs));
     }
     return pushQueryArray(this, 'order', args);
   }

--- a/packages/qb/pqb/src/queryMethods/rawSql.ts
+++ b/packages/qb/pqb/src/queryMethods/rawSql.ts
@@ -1,6 +1,10 @@
 import { Query } from '../query';
 import { ColumnType } from '../columns';
-import { ColumnTypesBase, RawExpression } from 'orchid-core';
+import {
+  ColumnTypesBase,
+  RawExpression,
+  TemplateLiteralArgs,
+} from 'orchid-core';
 
 type SqlArgs<T extends Query> = SqlColumnArgs<T> | SqlNoColumnArgs;
 
@@ -18,11 +22,6 @@ type SqlNoColumnArgs =
 type Values = Record<string, unknown>;
 
 type ColumnFn<T extends Query> = (types: T['columnTypes']) => ColumnType;
-
-type TemplateLiteralArgs = [
-  strings: TemplateStringsArray,
-  ...values: unknown[],
-];
 
 type SqlFn<C extends ColumnType> = (
   ...args: TemplateLiteralArgs

--- a/packages/qb/pqb/src/queryMethods/update.ts
+++ b/packages/qb/pqb/src/queryMethods/update.ts
@@ -23,6 +23,7 @@ import {
   raw,
   QueryThen,
   isObjectEmpty,
+  TemplateLiteralArgs,
 } from 'orchid-core';
 import { QueryResult } from '../adapter';
 import { JsonModifiers } from './json';
@@ -178,7 +179,7 @@ type UpdateArg<T extends Query> = T['meta']['hasWhere'] extends true
 // Type of argument for `updateRaw`.
 // not available when there are no conditions on the query.
 type UpdateRawArgs<T extends Query> = T['meta']['hasWhere'] extends true
-  ? [sql: RawExpression] | [TemplateStringsArray, ...unknown[]]
+  ? [sql: RawExpression] | TemplateLiteralArgs
   : never;
 
 // `update` and `updateOrThrow` methods output type.
@@ -464,7 +465,7 @@ export class Update {
     ...args: UpdateRawArgs<T>
   ): UpdateResult<T> {
     if (Array.isArray(args[0])) {
-      const sql = raw(args as [TemplateStringsArray, ...unknown[]]);
+      const sql = raw(args as TemplateLiteralArgs);
       return (this as T & { meta: { hasWhere: true } })._updateRaw(sql);
     }
 

--- a/packages/qb/pqb/src/queryMethods/where.ts
+++ b/packages/qb/pqb/src/queryMethods/where.ts
@@ -8,6 +8,7 @@ import {
   MaybeArray,
   emptyObject,
   raw,
+  TemplateLiteralArgs,
 } from 'orchid-core';
 import { getIsJoinSubQuery } from '../sql/join';
 import { getShapeFromSelect } from './select';
@@ -38,7 +39,7 @@ export type WhereArg<T extends QueryBase> =
 
 export type WhereArgs<T extends QueryBase> =
   | WhereArg<T>[]
-  | [TemplateStringsArray, ...unknown[]];
+  | TemplateLiteralArgs;
 
 export type WhereInColumn<T extends QueryBase> =
   | keyof T['selectable']
@@ -81,7 +82,7 @@ export const addWhere = <T extends Where>(
     return pushQueryValue(
       q,
       'and',
-      raw(args as [TemplateStringsArray, ...unknown[]]),
+      raw(args as TemplateLiteralArgs),
     ) as unknown as WhereResult<T>;
   }
   return pushQueryArray(q, 'and', args) as unknown as WhereResult<T>;
@@ -93,7 +94,7 @@ export const addWhereNot = <T extends QueryBase>(
 ): WhereResult<T> => {
   if (Array.isArray(args[0])) {
     return pushQueryValue(q, 'and', {
-      NOT: raw(args as [TemplateStringsArray, ...unknown[]]),
+      NOT: raw(args as TemplateLiteralArgs),
     }) as unknown as WhereResult<T>;
   }
   return pushQueryValue(q, 'and', {


### PR DESCRIPTION
This is general refactoring/simplification:

1) Globally export `TemplateLiteralArgs` helper and always use it.
2) Always use `raw()` to construct raw SQL excerpts.

I will be basing an another PR on this which you may possibly reject, so I extracted this separately as I believe this is generally useful.