### PR TITLE
fix(core): fixed issue with updateAt and snakecase

### DIFF
--- a/.changeset/cold-icons-push.md
+++ b/.changeset/cold-icons-push.md
@@ -1,0 +1,5 @@
+---
+'orchid-core': minor
+---
+
+Fixed issue where trying to set updatedAt on a table with snakecase resulted in error (#144)

--- a/packages/core/src/columns/timestamps.test.ts
+++ b/packages/core/src/columns/timestamps.test.ts
@@ -95,5 +95,29 @@ describe('timestamps methods', () => {
       expect(table.shape.createdAt.data.name).toBe('created_at');
       expect(table.shape.updatedAt.data.name).toBe('updated_at');
     });
+
+    it('should not update updated_at column when updating snakeCase table with `updated_at = `', () => {
+      const db = createDb({
+        databaseURL: process.env.PG_URL,
+        snakeCase: true,
+      });
+
+      const table = db('snake', (t) => ({
+        id: t.serial().primaryKey(),
+        ...t.timestampsSnakeCase(),
+      }));
+
+      const q = table.where().update({ updatedAt : now });
+
+      expectSql(
+        q.toSql(),
+        `
+            UPDATE "snake"
+            SET "updated_at" = $1
+        `,
+        [now],
+      );
+    });
+
   });
 });

--- a/packages/core/src/columns/timestamps.ts
+++ b/packages/core/src/columns/timestamps.ts
@@ -24,14 +24,16 @@ const makeInjector =
   (data: (RawSQLBase | Record<string, unknown> | (() => void))[]) => {
     const alreadyUpdatesUpdatedAt = data.some((item) => {
       if (isRawSQL(item)) {
-        updatedAtRegex.lastIndex = 0;
-        return updatedAtRegex.test(
+        const matches = updatedAtRegex.test(
           typeof item._sql === 'string'
             ? item._sql
             : (item._sql[0] as unknown as string[]).join(''),
         );
+        updatedAtRegex.lastIndex = 0;
+        return matches;
       } else {
-        return typeof item !== 'function' && item[key];
+        const exists = typeof item !== 'function' && item[key];
+        return exists;
       }
     });
 
@@ -81,7 +83,7 @@ export const makeTimestampsHelpers = (
     const updatedAtInjectorSnake = makeInjector(
       updatedAtRegexSnake,
       raw(`${quotedUpdatedAtSnakeCase} = ${now}`),
-      'updated_at',
+      'updatedAt',
     );
 
     // push a function to the query to search for existing timestamp and add a new timestamp value if it's not set in the update.


### PR DESCRIPTION
Fixed problem where adding updatedAt with a custom date to an update request on a snakecase table results in an error complainiing there are duplicate 'updated_at' columns in the generated sql.

Issue #144 