### PR TITLE
Add castTo method for raw expressions

### DIFF
--- a/.changeset/slow-turkeys-sleep.md
+++ b/.changeset/slow-turkeys-sleep.md
@@ -1,0 +1,6 @@
+---
+'pqb': patch
+'orchid-core': patch
+---
+
+Add `castTo` method for raw expressions (#113)

--- a/docs/src/guide/query-methods.md
+++ b/docs/src/guide/query-methods.md
@@ -172,13 +172,21 @@ const records = db.table
 
 When there is a need to use a piece of raw SQL, use the `sql` method.
 
-To select with a raw SQL, need to specify a column type as a first argument, so the TS could use it to guess the result type of the query:
+To select with a raw SQL, need to specify a column type as a first argument, so the TS could use it to infer the result type of the query:
 
 ```ts
-const result: { num: number }[] = await db.table.select({
+const result = await db.table.select({
   num: db.table.sql((t) => t.integer())`
     random() * 100
   `,
+});
+```
+
+Alternatively, static-cast the raw expression with:
+
+```ts
+const result = await db.table.select({
+  num: db.table.sql`random() * 100`.castTo<number>(),
 });
 ```
 
@@ -240,18 +248,21 @@ Summarizing:
 
 ```ts
 // simplest form:
-db.table`key = ${value}`;
+db.table.sql`key = ${value}`;
 
 // with column type for select:
-db.table((t) => t.boolean())`key = ${value}`;
+db.table.sql((t) => t.boolean())`key = ${value}`;
+
+// with static-cast column type:
+db.table.sql`key = ${value}`.castTo<boolean>();
 
 // raw SQL string, not allowed to interpolate:
-db.table({ raw: 'random()' });
+db.table.sql({ raw: 'random()' });
 
 // with values:
-db.table({
+db.table.sql({
   values: {
-    column: 'columnName',
+    columnName: 'column',
     one: 1,
     two: 2,
   },
@@ -259,10 +270,10 @@ db.table({
 });
 
 // with column type for select:
-db.table((t) => t.decimal(), { raw: 'random()' });
+db.table.sql((t) => t.decimal(), { raw: 'random()' });
 
 // combine values and template literal:
-db.table({ values: { one: 1, two: 2 } })`
+db.table.sql({ values: { one: 1, two: 2 } })`
   ($one + $two) / $one
 `;
 ```


### PR DESCRIPTION
This is forked from #117, so only the last commit is relevant.

The PR adds support for static-casting raw selects with:

```ts
const result = await db.table.select('id', 'name', {
  num: db.table.sql`random() * 100`.castTo<number>(),
});
```

Plus it fixes some mistakes in raw sql documentation.

Defining a type directly in query makes it easier and safer for users. The current alternative is no-op `transform`:

```ts
const result = await db.table
  .select('id', 'name', {
    num: db.table.sql`random() * 100`,
  })
  .transform(
    (items) =>
      items as Array<
        (typeof items)[0] & {
          num: number;
        }
      >,
  );
```

Deferring static-cast to user-land code is not really an option as it's against the separation of concerns. The further code is supposed to work with prepared data, not unknowns.

---

Converting `RawExpression` into a class also lays ground for simpler syntax for providing column name values or defining columns:

```ts
// this:
db.table.sql((t) => t.boolean())`key = ${value}`;

// could become:
db.table.sql`key = ${value}`.asColumn((t) => t.boolean());

// and this:
db.table.sql({
  values: {
    column: 'columnName',
    one: 1,
    two: 2,
  },
  raw: '$$columnName = $one + $two',
});

// could become:
db.table.sql`$$columnName = ${1} + ${2}`.withValues({
  column: 'columnName',
});
```

Honestly, I would deprecate the current `` sql(...)`...` `` syntax as it's hardly readable and it even breaks syntax highlight in VS Code:

<img width="429" alt="image" src="https://github.com/romeerez/orchid-orm/assets/128121/5de443e6-9b54-4802-89dc-963901627594">
