### PR TITLE
Types optimizations and 234 fix

### DIFF
--- a/.changeset/cool-dogs-bow.md
+++ b/.changeset/cool-dogs-bow.md
@@ -1,0 +1,12 @@
+---
+'orchid-orm-schema-to-zod': minor
+'orchid-orm-test-factory': minor
+'test-utils': minor
+'myqb': minor
+'rake-db': minor
+'pqb': minor
+'orchid-core': minor
+'orchid-orm': minor
+---
+
+Significantly optimize types

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -8,10 +8,12 @@ export type QueryInput = string | { text: string; values?: unknown[] };
 /**
  * Generic result returning from query methods.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type QueryResultRow = Record<string, any>;
+export interface QueryResultRow {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [K: string]: any;
+}
 
-export type AdapterConfigBase = {
+export interface AdapterConfigBase {
   /**
    * This option may be useful in CI when database container has started, CI starts performing next steps,
    * migrations begin to apply though database may be not fully ready for connections yet.
@@ -59,24 +61,24 @@ export type AdapterConfigBase = {
    * ```
    */
   connectRetry?: AdapterConfigConnectRetryParam | true;
-};
+}
 
-type AdapterConfigConnectRetryParam = {
+interface AdapterConfigConnectRetryParam {
   attempts?: number;
   strategy?:
     | AdapterConfigConnectRetryStrategyParam
     | AdapterConfigConnectRetryStrategy;
-};
+}
 
-type AdapterConfigConnectRetryStrategyParam = {
+interface AdapterConfigConnectRetryStrategyParam {
   delay?: number;
   factor?: number;
-};
+}
 
-export type AdapterConfigConnectRetry = {
+export interface AdapterConfigConnectRetry {
   attempts: number;
   strategy: AdapterConfigConnectRetryStrategy;
-};
+}
 
 type AdapterConfigConnectRetryStrategy = (
   attempt: number,
@@ -84,7 +86,7 @@ type AdapterConfigConnectRetryStrategy = (
 ) => Promise<void> | void;
 
 // Interface of a database adapter to use for different databases.
-export type AdapterBase = {
+export interface AdapterBase {
   connectRetryConfig?: AdapterConfigConnectRetry;
 
   connect(): Promise<unknown>;
@@ -105,13 +107,15 @@ export type AdapterBase = {
   ): Promise<unknown>;
   // close connection
   close(): Promise<void>;
-};
+}
 
 // Database adapter type for transaction that contains a connected db client.
-export type TransactionAdapterBase = AdapterBase & { client: unknown };
+export interface TransactionAdapterBase extends AdapterBase {
+  client: unknown;
+}
 
 // Wrapper type for transactions.
-export type TransactionState = {
+export interface TransactionState {
   // Database adapter that is connected to a currently running transaction.
   adapter: TransactionAdapterBase;
   // Number of transaction nesting.
@@ -120,7 +124,7 @@ export type TransactionState = {
   // Array of data and functions to call after commit.
   // 1st element is a query result, 2nd element is a query object, 3rd element is array of functions to call with the query result and object.
   afterCommit?: TransactionAfterCommitHook[];
-};
+}
 
 /**
  * Element of `afterCommit` transaction array. See {@link TransactionState.afterCommit}.

--- a/packages/core/src/columns/code.ts
+++ b/packages/core/src/columns/code.ts
@@ -1,14 +1,14 @@
-import { singleQuote } from '../utils';
+import { RecordKeyTrue, RecordString, singleQuote } from '../utils';
 import { ColumnDataBase } from './columnType';
 import {
   arrayMethodNames,
-  ArrayMethodsData,
   BaseNumberData,
   StringTypeData,
   DateColumnData,
   dateMethodNames,
   numberMethodNames,
   stringMethodNames,
+  ArrayMethodsDataForBaseColumn,
 } from './columnDataTypes';
 import { isRawSQL } from '../raw';
 
@@ -89,10 +89,10 @@ export const columnDefaultArgumentToCode = (
  */
 export const columnMethodsToCode = <T extends ColumnDataBase>(
   methodNames: (keyof T)[],
-  skip?: Record<string, true>,
-  aliases?: Record<string, string>,
+  skip?: RecordKeyTrue,
+  aliases?: RecordString,
 ) => {
-  return (data: T, skipLocal?: Record<string, true>) => {
+  return (data: T, skipLocal?: RecordKeyTrue) => {
     return methodNames
       .map((key) =>
         (skipLocal || skip)?.[key as string] ||
@@ -178,16 +178,14 @@ export const dateDataToCode =
 
 // Function to encode array column methods
 export const arrayDataToCode =
-  columnMethodsToCode<ArrayMethodsData>(arrayMethodNames);
+  columnMethodsToCode<ArrayMethodsDataForBaseColumn>(arrayMethodNames);
 
 /**
  * Converts column type and JSON type custom errors into code
  *
  * @param errors - custom error messages
  */
-export const columnErrorMessagesToCode = (
-  errors: Record<string, string>,
-): Code => {
+export const columnErrorMessagesToCode = (errors: RecordString): Code => {
   const props: Code[] = [];
 
   if (errors.required) {

--- a/packages/core/src/columns/columnDataTypes.ts
+++ b/packages/core/src/columns/columnDataTypes.ts
@@ -7,7 +7,7 @@ export const numberMethodNames: Exclude<
 >[] = ['gt', 'gte', 'lt', 'lte', 'step', 'int', 'finite', 'safe'];
 
 // numeric column and JSON type data for validations
-export type BaseNumberData = ColumnDataBase & {
+export interface BaseNumberData extends ColumnDataBase {
   lt?: number;
   lte?: number;
   gt?: number;
@@ -16,7 +16,7 @@ export type BaseNumberData = ColumnDataBase & {
   int?: boolean;
   finite?: boolean;
   safe?: boolean;
-};
+}
 
 // method names for string columns and JSON types to generate methods' code
 export const stringMethodNames: Exclude<
@@ -81,21 +81,27 @@ export const dateMethodNames: Exclude<
 >[] = ['min', 'max'];
 
 // date column data for validations
-export type DateColumnData = ColumnDataBase & {
+export interface DateColumnData extends ColumnDataBase {
   min?: Date;
   max?: Date;
-};
+}
 
 // method names for array column and JSON type to generate methods' code
-export const arrayMethodNames: Exclude<
-  keyof ArrayMethodsData,
-  keyof ColumnDataBase
->[] = ['min', 'max', 'length', 'nonEmpty'];
+export const arrayMethodNames: (keyof ArrayMethodsData)[] = [
+  'min',
+  'max',
+  'length',
+  'nonEmpty',
+];
 
 // array column and JSON type data for validations
-export type ArrayMethodsData = ColumnDataBase & {
+export interface ArrayMethodsData {
   min?: number;
   max?: number;
   length?: number;
   nonEmpty?: boolean;
-};
+}
+
+export interface ArrayMethodsDataForBaseColumn
+  extends ColumnDataBase,
+    ArrayMethodsData {}

--- a/packages/core/src/columns/columnSchema.ts
+++ b/packages/core/src/columns/columnSchema.ts
@@ -4,51 +4,71 @@ import {
   ErrorMessages,
   NullableColumn,
 } from './columnType';
-import { EmptyObject } from '../utils';
 
-export type ColumnSchemaGetterTableClass = {
+export interface ColumnSchemaGetterTableClass {
   prototype: { columns: ColumnTypesBase };
   inputSchema(): unknown;
   querySchema(): unknown;
-};
+}
 
 export type ColumnSchemaGetterColumns<T extends ColumnSchemaGetterTableClass> =
   T['prototype']['columns'];
 
-export interface ColumnSchemaConfig {
+export interface ColumnTypeSchemaArg {
   type: unknown;
-  parse: unknown;
+  nullable<T extends ColumnTypeBase>(
+    this: T,
+  ): NullableColumn<T, unknown, unknown, unknown>;
   encode: unknown;
+  parse: unknown;
   asType: unknown;
+  errors?<T extends ColumnTypeBase>(this: T, errors: ErrorMessages): void;
+}
+
+export interface ColumnSchemaConfig extends ColumnTypeSchemaArg {
   dateAsNumber: unknown;
   dateAsDate: unknown;
-  dateMethods: EmptyObject;
   enum: unknown;
   array: unknown;
   boolean: unknown;
   buffer: unknown;
   unknown: unknown;
   never: unknown;
-  string: unknown;
+  stringSchema: unknown;
   stringMin(max: number): unknown;
   stringMax(max: number): unknown;
   stringMinMax(min: number, max: number): unknown;
-  stringMethods: EmptyObject;
   number: unknown;
   int: unknown;
-  numberMethods: EmptyObject;
   stringNumberDate: unknown;
   timeInterval: unknown;
   bit(max?: number): unknown;
   uuid: unknown;
-  nullable<T extends ColumnTypeBase>(
-    this: T,
-  ): NullableColumn<T, unknown, unknown, unknown>;
   json(): ColumnTypeBase;
   inputSchema(this: ColumnSchemaGetterTableClass): unknown;
   outputSchema(this: ColumnSchemaGetterTableClass): unknown;
   querySchema(this: ColumnSchemaGetterTableClass): unknown;
   updateSchema(this: ColumnSchemaGetterTableClass): unknown;
   pkeySchema(this: ColumnSchemaGetterTableClass): unknown;
-  errors?<T extends ColumnTypeBase>(this: T, errors: ErrorMessages): void;
+
+  smallint(): ColumnTypeBase;
+  integer(): ColumnTypeBase;
+  real(): ColumnTypeBase;
+  smallSerial(): ColumnTypeBase;
+  serial(): ColumnTypeBase;
+
+  bigint(): ColumnTypeBase;
+  decimal(precision?: number, scale?: number): ColumnTypeBase;
+  doublePrecision(): ColumnTypeBase;
+  bigSerial(): ColumnTypeBase;
+  money(): ColumnTypeBase;
+  varchar(limit?: number): ColumnTypeBase;
+  char(limit?: number): ColumnTypeBase;
+  text(min: number, max: number): ColumnTypeBase;
+  string(limit?: number): ColumnTypeBase;
+  citext(min: number, max: number): ColumnTypeBase;
+
+  date(): ColumnTypeBase;
+  timestampNoTZ(precision?: number): ColumnTypeBase;
+  timestamp(precision?: number): ColumnTypeBase;
 }

--- a/packages/core/src/columns/columnType.ts
+++ b/packages/core/src/columns/columnType.ts
@@ -22,6 +22,10 @@ export type ColumnShapeInput<
   Optional
 > & { [K in Optional]?: Shape[K]['inputType'] };
 
+export type ColumnShapeInputPartial<Shape extends QueryColumnsInit> = {
+  [K in keyof Shape]?: Shape[K]['inputType'];
+};
+
 // output of a shape of columns
 export type ColumnShapeOutput<Shape extends QueryColumns> = {
   [K in keyof Shape]: Shape[K]['outputType'];
@@ -123,7 +127,9 @@ export type ParseColumn<T, OutputSchema, Output> = {
     : T[K];
 };
 
-export type PickColumnBaseData = { data: ColumnDataBase };
+export interface PickColumnBaseData {
+  data: ColumnDataBase;
+}
 
 // adds default type to the column
 // removes the default if the Value is null

--- a/packages/core/src/columns/columnType.ts
+++ b/packages/core/src/columns/columnType.ts
@@ -2,7 +2,7 @@ import { Code } from './code';
 import { RawSQLBase } from '../raw';
 import { QueryBaseCommon } from '../query';
 import { BaseOperators, OperatorBase } from './operators';
-import { ColumnSchemaConfig, ColumnTypeSchemaArg } from './columnSchema';
+import { ColumnTypeSchemaArg } from './columnSchema';
 import { RecordString } from '../utils';
 
 // get columns object type where nullable columns or columns with a default are optional
@@ -366,6 +366,19 @@ export type AsTypeArg<Schema> =
   | AsTypeArgWithType<Schema>
   | AsTypeArgWithoutType<Schema>;
 
+export interface PickType {
+  type: unknown;
+}
+
+export interface PickOutputType {
+  outputType: unknown;
+}
+
+export interface PickOutputTypeAndOperators {
+  outputType: unknown;
+  operators: unknown;
+}
+
 // Workaround for the "type instantiation is too deep" error.
 export interface QueryColumn<T = unknown, Op = BaseOperators> {
   dataType: string;
@@ -444,7 +457,7 @@ export abstract class ColumnTypeBase<
   errors: Schema['errors'];
 
   constructor(
-    schema: ColumnSchemaConfig,
+    schema: ColumnTypeSchemaArg,
     // type for validation lib for inserting and updating records
     // public inputSchema: InputSchema = undefined as InputSchema,
     public inputSchema: InputSchema,

--- a/packages/core/src/columns/operators.ts
+++ b/packages/core/src/columns/operators.ts
@@ -24,4 +24,6 @@ export type OperatorToSQL<Value, Ctx> = (
 ) => string;
 
 // Base type for the object with column operators.
-export type BaseOperators = Record<string, OperatorBase<any, any>>; // eslint-disable-line @typescript-eslint/no-explicit-any
+export interface BaseOperators {
+  [K: string]: OperatorBase<any, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+}

--- a/packages/core/src/columns/timestamps.ts
+++ b/packages/core/src/columns/timestamps.ts
@@ -3,7 +3,7 @@ import {
   ColumnWithDefault,
   getDefaultNowFn,
 } from './columnType';
-import { pushOrNewArrayToObject } from '../utils';
+import { pushOrNewArrayToObject, RecordUnknown } from '../utils';
 import { snakeCaseKey } from './types';
 import { isRawSQL, RawSQLBase } from '../raw';
 
@@ -20,7 +20,7 @@ type Timestamps<T extends ColumnTypeBase> = {
 // And if there is no value for `updatedAt`, it is setting the new value for it.
 const makeInjector =
   (updatedAtRegex: RegExp, updateUpdatedAtItem: RawSQLBase, key: string) =>
-  (data: (RawSQLBase | Record<string, unknown> | (() => void))[]) => {
+  (data: (RawSQLBase | RecordUnknown | (() => void))[]) => {
     const alreadyUpdatesUpdatedAt = data.some((item) => {
       if (isRawSQL(item)) {
         updatedAtRegex.lastIndex = 0;
@@ -51,7 +51,7 @@ class SimpleRawSQL extends RawSQLBase {
 // Construct a simplified raw SQL.
 const raw = (sql: string) => new SimpleRawSQL(sql);
 
-export type TimestampHelpers = {
+export interface TimestampHelpers {
   /**
    * Add `createdAt` and `updatedAt timestamps. Both have `now()` as a default, `updatedAt` is automatically updated during update.
    */
@@ -85,7 +85,7 @@ export type TimestampHelpers = {
     name(name: string): { timestampNoTZ(): T };
     timestampNoTZ(): T;
   }): Timestamps<T>;
-};
+}
 
 // Build `timestamps`, `timestampsNoTZ`, and similar helpers.
 export const makeTimestampsHelpers = (

--- a/packages/core/src/columns/timestamps.ts
+++ b/packages/core/src/columns/timestamps.ts
@@ -8,12 +8,12 @@ import { snakeCaseKey } from './types';
 import { isRawSQL, RawSQLBase } from '../raw';
 
 // Column types returned by `...t.timestamps()` and variations.
-type Timestamps<T extends ColumnTypeBase> = {
+export interface Timestamps<T extends ColumnTypeBase> {
   // Timestamp column with a `now()` default
   createdAt: ColumnWithDefault<T, RawSQLBase>;
   // Timestamp column with a `now()` default, and it's being updated on every record update.
   updatedAt: ColumnWithDefault<T, RawSQLBase>;
-};
+}
 
 // Builds a function which is triggered on every update of records.
 // It tries to find if `updatedAt` column is being updated with a user-provided value.

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2,7 +2,6 @@ import { AdapterBase } from './adapter';
 import {
   ColumnShapeInput,
   ColumnShapeOutput,
-  DefaultSelectColumns,
   QueryColumns,
   QueryColumnsInit,
   SinglePrimaryKey,
@@ -19,10 +18,6 @@ export type DbBase<
   Shape extends QueryColumnsInit,
   CT,
   ShapeWithComputed extends QueryColumns = Shape,
-  Result extends QueryColumns = Pick<
-    Shape,
-    DefaultSelectColumns<Shape>[number]
-  >,
 > = {
   adapter: Adapter;
   table: Table;
@@ -32,7 +27,6 @@ export type DbBase<
   singlePrimaryKey: SinglePrimaryKey<Shape>;
   outputType: ColumnShapeOutput<Shape>;
   inputType: ColumnShapeInput<Shape>;
-  result: Result;
   internal: QueryInternal;
   query(...args: SQLQueryArgs): Promise<unknown>;
   queryArrays(...args: SQLQueryArgs): Promise<unknown>;

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -15,7 +15,7 @@ export type Sql = {
 };
 
 // query metadata that is stored only on TS side, not available in runtime
-export type QueryMetaBase<Scopes extends RecordKeyTrue = RecordKeyTrue> = {
+export interface QueryMetaBase<Scopes extends RecordKeyTrue = RecordKeyTrue> {
   // kind of a query: select, update, create, etc.
   kind: string;
   // table alias
@@ -33,7 +33,7 @@ export type QueryMetaBase<Scopes extends RecordKeyTrue = RecordKeyTrue> = {
   scopes: Scopes;
   // tracking columns of the main table, joined tables, `with` tables that are available for `select`.
   selectable: SelectableBase;
-};
+}
 
 // static query data that is defined only once when the table instance is instantiated
 // and doesn't change anymore

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -59,6 +59,7 @@ export type CoreQueryScopes<Keys extends string = string> = Record<
 // both the table query objects
 // and the lightweight queries inside `where` and `on` callbacks
 export type QueryBaseCommon<Scopes extends RecordKeyTrue = RecordKeyTrue> = {
+  __isQuery: true;
   meta: QueryMetaBase<Scopes>;
   internal: QueryInternal;
 };

--- a/packages/core/src/queryMethods/then.ts
+++ b/packages/core/src/queryMethods/then.ts
@@ -1,21 +1,12 @@
 // This is a standard Promise['then'] method
 // copied from TS standard library because the original `then` is not decoupled from the Promise
 export type QueryThen<T> = <TResult1 = T, TResult2 = never>(
-  onfulfilled?:
-    | ((value: T) => TResult1 | PromiseLike<TResult1>)
-    | undefined
-    | null,
-  onrejected?:
-    | ((reason: any) => TResult2 | PromiseLike<TResult2>)
-    | undefined
-    | null,
+  onfulfilled?: (value: T) => TResult1 | PromiseLike<TResult1>,
+  onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>,
 ) => Promise<TResult1 | TResult2>;
 
 // This is a standard Promise['catch'] method
 // copied from TS standard library because the original `catch` is not decoupled from the Promise
 export type QueryCatch<T> = <TResult = never>(
-  onrejected?:
-    | ((reason: any) => TResult | PromiseLike<TResult>)
-    | undefined
-    | null,
+  onrejected?: (reason: any) => TResult | PromiseLike<TResult>,
 ) => Promise<T | TResult>;

--- a/packages/core/src/raw.ts
+++ b/packages/core/src/raw.ts
@@ -1,5 +1,6 @@
 import { ColumnTypeBase, QueryColumn } from './columns/columnType';
 import { OperatorToSQL } from './columns';
+import { RecordUnknown } from './utils';
 
 // Base class for the raw SQL and other classes that can produce SQL
 export abstract class Expression<T extends QueryColumn = QueryColumn> {
@@ -67,7 +68,7 @@ export type StaticSQLArgs =
   | [{ raw: string; values?: RawSQLValues }];
 
 // Record of values to pass and store in a RawSQL instance.
-export type RawSQLValues = Record<string, unknown>;
+export type RawSQLValues = RecordUnknown;
 
 // `type` method to be used in both static and dynamic variants of SQL expressions.
 export abstract class ExpressionTypeMethod {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -4,44 +4,15 @@ import {
   pushOrNewArray,
   pushOrNewArrayToObject,
   quoteObjectKey,
-  SetOptional,
   singleQuote,
-  SomeIsTrue,
 } from './utils';
 import url from 'url';
 import { assertType } from 'test-utils';
 
 describe('utils', () => {
-  describe('SomeIsTrue', () => {
-    it('should be true if some is true', () => {
-      assertType<SomeIsTrue<[false, false, true, false]>, true>();
-    });
-
-    it('should be false if none is true', () => {
-      assertType<SomeIsTrue<[false, false, false]>, false>();
-    });
-
-    it('should be false if types array is empty', () => {
-      assertType<SomeIsTrue<[]>, false>();
-    });
-  });
-
   describe('MaybeArray', () => {
     it('should turn a type into union of T | T[]', () => {
       assertType<MaybeArray<number>, number | number[]>();
-    });
-  });
-
-  describe('SetOptional', () => {
-    it('should make specified keys optional', () => {
-      assertType<
-        SetOptional<{ a: number; b: string; c: boolean }, 'b' | 'c'>,
-        {
-          a: number;
-          b?: string;
-          c?: boolean;
-        }
-      >();
     });
   });
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,23 +1,8 @@
 import url from 'url';
 import path from 'node:path';
 
-// Array contains `true` type.
-export type SomeIsTrue<T extends unknown[]> = T extends [
-  infer Head,
-  ...infer Tail,
-]
-  ? Head extends true
-    ? true
-    : SomeIsTrue<Tail>
-  : false;
-
 // It may be a value or an array of such values.
 export type MaybeArray<T> = T | T[];
-
-// Make some object properties optional.
-export type SetOptional<T, K extends PropertyKey> = Omit<T, K> & {
-  [P in K]?: P extends keyof T ? T[P] : never;
-};
 
 // Converts union to overloaded function.
 type OptionalPropertyNames<T> = {
@@ -54,10 +39,7 @@ export type Spread<A extends readonly [...any]> = A extends [
 
 // Simple merge two objects.
 // When they have common keys, the value of the second object will be used.
-export type MergeObjects<
-  A extends Record<string, unknown>,
-  B extends Record<string, unknown>,
-> = {
+export type MergeObjects<A extends RecordUnknown, B extends RecordUnknown> = {
   [K in keyof A | keyof B]: K extends keyof B
     ? B[K]
     : K extends keyof A
@@ -69,6 +51,10 @@ export type MergeObjects<
 // Use it for cases where you'd want to pick a string union,
 // this record type solves the same use case, but is better at handling the empty case.
 export type RecordKeyTrue = Record<PropertyKey, true>;
+
+export type RecordString = Record<string, string>;
+
+export type RecordUnknown = Record<string, unknown>;
 
 // Use a default string if the first argument string is undefined.
 export type CoalesceString<
@@ -283,16 +269,11 @@ export const deepCompare = (a: unknown, b: unknown): boolean => {
     }
 
     for (const key in a) {
-      if (
-        !deepCompare(
-          (a as Record<string, unknown>)[key],
-          (b as Record<string, unknown>)[key],
-        )
-      )
+      if (!deepCompare((a as RecordUnknown)[key], (b as RecordUnknown)[key]))
         return false;
     }
 
-    for (const key in b as Record<string, unknown>) {
+    for (const key in b as RecordUnknown) {
       if (!(key in a)) return false;
     }
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -50,11 +50,17 @@ export type MergeObjects<A extends RecordUnknown, B extends RecordUnknown> = {
 // Utility type to store info to know which keys are available.
 // Use it for cases where you'd want to pick a string union,
 // this record type solves the same use case, but is better at handling the empty case.
-export type RecordKeyTrue = Record<PropertyKey, true>;
+export interface RecordKeyTrue {
+  [K: string]: true;
+}
 
-export type RecordString = Record<string, string>;
+export interface RecordString {
+  [K: string]: string;
+}
 
-export type RecordUnknown = Record<string, unknown>;
+export interface RecordUnknown {
+  [K: string]: unknown;
+}
 
 // Use a default string if the first argument string is undefined.
 export type CoalesceString<

--- a/packages/orm/src/baseTable.test.ts
+++ b/packages/orm/src/baseTable.test.ts
@@ -447,7 +447,7 @@ describe('baseTable', () => {
     it('should have a columns shape type returned from database and parsed', () => {
       class SomeTable extends BaseTable {
         columns = this.setColumns((t) => ({
-          foo: t.text().parse(z.boolean(), () => true),
+          foo: t.text().parse(() => true),
         }));
       }
 

--- a/packages/orm/src/orm.ts
+++ b/packages/orm/src/orm.ts
@@ -20,10 +20,15 @@ import { DbTable, Table, TableClasses } from './baseTable';
 import { applyRelations } from './relations/relations';
 import { transaction } from './transaction';
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { ColumnsShapeBase, SQLQueryArgs, TransactionState } from 'orchid-core';
+import {
+  ColumnsShapeBase,
+  RecordUnknown,
+  SQLQueryArgs,
+  TransactionState,
+} from 'orchid-core';
 
 export type OrchidORM<T extends TableClasses = TableClasses> = {
-  [K in keyof T]: DbTable<T[K]>;
+  [K in keyof T]: DbTable<InstanceType<T[K]>>;
 } & {
   $transaction: typeof transaction;
   $adapter: Adapter;
@@ -187,7 +192,7 @@ export const orchidORM = <T extends TableClasses>(
       );
     }
 
-    (result as Record<string, unknown>)[key] = dbTable;
+    (result as RecordUnknown)[key] = dbTable;
   }
 
   applyRelations(qb, tableInstances, result);

--- a/packages/orm/src/relations/belongsTo.ts
+++ b/packages/orm/src/relations/belongsTo.ts
@@ -39,7 +39,6 @@ import {
 import {
   joinQueryChainingHOF,
   NestedInsertOneItem,
-  NestedInsertOneItemConnect,
   NestedInsertOneItemConnectOrCreate,
   NestedInsertOneItemCreate,
   NestedUpdateOneItem,
@@ -377,7 +376,7 @@ const nestedInsert = ({ query, primaryKeys }: State) => {
     let connected: unknown[];
     if (items.length) {
       for (let i = 0, len = items.length; i < len; i++) {
-        items[i] = t.findBy(items[i].connect as NestedInsertOneItemConnect);
+        items[i] = t.findBy(items[i].connect as WhereArg<Query>);
       }
 
       connected = await Promise.all(items);

--- a/packages/orm/src/relations/common/options.ts
+++ b/packages/orm/src/relations/common/options.ts
@@ -1,29 +1,29 @@
 import { ScopeFn, TableClass } from '../../baseTable';
 import { Query } from 'pqb';
 
-export type RelationCommonOptions<
+export interface RelationCommonOptions<
   Related extends TableClass = TableClass,
   Scope extends Query = Query,
-> = {
+> {
   scope?: ScopeFn<Related, Scope>;
   required?: boolean;
-};
+}
 
-export type RelationRefsOptions<
+export interface RelationRefsOptions<
   Column extends PropertyKey = string,
   Ref extends PropertyKey = string,
-> = {
+> {
   columns: Column[];
   references: Ref[];
-};
+}
 
-export type RelationKeysOptions<
+export interface RelationKeysOptions<
   PK extends PropertyKey = string,
   FK extends PropertyKey = string,
-> = {
+> {
   primaryKey: PK;
   foreignKey: FK;
-};
+}
 
 export type RelationRefsOrKeysOptions<
   Column extends PropertyKey = string,
@@ -32,13 +32,13 @@ export type RelationRefsOrKeysOptions<
   FK extends PropertyKey = string,
 > = RelationRefsOptions<Column, Ref> | RelationKeysOptions<PK, FK>;
 
-export type RelationThroughOptions<
+export interface RelationThroughOptions<
   Through extends PropertyKey = string,
   Source extends PropertyKey = string,
-> = {
+> {
   through: Through;
   source: Source;
-};
+}
 
 export type RelationHasOptions<
   Column extends PropertyKey = string,

--- a/packages/orm/src/relations/common/utils.ts
+++ b/packages/orm/src/relations/common/utils.ts
@@ -4,6 +4,7 @@ import {
   CreateCtx,
   getQueryAs,
   JoinCallback,
+  JoinQueryMethod,
   pushQueryOn,
   Query,
   RelationConfigBase,
@@ -13,12 +14,12 @@ import {
   WhereArg,
   WhereQueryBase,
 } from 'pqb';
-import { MaybeArray } from 'orchid-core';
+import { emptyArray, MaybeArray } from 'orchid-core';
 import { HasOneNestedInsert, HasOneNestedUpdate } from '../hasOne';
 import { HasManyNestedInsert, HasManyNestedUpdate } from '../hasMany';
 
 // INNER JOIN the current relation instead of the default OUTER behavior
-export type RelJoin = <T extends Query>(this: T) => T;
+export type RelJoin = JoinQueryMethod & (<T extends Query>(this: T) => T);
 
 export type NestedInsertOneItem = {
   create?: NestedInsertOneItemCreate;
@@ -262,7 +263,8 @@ export const joinQueryChainingHOF =
 
     return joiningQuery.where({
       EXISTS: {
-        args: [inner],
+        first: inner,
+        args: emptyArray,
       },
     });
   };

--- a/packages/orm/src/relations/common/utils.ts
+++ b/packages/orm/src/relations/common/utils.ts
@@ -14,26 +14,26 @@ import {
   WhereArg,
   WhereQueryBase,
 } from 'pqb';
-import { emptyArray, MaybeArray } from 'orchid-core';
+import { emptyArray, MaybeArray, RecordUnknown } from 'orchid-core';
 import { HasOneNestedInsert, HasOneNestedUpdate } from '../hasOne';
 import { HasManyNestedInsert, HasManyNestedUpdate } from '../hasMany';
 
 // INNER JOIN the current relation instead of the default OUTER behavior
 export type RelJoin = JoinQueryMethod & (<T extends Query>(this: T) => T);
 
-export type NestedInsertOneItem = {
+export interface NestedInsertOneItem {
   create?: NestedInsertOneItemCreate;
   connect?: NestedInsertOneItemConnect;
   connectOrCreate?: NestedInsertOneItemConnectOrCreate;
-};
+}
 
-export type NestedInsertOneItemCreate = Record<string, unknown>;
+export type NestedInsertOneItemCreate = RecordUnknown;
 
 export type NestedInsertOneItemConnect = WhereArg<WhereQueryBase>;
 
 export type NestedInsertOneItemConnectOrCreate = {
   where: WhereArg<WhereQueryBase>;
-  create: Record<string, unknown>;
+  create: RecordUnknown;
 };
 
 export type NestedInsertManyItems = {
@@ -42,13 +42,13 @@ export type NestedInsertManyItems = {
   connectOrCreate?: NestedInsertManyConnectOrCreate;
 };
 
-export type NestedInsertManyCreate = Record<string, unknown>[];
+export type NestedInsertManyCreate = RecordUnknown[];
 
 export type NestedInsertManyConnect = WhereArg<WhereQueryBase>[];
 
 export type NestedInsertManyConnectOrCreate = {
   where: WhereArg<WhereQueryBase>;
-  create: Record<string, unknown>;
+  create: RecordUnknown;
 }[];
 
 export type NestedInsertItem = NestedInsertOneItem | NestedInsertManyItems;
@@ -60,9 +60,9 @@ export type NestedUpdateOneItem = {
   update?: UpdateData<Query>;
   upsert?: {
     update: UpdateData<Query>;
-    create: Record<string, unknown> | (() => Record<string, unknown>);
+    create: RecordUnknown | (() => RecordUnknown);
   };
-  create: Record<string, unknown>;
+  create: RecordUnknown;
 };
 
 export type NestedUpdateManyItems = {
@@ -73,7 +73,7 @@ export type NestedUpdateManyItems = {
     where: MaybeArray<WhereArg<WhereQueryBase>>;
     data: UpdateData<Query>;
   };
-  create: Record<string, unknown>[];
+  create: RecordUnknown[];
 };
 
 export type NestedUpdateItem = NestedUpdateOneItem | NestedUpdateManyItems;
@@ -95,7 +95,7 @@ export const getSourceRelation = (
 export const hasRelationHandleCreate = (
   q: Query,
   ctx: CreateCtx,
-  item: Record<string, unknown>,
+  item: RecordUnknown,
   rowIndex: number,
   key: string,
   primaryKeys: string[],
@@ -144,7 +144,7 @@ export const hasRelationHandleCreate = (
 
 export const hasRelationHandleUpdate = (
   q: Query,
-  set: Record<string, unknown>,
+  set: RecordUnknown,
   key: string,
   primaryKeys: string[],
   nestedUpdate: HasOneNestedUpdate | HasManyNestedUpdate,
@@ -192,8 +192,8 @@ export const selectIfNotSelected = (q: Query, columns: string[]) => {
 
 export const relationWhere =
   (len: number, keys: string[], valueKeys: string[]) =>
-  (params: Record<string, unknown>) => {
-    const obj: Record<string, unknown> = {};
+  (params: RecordUnknown) => {
+    const obj: RecordUnknown = {};
     for (let i = 0; i < len; i++) {
       obj[keys[i]] = params[valueKeys[i]];
     }

--- a/packages/orm/src/relations/hasAndBelongsToMany.ts
+++ b/packages/orm/src/relations/hasAndBelongsToMany.ts
@@ -693,18 +693,20 @@ const nestedUpdate = (state: State) => {
               },
             ]);
           }),
-          [conditionsToWhereArg(params.update.where)],
+          [conditionsToWhereArg(params.update.where as WhereArg<Query>)],
         ),
         params.update.data as UpdateArg<Query>,
       );
     }
 
     if (params.disconnect) {
-      await _queryDelete(queryJoinTable(state, data, params.disconnect));
+      await _queryDelete(
+        queryJoinTable(state, data, params.disconnect as WhereArg<Query>),
+      );
     }
 
     if (params.delete) {
-      const j = queryJoinTable(state, data, params.delete);
+      const j = queryJoinTable(state, data, params.delete as WhereArg<Query>);
 
       const idsRows = await _queryDelete(
         _queryRows(_querySelect(j, state.throughForeignKeys)),
@@ -727,7 +729,9 @@ const nestedUpdate = (state: State) => {
 
       const idsRows = await _queryRows(
         _querySelect(
-          state.relatedTableQuery.where(conditionsToWhereArg(params.set)),
+          state.relatedTableQuery.where(
+            conditionsToWhereArg(params.set as WhereArg<Query>),
+          ),
           state.throughPrimaryKeys,
         ),
       );

--- a/packages/orm/src/relations/hasMany.ts
+++ b/packages/orm/src/relations/hasMany.ts
@@ -401,7 +401,7 @@ const nestedInsert = ({ query, primaryKeys, foreignKeys }: State) => {
         }
 
         items[i] = _queryUpdateOrThrow(
-          t.orWhere<Query>(...connect),
+          t.orWhere<Query>(...(connect as WhereArg<Query>[])),
           obj as UpdateData<WhereResult<Query>>,
         );
       }
@@ -549,11 +549,11 @@ const nestedUpdate = ({ query, primaryKeys, foreignKeys }: State) => {
 
         await _queryUpdate(
           t.where<Query>(
-            Array.isArray(params.set)
+            (Array.isArray(params.set)
               ? {
                   OR: params.set,
                 }
-              : params.set,
+              : params.set) as WhereArg<Query>,
           ),
           obj as UpdateData<WhereResult<Query>>,
         );

--- a/packages/orm/src/relations/hasOne.ts
+++ b/packages/orm/src/relations/hasOne.ts
@@ -41,7 +41,6 @@ import {
   joinHasThrough,
   joinQueryChainingHOF,
   NestedInsertOneItem,
-  NestedInsertOneItemConnect,
   NestedInsertOneItemConnectOrCreate,
   NestedInsertOneItemCreate,
   NestedUpdateOneItem,
@@ -395,7 +394,7 @@ const nestedInsert = ({ query, primaryKeys, foreignKeys }: State) => {
         items[i] =
           'connect' in item
             ? _queryUpdateOrThrow(
-                t.where(item.connect as NestedInsertOneItemConnect) as Omit<
+                t.where(item.connect as WhereArg<Query>) as Omit<
                   Query,
                   'meta'
                 > & {

--- a/packages/orm/src/relations/relations.ts
+++ b/packages/orm/src/relations/relations.ts
@@ -17,7 +17,7 @@ import {
   VirtualColumn,
   WhereArg,
 } from 'pqb';
-import { ColumnSchemaConfig, EmptyObject } from 'orchid-core';
+import { ColumnSchemaConfig, emptyArray, EmptyObject } from 'orchid-core';
 import { HasMany, HasManyInfo, makeHasManyMethod } from './hasMany';
 import {
   HasAndBelongsToMany,
@@ -375,7 +375,8 @@ const makeRelationQuery = (
         query = _queryWhere(_queryAll(toTable), [
           {
             EXISTS: {
-              args: [data.reverseJoin(this, toTable)],
+              first: data.reverseJoin(this, toTable),
+              args: emptyArray,
             },
           },
         ]);

--- a/packages/orm/src/relations/relations.ts
+++ b/packages/orm/src/relations/relations.ts
@@ -1,5 +1,10 @@
-import { BelongsTo, BelongsToInfo, makeBelongsToMethod } from './belongsTo';
-import { HasOne, HasOneInfo, makeHasOneMethod } from './hasOne';
+import {
+  BelongsTo,
+  BelongsToInfo,
+  BelongsToParams,
+  makeBelongsToMethod,
+} from './belongsTo';
+import { HasOne, HasOneInfo, HasOneParams, makeHasOneMethod } from './hasOne';
 import { DbTable, Table, TableClass } from '../baseTable';
 import { OrchidORM } from '../orm';
 import {
@@ -10,18 +15,29 @@ import {
   CreateData,
   getQueryAs,
   Query,
-  RelationConfigBase,
   RelationJoinQuery,
   RelationQuery,
   RelationsBase,
   VirtualColumn,
   WhereArg,
 } from 'pqb';
-import { ColumnSchemaConfig, emptyArray, EmptyObject } from 'orchid-core';
-import { HasMany, HasManyInfo, makeHasManyMethod } from './hasMany';
+import {
+  ColumnSchemaConfig,
+  ColumnsShapeBase,
+  emptyArray,
+  EmptyObject,
+  RecordUnknown,
+} from 'orchid-core';
+import {
+  HasMany,
+  HasManyInfo,
+  HasManyParams,
+  makeHasManyMethod,
+} from './hasMany';
 import {
   HasAndBelongsToMany,
   HasAndBelongsToManyInfo,
+  HasAndBelongsToManyParams,
   makeHasAndBelongsToManyMethod,
 } from './hasAndBelongsToMany';
 import { getSourceRelation, getThroughRelation } from './common/utils';
@@ -53,6 +69,26 @@ export type RelationToOneDataForCreate<
       };
     };
 
+export type RelationToOneDataForCreateSameQuery<Q extends Query> =
+  | {
+      create: CreateData<Q>;
+      connect?: never;
+      connectOrCreate?: never;
+    }
+  | {
+      create?: never;
+      connect: WhereArg<Q>;
+      connectOrCreate?: never;
+    }
+  | {
+      create?: never;
+      connect?: never;
+      connectOrCreate: {
+        where: WhereArg<Q>;
+        create: CreateData<Q>;
+      };
+    };
+
 // `hasMany` and `hasAndBelongsToMany` relation data available for create. It supports:
 // - `create` to create related records
 // - `connect` to find existing records by `where` conditions and update their foreign keys with the new id
@@ -76,69 +112,72 @@ export interface RelationThunkBase {
 
 export type RelationThunk = BelongsTo | HasOne | HasMany | HasAndBelongsToMany;
 
-export type RelationThunks = Record<string, RelationThunk>;
+export interface RelationThunks {
+  [K: string]: RelationThunk;
+}
 
-export type RelationData = {
+export interface RelationData {
   returns: 'one' | 'many';
-  method(params: Record<string, unknown>): Query;
+  method(params: RecordUnknown): Query;
   virtualColumn?: VirtualColumn<ColumnSchemaConfig>;
   joinQuery: RelationJoinQuery;
   reverseJoin: RelationJoinQuery;
   modifyRelatedQuery?(relatedQuery: Query): (query: Query) => void;
-};
+}
 
 export type RelationScopeOrTable<Relation extends RelationThunkBase> =
   Relation['options']['scope'] extends (q: Query) => Query
     ? ReturnType<Relation['options']['scope']>
-    : RelationQueryFromFn<Relation>;
+    : DbTable<InstanceType<ReturnType<Relation['fn']>>>;
 
-type RelationQueryFromFn<
-  Relation extends RelationThunkBase,
-  TC extends TableClass = ReturnType<Relation['fn']>,
-  Q extends Query = DbTable<TC>,
-> = Q;
+export interface RelationConfigSelf {
+  columns: ColumnsShapeBase;
+  relations: RelationThunks;
+}
 
-export type RelationConfig<
-  T extends Table = Table,
-  Relations extends RelationThunks = RelationThunks,
-  Relation extends RelationThunk = RelationThunk,
-  K extends string = string,
-  TableQuery extends Query = Query,
-  Result extends RelationConfigBase = Relation extends BelongsTo
-    ? BelongsToInfo<T, Relation, K, TableQuery>
-    : Relation extends HasOne
-    ? HasOneInfo<T, Relations, Relation, K, TableQuery>
-    : Relation extends HasMany
-    ? HasManyInfo<T, Relations, Relation, K, TableQuery>
-    : Relation extends HasAndBelongsToMany
-    ? HasAndBelongsToManyInfo<T, Relation, K, TableQuery>
-    : never,
-> = Result;
+export type RelationConfigParams<
+  T extends RelationConfigSelf,
+  Relation extends RelationThunk,
+> = Relation extends BelongsTo
+  ? BelongsToParams<T, Relation>
+  : Relation extends HasOne
+  ? HasOneParams<T, Relation>
+  : Relation extends HasMany
+  ? HasManyParams<T, Relation>
+  : Relation extends HasAndBelongsToMany
+  ? HasAndBelongsToManyParams<T, Relation>
+  : never;
 
 export type MapRelation<
-  T extends Table,
-  Relations extends RelationThunks,
-  RelationName extends keyof Relations & string,
-  Relation extends RelationThunk = Relations[RelationName],
-  TableQuery extends Query = RelationScopeOrTable<Relation>,
+  T extends RelationConfigSelf,
+  K extends keyof T['relations'] & string,
 > = RelationQuery<
-  RelationConfig<T, Relations, Relation, RelationName, TableQuery>
+  T['relations'][K] extends BelongsTo
+    ? BelongsToInfo<T, K, RelationScopeOrTable<T['relations'][K]>>
+    : T['relations'][K] extends HasOne
+    ? HasOneInfo<T, K, RelationScopeOrTable<T['relations'][K]>>
+    : T['relations'][K] extends HasMany
+    ? HasManyInfo<T, K, RelationScopeOrTable<T['relations'][K]>>
+    : T['relations'][K] extends HasAndBelongsToMany
+    ? HasAndBelongsToManyInfo<T, K, RelationScopeOrTable<T['relations'][K]>>
+    : never
 >;
 
-export type MapRelations<T extends Table> = T extends {
+export type MapRelations<T> = T extends {
+  columns: ColumnsShapeBase;
   relations: RelationThunks;
 }
   ? {
-      [K in keyof T['relations'] & string]: MapRelation<T, T['relations'], K>;
+      [K in keyof T['relations'] & string]: MapRelation<T, K>;
     }
   : EmptyObject;
 
-type ApplyRelationData = {
+interface ApplyRelationData {
   relationName: string;
   relation: RelationThunk;
-  dbTable: DbTable<TableClass>;
-  otherDbTable: DbTable<TableClass>;
-};
+  dbTable: DbTable<Table>;
+  otherDbTable: DbTable<Table>;
+}
 
 type DelayedRelations = Map<Query, Record<string, ApplyRelationData[]>>;
 
@@ -241,7 +280,7 @@ export const applyRelations = (
           !throughRel.table.relations[source as never]
         ) {
           message += `: cannot find \`${source}\` relation in \`${
-            (throughRel.table as DbTable<TableClass>).definedAs
+            (throughRel.table as DbTable<Table>).definedAs
           }\` required by the \`source\` option`;
         }
 
@@ -344,7 +383,7 @@ const applyRelation = (
     joinQuery: data.joinQuery,
   };
 
-  (dbTable.relations as Record<string, unknown>)[relationName] = query;
+  (dbTable.relations as RecordUnknown)[relationName] = query;
 
   const tableRelations = delayedRelations.get(dbTable);
   if (!tableRelations) return;
@@ -399,7 +438,7 @@ const makeRelationQuery = (
 
       return new Proxy(data.method, {
         get(_, prop) {
-          return (query as unknown as Record<string, unknown>)[prop as string];
+          return (query as unknown as RecordUnknown)[prop as string];
         },
       }) as unknown as RelationQuery;
     },

--- a/packages/orm/src/repo.test.ts
+++ b/packages/orm/src/repo.test.ts
@@ -1,8 +1,8 @@
 import { orchidORM } from './orm';
-import { QueryReturnType } from 'pqb';
 import { createRepo } from './repo';
 import { BaseTable } from './test-utils/test-utils';
 import { assertType, expectSql, testDbOptions } from 'test-utils';
+import { QueryReturnType } from 'orchid-core';
 
 class SomeTable extends BaseTable {
   readonly table = 'someTable';

--- a/packages/orm/src/test-utils/test-utils.ts
+++ b/packages/orm/src/test-utils/test-utils.ts
@@ -2,12 +2,9 @@ import { createBaseTable, Selectable } from '../baseTable';
 import { now, testAdapter, testColumnTypes } from 'test-utils';
 import { orchidORM } from '../orm';
 import { Query, testTransaction } from 'pqb';
-import { z } from 'zod';
-import { zodSchemaConfig } from 'schema-to-zod';
 
 export const BaseTable = createBaseTable({
   columnTypes: testColumnTypes,
-  schemaConfig: zodSchemaConfig,
 });
 
 export type User = Selectable<UserTable>;
@@ -19,15 +16,7 @@ export class UserTable extends BaseTable {
     UserKey: t.name('userKey').text(),
     Password: t.name('password').text(),
     Picture: t.name('picture').text().nullable(),
-    Data: t
-      .name('data')
-      .json(
-        z.object({
-          name: z.string(),
-          tags: z.string().array(),
-        }),
-      )
-      .nullable(),
+    Data: t.name('data').json<{ name: string; tags: string[] }>().nullable(),
     Age: t.name('age').integer().nullable(),
     Active: t.name('active').boolean().nullable(),
     ...t.timestamps(),
@@ -279,14 +268,7 @@ export class ActiveUserWithProfile extends BaseTable {
     bio: t.text().nullable(),
     password: t.text(),
     picture: t.text().nullable(),
-    data: t
-      .json(
-        z.object({
-          name: z.string(),
-          tags: z.string().array(),
-        }),
-      )
-      .nullable(),
+    data: t.json<{ name: string; tags: string[] }>().nullable(),
     age: t.integer().nullable(),
     active: t.boolean().nullable(),
     ...t.timestamps(),

--- a/packages/qb/myqb/src/columns/columnType.ts
+++ b/packages/qb/myqb/src/columns/columnType.ts
@@ -1,9 +1,32 @@
-import { BaseOperators, ColumnDataBase, ColumnTypeBase } from 'orchid-core';
+import {
+  BaseOperators,
+  ColumnDataBase,
+  ColumnSchemaConfig,
+  ColumnTypeBase,
+} from 'orchid-core';
 
 export type ColumnData = ColumnDataBase;
 
 export abstract class ColumnType<
+  Schema extends ColumnSchemaConfig = ColumnSchemaConfig,
   Type = unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  InputSchema extends Schema['type'] = any,
   Ops extends BaseOperators = BaseOperators,
   InputType = Type,
-> extends ColumnTypeBase<Type, Ops, InputType, ColumnData> {}
+  OutputType = Type,
+  OutputSchema extends Schema['type'] = InputSchema,
+  QueryType = InputType,
+  QuerySchema extends Schema['type'] = InputSchema,
+> extends ColumnTypeBase<
+  Schema,
+  Type,
+  InputSchema,
+  Ops,
+  InputType,
+  OutputType,
+  OutputSchema,
+  QueryType,
+  QuerySchema,
+  ColumnData
+> {}

--- a/packages/qb/pqb/src/adapter.ts
+++ b/packages/qb/pqb/src/adapter.ts
@@ -11,23 +11,25 @@ import {
 
 const { types } = pg;
 
-export type TypeParsers = Record<number, (input: string) => unknown>;
+export interface TypeParsers {
+  [K: number]: (input: string) => unknown;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type QueryResult<T extends QueryResultRow = any> = {
+export interface QueryResult<T extends QueryResultRow = any> {
   rowCount: number;
   rows: T[];
   fields: {
     name: string;
   }[];
-};
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type QueryArraysResult<R extends any[] = any[]> = {
+export interface QueryArraysResult<R extends any[] = any[]> {
   rowCount: number;
   rows: R[];
   fields: { name: string }[];
-};
+}
 
 const defaultTypeParsers: TypeParsers = {};
 
@@ -110,9 +112,7 @@ export class Adapter implements AdapterBase {
     query: QueryInput,
     types?: TypeParsers,
   ): Promise<QueryResult<T>> {
-    return performQuery(this, query, types) as unknown as Promise<
-      QueryResult<T>
-    >;
+    return performQuery(this, query, types) as never;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -120,9 +120,7 @@ export class Adapter implements AdapterBase {
     query: QueryInput,
     types?: TypeParsers,
   ): Promise<QueryArraysResult<R>> {
-    return performQuery(this, query, types, 'array') as unknown as Promise<
-      QueryArraysResult<R>
-    >;
+    return performQuery(this, query, types, 'array') as never;
   }
 
   async transaction<Result>(
@@ -160,7 +158,9 @@ const defaultTypesConfig = {
   },
 };
 
-type ConnectionSchema = { connection: { schema?: string } };
+interface ConnectionSchema {
+  connection: { schema?: string };
+}
 
 const setSearchPath = (client: PoolClient, schema?: string) => {
   if ((client as unknown as ConnectionSchema).connection.schema !== schema) {

--- a/packages/qb/pqb/src/adapter.ts
+++ b/packages/qb/pqb/src/adapter.ts
@@ -55,9 +55,9 @@ export interface AdapterConfig
   databaseURL?: string;
 }
 
-export type AdapterOptions = AdapterConfig & {
+export interface AdapterOptions extends AdapterConfig {
   types?: TypeParsers;
-};
+}
 
 export class Adapter implements AdapterBase {
   types: TypeParsers;

--- a/packages/qb/pqb/src/columns/array.test.ts
+++ b/packages/qb/pqb/src/columns/array.test.ts
@@ -1,4 +1,4 @@
-import { assertType, testColumnTypes as t, testDb } from 'test-utils';
+import { assertType, testZodColumnTypes as t, testDb } from 'test-utils';
 
 describe('array column', () => {
   afterAll(testDb.close);

--- a/packages/qb/pqb/src/columns/array.ts
+++ b/packages/qb/pqb/src/columns/array.ts
@@ -25,17 +25,18 @@ export type ArrayColumnValue = Pick<
   | 'data'
 >;
 
-export type ArrayData<Item extends ArrayColumnValue> = ColumnData &
-  ArrayMethodsData & {
-    item: Item;
-  };
+export interface ArrayData<Item extends ArrayColumnValue>
+  extends ColumnData,
+    ArrayMethodsData {
+  item: Item;
+}
 
 export class ArrayColumn<
   Schema extends ColumnSchemaConfig,
   Item extends ArrayColumnValue,
-  InputType extends Schema['type'],
-  OutputType extends Schema['type'],
-  QueryType extends Schema['type'],
+  InputType,
+  OutputType,
+  QueryType,
 > extends ColumnType<
   Schema,
   Item['type'][],

--- a/packages/qb/pqb/src/columns/array.ts
+++ b/packages/qb/pqb/src/columns/array.ts
@@ -6,6 +6,7 @@ import {
   ArrayMethodsData,
   arrayDataToCode,
   ColumnSchemaConfig,
+  ColumnTypeSchemaArg,
 } from 'orchid-core';
 import { columnCode } from './code';
 import { Operators, OperatorsArray } from './operators';
@@ -32,7 +33,7 @@ export interface ArrayData<Item extends ArrayColumnValue>
 }
 
 export class ArrayColumn<
-  Schema extends ColumnSchemaConfig,
+  Schema extends ColumnTypeSchemaArg,
   Item extends ArrayColumnValue,
   InputType,
   OutputType,

--- a/packages/qb/pqb/src/columns/boolean.test.ts
+++ b/packages/qb/pqb/src/columns/boolean.test.ts
@@ -1,4 +1,4 @@
-import { assertType, testColumnTypes as t, testDb } from 'test-utils';
+import { assertType, testZodColumnTypes as t, testDb } from 'test-utils';
 
 describe('boolean column', () => {
   afterAll(testDb.close);

--- a/packages/qb/pqb/src/columns/boolean.ts
+++ b/packages/qb/pqb/src/columns/boolean.ts
@@ -1,7 +1,9 @@
 import { ColumnType } from './columnType';
 import { columnCode } from './code';
-import { Code, ColumnSchemaConfig } from 'orchid-core';
+import { Code, ColumnSchemaConfig, QueryColumn } from 'orchid-core';
 import { Operators, OperatorsBoolean } from './operators';
+
+export type BooleanQueryColumn = QueryColumn<boolean, OperatorsBoolean>;
 
 // 1 byte, true or false
 export class BooleanColumn<

--- a/packages/qb/pqb/src/columns/code.test.ts
+++ b/packages/qb/pqb/src/columns/code.test.ts
@@ -1,7 +1,7 @@
 import { columnsShapeToCode } from './code';
 import { codeToString } from 'orchid-core';
 import { raw } from '../sql/rawSql';
-import { testColumnTypes as t } from 'test-utils';
+import { testZodColumnTypes as t } from 'test-utils';
 
 describe('code', () => {
   describe('codeToString', () => {

--- a/packages/qb/pqb/src/columns/columnType.ts
+++ b/packages/qb/pqb/src/columns/columnType.ts
@@ -76,13 +76,13 @@ export type ForeignKey<Table extends string, Columns extends string[]> = (
 export type DropMode = 'CASCADE' | 'RESTRICT';
 
 // Used in migrations to make foreign key SQL
-export type ForeignKeyOptions = {
+export interface ForeignKeyOptions {
   name?: string;
   match?: ForeignKeyMatch;
   onUpdate?: ForeignKeyAction;
   onDelete?: ForeignKeyAction;
   dropMode?: DropMode;
-};
+}
 
 interface IndexColumnOptionsForColumn {
   collate?: string;
@@ -122,16 +122,18 @@ export interface SingleColumnIndexOptionsForColumn
 // Options for the `index` method of a column.
 export type SingleColumnIndexOptions = IndexColumnOptions & IndexOptions;
 
-export type ColumnFromDbParams = {
+export interface ColumnFromDbParams {
   isNullable?: boolean;
   default?: string;
   maxChars?: number;
   numericPrecision?: number;
   numericScale?: number;
   dateTimePrecision?: number;
-};
+}
 
-type PickColumnData = { data: ColumnData };
+export interface PickColumnData {
+  data: ColumnData;
+}
 
 export abstract class ColumnType<
   Schema extends ColumnTypeSchemaArg = ColumnTypeSchemaArg,
@@ -177,11 +179,7 @@ export abstract class ColumnType<
    * ```
    */
   primaryKey<T extends PickColumnBaseData>(this: T): PrimaryKeyColumn<T> {
-    return setColumnData(
-      this,
-      'isPrimaryKey',
-      true,
-    ) as unknown as PrimaryKeyColumn<T>;
+    return setColumnData(this, 'isPrimaryKey', true) as never;
   }
 
   /**

--- a/packages/qb/pqb/src/columns/columnType.utils.ts
+++ b/packages/qb/pqb/src/columns/columnType.utils.ts
@@ -1,8 +1,9 @@
 import { RawSQL } from '../sql/rawSql';
-import { ColumnFromDbParams, ColumnType } from './columnType';
+import { ColumnFromDbParams } from './columnType';
 import { TableData } from './columnTypes';
+import { ColumnTypeBase, RecordString } from 'orchid-core';
 
-const knownDefaults: Record<string, string> = {
+const knownDefaults: RecordString = {
   current_timestamp: 'now()',
   'transaction_timestamp()': 'now()',
 };
@@ -16,9 +17,9 @@ export const simplifyColumnDefault = (value?: string) => {
 };
 
 export const instantiateColumn = (
-  typeFn: () => ColumnType,
+  typeFn: () => ColumnTypeBase,
   params: ColumnFromDbParams,
-): ColumnType => {
+): ColumnTypeBase => {
   const column = typeFn();
 
   Object.assign(column.data, {
@@ -26,7 +27,7 @@ export const instantiateColumn = (
     default: simplifyColumnDefault(params.default),
   });
 
-  return column as unknown as ColumnType;
+  return column as unknown as ColumnTypeBase;
 };
 
 export const getConstraintKind = (

--- a/packages/qb/pqb/src/columns/columnTypes.ts
+++ b/packages/qb/pqb/src/columns/columnTypes.ts
@@ -52,39 +52,39 @@ import { makeRegexToFindInSql } from '../common/utils';
 import { CustomTypeColumn, DomainColumn } from './customType';
 import { RawSQL } from '../sql/rawSql';
 
-export type TableData = {
+export interface TableData {
   primaryKey?: TableData.PrimaryKey;
   indexes?: TableData.Index[];
   constraints?: TableData.Constraint[];
-};
+}
 
 export namespace TableData {
-  export type PrimaryKey = {
+  export interface PrimaryKey {
     columns: string[];
     options?: { name?: string };
-  };
+  }
 
-  export type Index = {
+  export interface Index {
     columns: IndexColumnOptions[];
     options: IndexOptions;
-  };
+  }
 
-  export type Constraint = {
+  export interface Constraint {
     name?: string;
     check?: Check;
     identity?: Identity;
     references?: References;
     dropMode?: DropMode;
-  };
+  }
 
   export type Check = RawSQLBase;
 
-  export type References = {
+  export interface References {
     columns: string[];
     fnOrTable: (() => ForeignKeyTable) | string;
     foreignColumns: string[];
     options?: ForeignKeyOptions;
-  };
+  }
 
   export interface Identity extends SequenceBaseOptions {
     always?: boolean;
@@ -304,7 +304,7 @@ export const makeColumnTypes = <SchemaConfig extends ColumnSchemaConfig>(
     identity(options) {
       return (schema.integer() as IntegerColumn<SchemaConfig>).identity(
         options,
-      ) as unknown as IdentityColumn<ReturnType<SchemaConfig['integer']>>;
+      ) as never;
     },
     smallSerial: schema.smallSerial,
     serial: schema.serial,

--- a/packages/qb/pqb/src/columns/columnTypes.ts
+++ b/packages/qb/pqb/src/columns/columnTypes.ts
@@ -1,48 +1,25 @@
-import {
-  BigIntColumn,
-  BigSerialColumn,
-  DecimalColumn,
-  DoublePrecisionColumn,
-  IdentityColumn,
-  IntegerColumn,
-  RealColumn,
-  SerialColumn,
-  SmallIntColumn,
-  SmallSerialColumn,
-} from './number';
+import { IdentityColumn, IntegerColumn } from './number';
 import {
   BitColumn,
   BitVaryingColumn,
   BoxColumn,
   ByteaColumn,
-  CharColumn,
   CidrColumn,
   CircleColumn,
-  CitextColumn,
   InetColumn,
   LineColumn,
   LsegColumn,
   MacAddr8Column,
   MacAddrColumn,
-  MoneyColumn,
   PathColumn,
   PointColumn,
   PolygonColumn,
-  StringColumn,
-  TextColumn,
   TsQueryColumn,
   TsVectorColumn,
   UUIDColumn,
-  VarCharColumn,
   XMLColumn,
 } from './string';
-import {
-  DateColumn,
-  IntervalColumn,
-  TimeColumn,
-  TimestampColumn,
-  TimestampTZColumn,
-} from './dateTime';
+import { IntervalColumn, TimeColumn } from './dateTime';
 import { BooleanColumn } from './boolean';
 import { JSONTextColumn } from './json';
 import {
@@ -56,6 +33,7 @@ import {
   QueryColumn,
   QueryColumnsInit,
   RawSQLBase,
+  RecordUnknown,
   setCurrentColumnName,
   setDefaultLanguage,
   setDefaultNowFn,
@@ -148,12 +126,8 @@ export const getColumnTypes = <ColumnTypes, Shape extends QueryColumnsInit>(
   return fn(types);
 };
 
-export type DefaultColumnTypes<
-  SchemaConfig extends ColumnSchemaConfig,
-  NumberMethods = SchemaConfig['numberMethods'],
-  StringMethods = SchemaConfig['stringMethods'],
-  DateMethods = SchemaConfig['dateMethods'],
-> = TimestampHelpers & {
+export interface DefaultColumnTypes<SchemaConfig extends ColumnSchemaConfig>
+  extends TimestampHelpers {
   schema: SchemaConfig;
   enum: SchemaConfig['enum'];
   array: SchemaConfig['array'];
@@ -168,52 +142,44 @@ export type DefaultColumnTypes<
   sql<T>(this: T, sql: string): RawSQLBase<QueryColumn, T>;
   sql<T>(
     this: T,
-    values: Record<string, unknown>,
+    values: RecordUnknown,
     sql: string,
   ): RawSQLBase<QueryColumn, T>;
   sql<T>(
     this: T,
-    values: Record<string, unknown>,
+    values: RecordUnknown,
   ): (...sql: TemplateLiteralArgs) => RawSQLBase<QueryColumn, T>;
   sql(
     ...args:
       | [sql: TemplateStringsArray, ...values: unknown[]]
       | [sql: string]
-      | [values: Record<string, unknown>, sql?: string]
+      | [values: RecordUnknown, sql?: string]
   ): ((...sql: TemplateLiteralArgs) => RawSQLBase) | RawSQLBase;
 
-  smallint(): SmallIntColumn<SchemaConfig> & NumberMethods;
-  integer(): IntegerColumn<SchemaConfig> & NumberMethods;
-  bigint(): BigIntColumn<SchemaConfig> & StringMethods;
-  numeric(
-    precision?: number,
-    scale?: number,
-  ): DecimalColumn<SchemaConfig> & StringMethods;
-  decimal(
-    precision?: number,
-    scale?: number,
-  ): DecimalColumn<SchemaConfig> & StringMethods;
-  real(): RealColumn<SchemaConfig> & NumberMethods;
-  doublePrecision(): DoublePrecisionColumn<SchemaConfig> & StringMethods;
+  smallint: SchemaConfig['smallint'];
+  integer: SchemaConfig['integer'];
+  bigint: SchemaConfig['bigint'];
+  numeric: SchemaConfig['decimal'];
+  decimal: SchemaConfig['decimal'];
+  real: SchemaConfig['real'];
+  doublePrecision: SchemaConfig['doublePrecision'];
   identity(
     options?: TableData.Identity,
-  ): IdentityColumn<IntegerColumn<SchemaConfig> & NumberMethods>;
-  smallSerial(): SmallSerialColumn<SchemaConfig> & NumberMethods;
-  serial(): SerialColumn<SchemaConfig> & NumberMethods;
-  bigSerial(): BigSerialColumn<SchemaConfig> & StringMethods;
-  money(): MoneyColumn<SchemaConfig> & StringMethods;
-  varchar(limit?: number): VarCharColumn<SchemaConfig> & StringMethods;
-  char(limit?: number): CharColumn<SchemaConfig> & StringMethods;
-  text(min: number, max: number): TextColumn<SchemaConfig> & StringMethods;
+  ): IdentityColumn<ReturnType<SchemaConfig['integer']>>;
+  smallSerial: SchemaConfig['smallSerial'];
+  serial: SchemaConfig['serial'];
+  bigSerial: SchemaConfig['bigSerial'];
+  money: SchemaConfig['money'];
+  varchar: SchemaConfig['varchar'];
+  char: SchemaConfig['char'];
+  text: SchemaConfig['text'];
   // `varchar` column with optional limit defaulting to 255.
-  string(limit?: number): StringColumn<SchemaConfig> & StringMethods;
-  citext(min: number, max: number): CitextColumn<SchemaConfig> & StringMethods;
+  string: SchemaConfig['string'];
+  citext: SchemaConfig['citext'];
   bytea(): ByteaColumn<SchemaConfig>;
-  date(): DateColumn<SchemaConfig> & DateMethods;
-  timestampNoTZ(
-    precision?: number,
-  ): TimestampColumn<SchemaConfig> & DateMethods;
-  timestamp(precision?: number): TimestampTZColumn<SchemaConfig> & DateMethods;
+  date: SchemaConfig['date'];
+  timestampNoTZ: SchemaConfig['timestampNoTZ'];
+  timestamp: SchemaConfig['timestamp'];
   time(precision?: number): TimeColumn<SchemaConfig>;
   interval(fields?: string, precision?: number): IntervalColumn<SchemaConfig>;
   boolean(): BooleanColumn<SchemaConfig>;
@@ -300,38 +266,11 @@ export type DefaultColumnTypes<
   ): EmptyObject;
 
   check(check: RawSQLBase): EmptyObject;
-};
+}
 
 export const makeColumnTypes = <SchemaConfig extends ColumnSchemaConfig>(
   schema: SchemaConfig,
 ): DefaultColumnTypes<SchemaConfig> => {
-  const columnsWithMethods: Record<
-    string,
-    { new (...args: unknown[]): unknown }
-  > = {};
-
-  function columnWithMethods<
-    Methods extends Record<string, unknown>,
-    Args extends unknown[],
-    Klass extends { new (...args: Args): EmptyObject },
-  >(klass: Klass, methods: Methods, ...args: Args): never {
-    if (columnsWithMethods[klass.name]) {
-      return new columnsWithMethods[klass.name](...args) as never;
-    }
-
-    // @ts-expect-error don't know how to fix that error
-    const withMethods = class extends klass {};
-    Object.assign(withMethods.prototype, methods);
-
-    return new (columnsWithMethods[klass.name] = withMethods as unknown as {
-      new (...args: unknown[]): unknown;
-    })(...args) as never;
-  }
-
-  const numberMethods = schema.numberMethods;
-  const stringMethods = schema.stringMethods;
-  const dateMethods = schema.dateMethods;
-
   return {
     schema,
     enum: schema.enum,
@@ -358,97 +297,36 @@ export const makeColumnTypes = <SchemaConfig extends ColumnSchemaConfig>(
       }
 
       return (...args: TemplateLiteralArgs) =>
-        new RawSQL(args, arg as Record<string, unknown>);
+        new RawSQL(args, arg as RecordUnknown);
     },
 
-    smallint() {
-      return columnWithMethods(SmallIntColumn, numberMethods, schema);
-    },
-    integer() {
-      return columnWithMethods(IntegerColumn, numberMethods, schema);
-    },
-    bigint() {
-      return columnWithMethods(BigIntColumn, stringMethods, schema);
-    },
-    numeric(precision, scale) {
-      return columnWithMethods(
-        DecimalColumn,
-        stringMethods,
-        schema,
-        precision,
-        scale,
-      );
-    },
-    decimal(precision, scale) {
-      return columnWithMethods(
-        DecimalColumn,
-        stringMethods,
-        schema,
-        precision,
-        scale,
-      );
-    },
-    real() {
-      return columnWithMethods(RealColumn, numberMethods, schema);
-    },
-    doublePrecision() {
-      return columnWithMethods(DoublePrecisionColumn, stringMethods, schema);
-    },
+    smallint: schema.smallint,
+    integer: schema.integer,
+    bigint: schema.bigint,
+    numeric: schema.decimal,
+    decimal: schema.decimal,
+    real: schema.real,
+    doublePrecision: schema.doublePrecision,
     identity(options) {
-      return (
-        columnWithMethods(
-          IntegerColumn,
-          numberMethods,
-          schema,
-        ) as IntegerColumn<SchemaConfig>
-      ).identity(options) as unknown as IdentityColumn<
-        IntegerColumn<SchemaConfig> & SchemaConfig['numberMethods']
-      >;
+      return (schema.integer() as IntegerColumn<SchemaConfig>).identity(
+        options,
+      ) as unknown as IdentityColumn<ReturnType<SchemaConfig['integer']>>;
     },
-    smallSerial() {
-      return columnWithMethods(SmallSerialColumn, numberMethods, schema);
-    },
-    serial() {
-      return columnWithMethods(SerialColumn, numberMethods, schema);
-    },
-    bigSerial() {
-      return columnWithMethods(BigSerialColumn, stringMethods, schema);
-    },
-    money() {
-      return columnWithMethods(MoneyColumn, stringMethods, schema);
-    },
-    varchar(limit) {
-      return columnWithMethods(VarCharColumn, stringMethods, schema, limit);
-    },
-    char(limit) {
-      return columnWithMethods(CharColumn, stringMethods, schema, limit);
-    },
-    text(min, max) {
-      return columnWithMethods(TextColumn, stringMethods, schema, min, max);
-    },
-    string(limit = 255) {
-      return columnWithMethods(StringColumn, stringMethods, schema, limit);
-    },
-    citext(min, max) {
-      return columnWithMethods(CitextColumn, stringMethods, schema, min, max);
-    },
+    smallSerial: schema.smallSerial,
+    serial: schema.serial,
+    bigSerial: schema.bigSerial,
+    money: schema.money,
+    varchar: schema.varchar,
+    char: schema.char,
+    text: schema.text,
+    string: schema.string,
+    citext: schema.citext,
     bytea() {
       return new ByteaColumn<SchemaConfig>(schema);
     },
-    date() {
-      return columnWithMethods(DateColumn, dateMethods, schema);
-    },
-    timestampNoTZ(precision) {
-      return columnWithMethods(TimestampColumn, dateMethods, schema, precision);
-    },
-    timestamp(precision) {
-      return columnWithMethods(
-        TimestampTZColumn,
-        dateMethods,
-        schema,
-        precision,
-      );
-    },
+    date: schema.date,
+    timestampNoTZ: schema.timestampNoTZ,
+    timestamp: schema.timestamp,
     time(precision) {
       return new TimeColumn<SchemaConfig>(schema, precision);
     },

--- a/packages/qb/pqb/src/columns/columnTypes.ts
+++ b/packages/qb/pqb/src/columns/columnTypes.ts
@@ -137,27 +137,18 @@ export interface DefaultColumnTypes<SchemaConfig extends ColumnSchemaConfig>
 
   name<T>(this: T, name: string): T;
 
-  sql<T>(
-    this: T,
-    sql: TemplateStringsArray,
-    ...values: unknown[]
-  ): RawSQLBase<QueryColumn, T>;
-  sql<T>(this: T, sql: string): RawSQLBase<QueryColumn, T>;
-  sql<T>(
-    this: T,
-    values: RecordUnknown,
-    sql: string,
-  ): RawSQLBase<QueryColumn, T>;
-  sql<T>(
-    this: T,
-    values: RecordUnknown,
-  ): (...sql: TemplateLiteralArgs) => RawSQLBase<QueryColumn, T>;
-  sql(
-    ...args:
+  sql<
+    T,
+    Args extends
       | [sql: TemplateStringsArray, ...values: unknown[]]
       | [sql: string]
-      | [values: RecordUnknown, sql?: string]
-  ): ((...sql: TemplateLiteralArgs) => RawSQLBase) | RawSQLBase;
+      | [values: RecordUnknown, sql?: string],
+  >(
+    this: T,
+    ...args: Args
+  ): Args extends [RecordUnknown]
+    ? (...sql: TemplateLiteralArgs) => RawSQLBase<QueryColumn, T>
+    : RawSQLBase<QueryColumn, T>;
 
   smallint: SchemaConfig['smallint'];
   integer: SchemaConfig['integer'];

--- a/packages/qb/pqb/src/columns/columnTypes.ts
+++ b/packages/qb/pqb/src/columns/columnTypes.ts
@@ -86,20 +86,23 @@ export namespace TableData {
     options?: ForeignKeyOptions;
   };
 
-  export type Identity = {
+  export interface Identity extends SequenceBaseOptions {
     always?: boolean;
-  } & Omit<SequenceOptions, 'dataType' | 'ownedBy'>;
+  }
 
-  export type SequenceOptions = {
-    dataType?: 'smallint' | 'integer' | 'bigint';
+  interface SequenceBaseOptions {
     incrementBy?: number;
     startWith?: number;
     min?: number;
     max?: number;
     cache?: number;
     cycle?: boolean;
+  }
+
+  export interface SequenceOptions extends SequenceBaseOptions {
+    dataType?: 'smallint' | 'integer' | 'bigint';
     ownedBy?: string;
-  };
+  }
 }
 
 export const newTableData = (): TableData => ({});

--- a/packages/qb/pqb/src/columns/columnsByType.ts
+++ b/packages/qb/pqb/src/columns/columnsByType.ts
@@ -2,7 +2,9 @@ import { ColumnSchemaConfig, ColumnTypeBase } from 'orchid-core';
 import { makeColumnTypes } from './columnTypes';
 import { ColumnType } from './columnType';
 
-export type ColumnsByType = Record<string, () => ColumnTypeBase>;
+export interface ColumnsByType {
+  [K: string]: () => ColumnTypeBase;
+}
 
 export const makeColumnsByType = (schema: ColumnSchemaConfig) => {
   const t = makeColumnTypes(schema);

--- a/packages/qb/pqb/src/columns/columnsByType.ts
+++ b/packages/qb/pqb/src/columns/columnsByType.ts
@@ -1,8 +1,8 @@
-import { ColumnSchemaConfig } from 'orchid-core';
+import { ColumnSchemaConfig, ColumnTypeBase } from 'orchid-core';
 import { makeColumnTypes } from './columnTypes';
 import { ColumnType } from './columnType';
 
-export type ColumnsByType = Record<string, () => ColumnType>;
+export type ColumnsByType = Record<string, () => ColumnTypeBase>;
 
 export const makeColumnsByType = (schema: ColumnSchemaConfig) => {
   const t = makeColumnTypes(schema);

--- a/packages/qb/pqb/src/columns/columnsSchema.ts
+++ b/packages/qb/pqb/src/columns/columnsSchema.ts
@@ -2,23 +2,25 @@ import { ColumnType } from './columnType';
 import { OperatorsAny } from './operators';
 import { QueryColumns } from 'orchid-core';
 
-export type ColumnsShape = Record<string, ColumnType>;
+export interface ColumnsShape {
+  [K: string]: ColumnType;
+}
 
-export type ColumnsShapeToObject<Shape extends QueryColumns> = {
+export interface ColumnsShapeToObject<Shape extends QueryColumns> {
   dataType: 'object';
   type: ObjectType<Shape>;
   outputType: ObjectOutput<Shape>;
   queryType: ObjectQuery<Shape>;
   operators: OperatorsAny;
-};
+}
 
-export type ColumnsShapeToNullableObject<Shape extends QueryColumns> = {
+export interface ColumnsShapeToNullableObject<Shape extends QueryColumns> {
   dataType: 'object';
   type: ObjectType<Shape>;
   outputType: ObjectOutput<Shape> | null;
   queryType: ObjectQuery<Shape> | null;
   operators: OperatorsAny;
-};
+}
 
 type ObjectType<Shape extends QueryColumns> = {
   [K in keyof Shape]: Shape[K]['type'];
@@ -32,18 +34,18 @@ type ObjectQuery<Shape extends QueryColumns> = {
   [K in keyof Shape]: Shape[K]['queryType'];
 };
 
-export type ColumnsShapeToPluck<Shape extends QueryColumns> = {
+export interface ColumnsShapeToPluck<Shape extends QueryColumns> {
   dataType: 'array';
   type: Shape['pluck']['type'][];
   outputType: Shape['pluck']['outputType'][];
   queryType: Shape['pluck']['queryType'][];
   operators: OperatorsAny;
-};
+}
 
-export type ColumnsShapeToObjectArray<Shape extends QueryColumns> = {
+export interface ColumnsShapeToObjectArray<Shape extends QueryColumns> {
   dataType: 'array';
   type: ObjectType<Shape>[];
   outputType: ObjectOutput<Shape>[];
   queryType: ObjectQuery<Shape>[];
   operators: OperatorsAny;
-};
+}

--- a/packages/qb/pqb/src/columns/customType.test.ts
+++ b/packages/qb/pqb/src/columns/customType.test.ts
@@ -1,7 +1,7 @@
 import { CustomTypeColumn } from './customType';
 import {
   assertType,
-  testColumnTypes as t,
+  testZodColumnTypes as t,
   testDb,
   testSchemaConfig,
 } from 'test-utils';

--- a/packages/qb/pqb/src/columns/dateTime.test.ts
+++ b/packages/qb/pqb/src/columns/dateTime.test.ts
@@ -1,18 +1,17 @@
 import { userData } from '../test-utils/test-utils';
 import { TimestampColumn, TimestampTZColumn } from './dateTime';
-import { ColumnType } from './columnType';
 import {
   assertType,
   expectSql,
-  testColumnTypes as t,
+  testZodColumnTypes as t,
   testDb,
   testSchemaConfig,
   useTestDatabase,
 } from 'test-utils';
-import { TimeInterval } from 'orchid-core';
+import { ColumnTypeBase, TimeInterval } from 'orchid-core';
 import { z } from 'zod';
 
-const testTimestampInput = (column: ColumnType) => {
+const testTimestampInput = (column: ColumnTypeBase) => {
   const date = new Date();
   const string = date.toISOString();
   expect(column.encodeFn?.(string) as Date).toBe(string);

--- a/packages/qb/pqb/src/columns/dateTime.ts
+++ b/packages/qb/pqb/src/columns/dateTime.ts
@@ -30,7 +30,7 @@ export abstract class DateBaseColumn<
   OperatorsDate,
   DateColumnInput,
   string,
-  Schema['string']
+  Schema['stringSchema']
 > {
   declare data: DateColumnData;
   operators = Operators.date;
@@ -138,7 +138,7 @@ export class TimestampTZColumn<
 export class TimeColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
   Schema,
   string,
-  Schema['string'],
+  Schema['stringSchema'],
   OperatorsTime
 > {
   declare data: DateColumnData & { dateTimePrecision?: number };
@@ -146,7 +146,7 @@ export class TimeColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
   operators = Operators.time;
 
   constructor(schema: Schema, dateTimePrecision?: number) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
     this.data.dateTimePrecision = dateTimePrecision;
   }
 

--- a/packages/qb/pqb/src/columns/defaultSchemaConfig.ts
+++ b/packages/qb/pqb/src/columns/defaultSchemaConfig.ts
@@ -6,22 +6,34 @@ import {
   ParseColumn,
   setColumnData,
 } from 'orchid-core';
-import { DateBaseColumn } from './dateTime';
+import {
+  DateBaseColumn,
+  DateColumn,
+  TimestampColumn,
+  TimestampTZColumn,
+} from './dateTime';
 import { EnumColumn } from './enum';
 import { ArrayColumn, ArrayColumnValue } from './array';
 import { JSONColumn } from './json';
-
-type ParseDateToNumber = ParseColumn<
-  DateBaseColumn<DefaultSchemaConfig>,
-  unknown,
-  number
->;
-
-type ParseDateToDate = ParseColumn<
-  DateBaseColumn<DefaultSchemaConfig>,
-  unknown,
-  Date
->;
+import {
+  BigIntColumn,
+  BigSerialColumn,
+  DecimalColumn,
+  DoublePrecisionColumn,
+  IntegerColumn,
+  RealColumn,
+  SerialColumn,
+  SmallIntColumn,
+  SmallSerialColumn,
+} from './number';
+import {
+  CharColumn,
+  CitextColumn,
+  MoneyColumn,
+  StringColumn,
+  TextColumn,
+  VarCharColumn,
+} from './string';
 
 export interface DefaultSchemaConfig extends ColumnSchemaConfig {
   parse<T extends { type: unknown }, Output>(
@@ -38,9 +50,9 @@ export interface DefaultSchemaConfig extends ColumnSchemaConfig {
     T,
     Types extends {
       type: unknown;
-      input: unknown;
-      output: unknown;
-      query: unknown;
+      inputType: unknown;
+      outputType: unknown;
+      queryType: unknown;
     },
   >(
     this: T,
@@ -48,16 +60,20 @@ export interface DefaultSchemaConfig extends ColumnSchemaConfig {
     _fn: (
       type: <Type, Input = Type, Output = Type, Query = Type>() => {
         type: Type;
-        input: Input;
-        output: Output;
-        query: Query;
+        inputType: Input;
+        outputType: Output;
+        queryType: Query;
       },
     ) => Types,
-  ): Omit<T, 'type' | 'inputType' | 'outputType' | 'queryType'> & Types;
+  ): { [K in keyof T]: K extends keyof Types ? Types[K] : T[K] };
 
-  dateAsNumber(): ParseDateToNumber;
+  dateAsNumber(): ParseColumn<
+    DateBaseColumn<DefaultSchemaConfig>,
+    unknown,
+    number
+  >;
 
-  dateAsDate(): ParseDateToDate;
+  dateAsDate(): ParseColumn<DateBaseColumn<DefaultSchemaConfig>, unknown, Date>;
 
   enum<U extends string, T extends [U, ...U[]]>(
     dataType: string,
@@ -75,6 +91,30 @@ export interface DefaultSchemaConfig extends ColumnSchemaConfig {
   querySchema(): undefined;
   updateSchema(): undefined;
   pkeySchema(): undefined;
+
+  smallint(): SmallIntColumn<DefaultSchemaConfig>;
+  integer(): IntegerColumn<DefaultSchemaConfig>;
+  real(): RealColumn<DefaultSchemaConfig>;
+  smallSerial(): SmallSerialColumn<DefaultSchemaConfig>;
+  serial(): SerialColumn<DefaultSchemaConfig>;
+
+  bigint(): BigIntColumn<DefaultSchemaConfig>;
+  decimal(
+    precision?: number,
+    scale?: number,
+  ): DecimalColumn<DefaultSchemaConfig>;
+  doublePrecision(): DoublePrecisionColumn<DefaultSchemaConfig>;
+  bigSerial(): BigSerialColumn<DefaultSchemaConfig>;
+  money(): MoneyColumn<DefaultSchemaConfig>;
+  varchar(limit?: number): VarCharColumn<DefaultSchemaConfig>;
+  char(limit?: number): CharColumn<DefaultSchemaConfig>;
+  text(min: number, max: number): TextColumn<DefaultSchemaConfig>;
+  string(limit?: number): StringColumn<DefaultSchemaConfig>;
+  citext(min: number, max: number): CitextColumn<DefaultSchemaConfig>;
+
+  date(): DateColumn<DefaultSchemaConfig>;
+  timestampNoTZ(precision?: number): TimestampColumn<DefaultSchemaConfig>;
+  timestamp(precision?: number): TimestampTZColumn<DefaultSchemaConfig>;
 }
 
 // parse a date string to number, with respect to null
@@ -123,4 +163,30 @@ export const defaultSchemaConfig = {
     return new JSONColumn(defaultSchemaConfig, undefined);
   },
   setErrors: noop,
+
+  smallint: () => new SmallIntColumn(defaultSchemaConfig),
+  integer: () => new IntegerColumn(defaultSchemaConfig),
+  real: () => new RealColumn(defaultSchemaConfig),
+  smallSerial: () => new SmallSerialColumn(defaultSchemaConfig),
+  serial: () => new SerialColumn(defaultSchemaConfig),
+
+  bigint: () => new BigIntColumn(defaultSchemaConfig),
+  decimal: (precision?: number, scale?: number) =>
+    new DecimalColumn(defaultSchemaConfig, precision, scale),
+  doublePrecision: () => new DoublePrecisionColumn(defaultSchemaConfig),
+  bigSerial: () => new BigSerialColumn(defaultSchemaConfig),
+  money: () => new MoneyColumn(defaultSchemaConfig),
+  varchar: (limit?: number) => new VarCharColumn(defaultSchemaConfig, limit),
+  char: (limit?: number) => new CharColumn(defaultSchemaConfig, limit),
+  text: (min: number, max: number) =>
+    new TextColumn(defaultSchemaConfig, min, max),
+  string: (limit?: number) => new StringColumn(defaultSchemaConfig, limit),
+  citext: (min: number, max: number) =>
+    new CitextColumn(defaultSchemaConfig, min, max),
+
+  date: () => new DateColumn(defaultSchemaConfig),
+  timestampNoTZ: (precision?: number) =>
+    new TimestampColumn(defaultSchemaConfig, precision),
+  timestamp: (precision?: number) =>
+    new TimestampTZColumn(defaultSchemaConfig, precision),
 } as unknown as DefaultSchemaConfig;

--- a/packages/qb/pqb/src/columns/enum.test.ts
+++ b/packages/qb/pqb/src/columns/enum.test.ts
@@ -1,4 +1,4 @@
-import { assertType, testColumnTypes as t, testDb } from 'test-utils';
+import { assertType, testZodColumnTypes as t, testDb } from 'test-utils';
 
 describe('enum column', () => {
   afterAll(testDb.close);

--- a/packages/qb/pqb/src/columns/enum.ts
+++ b/packages/qb/pqb/src/columns/enum.ts
@@ -1,10 +1,10 @@
 import { ColumnType } from './columnType';
 import { columnCode } from './code';
-import { Code, ColumnSchemaConfig } from 'orchid-core';
+import { Code, ColumnTypeSchemaArg } from 'orchid-core';
 import { Operators, OperatorsAny } from './operators';
 
 export class EnumColumn<
-  Schema extends ColumnSchemaConfig,
+  Schema extends ColumnTypeSchemaArg,
   SchemaType extends Schema['type'],
   U extends string = string,
   T extends [U, ...U[]] = [U],

--- a/packages/qb/pqb/src/columns/json.test.ts
+++ b/packages/qb/pqb/src/columns/json.test.ts
@@ -1,5 +1,5 @@
 import { codeToString } from 'orchid-core';
-import { testColumnTypes as t, useTestDatabase } from 'test-utils';
+import { testZodColumnTypes as t, useTestDatabase } from 'test-utils';
 import { z } from 'zod';
 
 describe('json columns', () => {

--- a/packages/qb/pqb/src/columns/json.ts
+++ b/packages/qb/pqb/src/columns/json.ts
@@ -24,12 +24,12 @@ JSONColumn.prototype.encodeFn = JSON.stringify;
 // JSON non-binary type, stored as a text in the database, so it doesn't have rich functionality.
 export class JSONTextColumn<
   Schema extends ColumnSchemaConfig,
-> extends ColumnType<Schema, string, Schema['string'], OperatorsText> {
+> extends ColumnType<Schema, string, Schema['stringSchema'], OperatorsText> {
   dataType = 'json' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {

--- a/packages/qb/pqb/src/columns/json.ts
+++ b/packages/qb/pqb/src/columns/json.ts
@@ -1,7 +1,7 @@
 import { ColumnType } from './columnType';
 import { columnCode } from './code';
 import { Operators, OperatorsJson, OperatorsText } from './operators';
-import { Code, ColumnSchemaConfig } from 'orchid-core';
+import { Code, ColumnSchemaConfig, ColumnTypeSchemaArg } from 'orchid-core';
 
 // skip adding the default `encode` function to code
 const toCodeSkip = { encodeFn: JSON.stringify };
@@ -9,7 +9,7 @@ const toCodeSkip = { encodeFn: JSON.stringify };
 // Type of JSON column (jsonb).
 export class JSONColumn<
   T,
-  Schema extends ColumnSchemaConfig,
+  Schema extends ColumnTypeSchemaArg,
 > extends ColumnType<Schema, T, Schema['type'], OperatorsJson> {
   dataType = 'jsonb' as const;
   operators = Operators.json;

--- a/packages/qb/pqb/src/columns/number.test.ts
+++ b/packages/qb/pqb/src/columns/number.test.ts
@@ -1,15 +1,15 @@
-import { NumberBaseColumn } from './number';
 import {
   assertType,
   expectSql,
-  testColumnTypes as t,
+  testZodColumnTypes as t,
   testDb,
   TestSchemaConfig,
 } from 'test-utils';
 
 const testNumberColumnMethods = (
-  type: NumberBaseColumn<TestSchemaConfig, TestSchemaConfig['type']> &
-    TestSchemaConfig['numberMethods'],
+  type: ReturnType<
+    TestSchemaConfig['smallint' | 'integer' | 'real' | 'smallSerial' | 'serial']
+  >,
   name: string,
 ) => {
   expect(

--- a/packages/qb/pqb/src/columns/number.ts
+++ b/packages/qb/pqb/src/columns/number.ts
@@ -43,19 +43,19 @@ export abstract class IntegerBaseColumn<
 
 export abstract class NumberAsStringBaseColumn<
   Schema extends ColumnSchemaConfig,
-> extends ColumnType<Schema, string, Schema['string'], OperatorsNumber> {
+> extends ColumnType<Schema, string, Schema['stringSchema'], OperatorsNumber> {
   operators = Operators.number;
   declare data: ColumnData;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 }
 
 // exact numeric of selectable precision
 export class DecimalColumn<
   Schema extends ColumnSchemaConfig,
-> extends ColumnType<Schema, string, Schema['string'], OperatorsNumber> {
+> extends ColumnType<Schema, string, Schema['stringSchema'], OperatorsNumber> {
   declare data: ColumnData & {
     numericPrecision?: number;
     numericScale?: number;
@@ -68,7 +68,7 @@ export class DecimalColumn<
     numericPrecision?: number,
     numericScale?: number,
   ) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
     this.data.numericPrecision = numericPrecision;
     this.data.numericScale = numericScale;
   }

--- a/packages/qb/pqb/src/columns/number.ts
+++ b/packages/qb/pqb/src/columns/number.ts
@@ -8,8 +8,8 @@ import {
   setColumnData,
   addCode,
   ColumnWithDefault,
-  ColumnTypeBase,
   ColumnSchemaConfig,
+  PickColumnBaseData,
 } from 'orchid-core';
 import { columnCode, identityToCode } from './code';
 import type { TableData } from './columnTypes';
@@ -114,8 +114,10 @@ const intToCode = (column: ColumnType, t: string): Code => {
   return columnCode(column, t, code);
 };
 
-export type IdentityColumn<T extends Pick<ColumnTypeBase, 'data'>> =
-  ColumnWithDefault<T, Expression>;
+export type IdentityColumn<T extends PickColumnBaseData> = ColumnWithDefault<
+  T,
+  Expression
+>;
 
 // signed two-byte integer
 export class SmallIntColumn<

--- a/packages/qb/pqb/src/columns/string.test.ts
+++ b/packages/qb/pqb/src/columns/string.test.ts
@@ -1,14 +1,25 @@
-import { TextBaseColumn } from './string';
 import {
   assertType,
-  testColumnTypes as t,
+  testZodColumnTypes as t,
   testDb,
   TestSchemaConfig,
 } from 'test-utils';
 import { raw } from '../sql/rawSql';
 
 const testStringColumnMethods = (
-  type: TextBaseColumn<TestSchemaConfig> & TestSchemaConfig['stringMethods'],
+  type: ReturnType<
+    TestSchemaConfig[
+      | 'bigint'
+      | 'decimal'
+      | 'doublePrecision'
+      | 'bigSerial'
+      | 'money'
+      | 'varchar'
+      | 'char'
+      | 'text'
+      | 'string'
+      | 'citext']
+  >,
   name: string,
 ) => {
   expect(type.nonEmpty().toCode('t')).toBe(`t.${name}().nonEmpty()`);

--- a/packages/qb/pqb/src/columns/string.ts
+++ b/packages/qb/pqb/src/columns/string.ts
@@ -22,11 +22,14 @@ export type TextColumnData = StringTypeData;
 
 export abstract class TextBaseColumn<
   Schema extends ColumnSchemaConfig,
-> extends ColumnType<Schema, string, Schema['string'], OperatorsText> {
+> extends ColumnType<Schema, string, Schema['stringSchema'], OperatorsText> {
   declare data: TextColumnData;
   operators = Operators.text;
 
-  constructor(schema: Schema, schemaType: Schema['string'] = schema.string) {
+  constructor(
+    schema: Schema,
+    schemaType: Schema['stringSchema'] = schema.stringSchema,
+  ) {
     super(schema, schemaType);
   }
 }
@@ -37,7 +40,7 @@ export abstract class LimitedTextBaseColumn<
   declare data: TextColumnData & { maxChars?: number };
 
   constructor(schema: Schema, limit?: number) {
-    super(schema, limit ? schema.stringMax(limit) : schema.string);
+    super(schema, limit ? schema.stringMax(limit) : schema.stringSchema);
     this.data.maxChars = limit;
   }
 
@@ -147,7 +150,7 @@ const minMaxToSchema = <Schema extends ColumnSchemaConfig>(
     ? max
       ? schema.stringMinMax(min, max)
       : schema.stringMin(min)
-    : schema.string;
+    : schema.stringSchema;
 
 // text	variable unlimited length
 export class TextColumn<

--- a/packages/qb/pqb/src/columns/string.ts
+++ b/packages/qb/pqb/src/columns/string.ts
@@ -1,4 +1,4 @@
-import { ColumnData, ColumnType } from './columnType';
+import { ColumnData, ColumnType, PickColumnData } from './columnType';
 import { NumberBaseColumn } from './number';
 import {
   Code,
@@ -9,9 +9,9 @@ import {
   TemplateLiteralArgs,
   getDefaultLanguage,
   RawSQLBase,
-  ColumnTypeBase,
   StaticSQLArgs,
   ColumnSchemaConfig,
+  PickColumnBaseData,
 } from 'orchid-core';
 import { columnCode } from './code';
 import { RawSQL } from '../sql/rawSql';
@@ -509,7 +509,7 @@ export class TsVectorColumn<
    *
    * @param args
    */
-  generated<T extends Pick<ColumnType, 'data'>>(
+  generated<T extends PickColumnData>(
     this: T,
     ...args:
       | StaticSQLArgs
@@ -585,7 +585,7 @@ export class UUIDColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
     super(schema, schema.uuid);
   }
 
-  primaryKey<T extends Pick<ColumnTypeBase, 'data'>>(
+  primaryKey<T extends PickColumnBaseData>(
     this: T,
   ): // using & bc otherwise the return type doesn't match `primaryKey` in ColumnType and TS complains
   PrimaryKeyColumn<T> & { data: { default: RawSQLBase } } {

--- a/packages/qb/pqb/src/columns/string.ts
+++ b/packages/qb/pqb/src/columns/string.ts
@@ -192,14 +192,14 @@ export class ByteaColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
 export class PointColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
   Schema,
   string,
-  Schema['string'],
+  Schema['stringSchema'],
   OperatorsText
 > {
   dataType = 'point' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -211,14 +211,14 @@ export class PointColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
 export class LineColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
   Schema,
   string,
-  Schema['string'],
+  Schema['stringSchema'],
   OperatorsText
 > {
   dataType = 'line' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -230,14 +230,14 @@ export class LineColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
 export class LsegColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
   Schema,
   string,
-  Schema['string'],
+  Schema['stringSchema'],
   OperatorsText
 > {
   dataType = 'lseg' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -249,14 +249,14 @@ export class LsegColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
 export class BoxColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
   Schema,
   string,
-  Schema['string'],
+  Schema['stringSchema'],
   OperatorsText
 > {
   dataType = 'box' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -269,14 +269,14 @@ export class BoxColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
 export class PathColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
   Schema,
   string,
-  Schema['string'],
+  Schema['stringSchema'],
   OperatorsText
 > {
   dataType = 'path' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -287,12 +287,12 @@ export class PathColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
 // polygon	40+16n bytes	Polygon (similar to closed path)	((x1,y1),...)
 export class PolygonColumn<
   Schema extends ColumnSchemaConfig,
-> extends ColumnType<Schema, string, Schema['string'], OperatorsText> {
+> extends ColumnType<Schema, string, Schema['stringSchema'], OperatorsText> {
   dataType = 'polygon' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -304,14 +304,14 @@ export class PolygonColumn<
 export class CircleColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
   Schema,
   string,
-  Schema['string'],
+  Schema['stringSchema'],
   OperatorsText
 > {
   dataType = 'circle' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -321,11 +321,11 @@ export class CircleColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
 
 export class MoneyColumn<
   Schema extends ColumnSchemaConfig,
-> extends NumberBaseColumn<Schema, Schema['string']> {
+> extends NumberBaseColumn<Schema, Schema['stringSchema']> {
   dataType = 'money' as const;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -346,14 +346,14 @@ export class MoneyColumn<
 export class CidrColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
   Schema,
   string,
-  Schema['string'],
+  Schema['stringSchema'],
   OperatorsText
 > {
   dataType = 'cidr' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -365,14 +365,14 @@ export class CidrColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
 export class InetColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
   Schema,
   string,
-  Schema['string'],
+  Schema['stringSchema'],
   OperatorsText
 > {
   dataType = 'inet' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -383,12 +383,12 @@ export class InetColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
 // macaddr	6 bytes	MAC addresses
 export class MacAddrColumn<
   Schema extends ColumnSchemaConfig,
-> extends ColumnType<Schema, string, Schema['string'], OperatorsText> {
+> extends ColumnType<Schema, string, Schema['stringSchema'], OperatorsText> {
   dataType = 'macaddr' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -399,12 +399,12 @@ export class MacAddrColumn<
 // macaddr8	8 bytes	MAC addresses (EUI-64 format)
 export class MacAddr8Column<
   Schema extends ColumnSchemaConfig,
-> extends ColumnType<Schema, string, Schema['string'], OperatorsText> {
+> extends ColumnType<Schema, string, Schema['stringSchema'], OperatorsText> {
   dataType = 'macaddr8' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -473,12 +473,12 @@ type TsVectorGeneratedColumns = string[] | Record<string, SearchWeight>;
 // A tsvector value is a sorted list of distinct lexemes
 export class TsVectorColumn<
   Schema extends ColumnSchemaConfig,
-> extends ColumnType<Schema, string, Schema['string'], OperatorsText> {
+> extends ColumnType<Schema, string, Schema['stringSchema'], OperatorsText> {
   dataType = 'tsvector' as const;
   operators = Operators.text;
 
   constructor(schema: Schema, public defaultLanguage = getDefaultLanguage()) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -555,12 +555,12 @@ export class TsVectorColumn<
 // A tsquery value stores lexemes that are to be searched for
 export class TsQueryColumn<
   Schema extends ColumnSchemaConfig,
-> extends ColumnType<Schema, string, Schema['string'], OperatorsText> {
+> extends ColumnType<Schema, string, Schema['stringSchema'], OperatorsText> {
   dataType = 'tsquery' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {
@@ -614,14 +614,14 @@ export class UUIDColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
 export class XMLColumn<Schema extends ColumnSchemaConfig> extends ColumnType<
   Schema,
   string,
-  Schema['string'],
+  Schema['stringSchema'],
   OperatorsText
 > {
   dataType = 'xml' as const;
   operators = Operators.text;
 
   constructor(schema: Schema) {
-    super(schema, schema.string);
+    super(schema, schema.stringSchema);
   }
 
   toCode(t: string): Code {

--- a/packages/qb/pqb/src/columns/virtual.ts
+++ b/packages/qb/pqb/src/columns/virtual.ts
@@ -1,7 +1,7 @@
 import { ColumnType } from './columnType';
 import { CreateCtx, CreateSelf, UpdateCtx, UpdateSelf } from '../queryMethods';
 import { Operators, OperatorsAny } from './operators';
-import { ColumnSchemaConfig } from 'orchid-core';
+import { ColumnSchemaConfig, RecordUnknown } from 'orchid-core';
 
 export abstract class VirtualColumn<
   Schema extends ColumnSchemaConfig,
@@ -24,9 +24,9 @@ export abstract class VirtualColumn<
   create?(
     q: CreateSelf,
     ctx: CreateCtx,
-    item: Record<string, unknown>,
+    item: RecordUnknown,
     rowIndex: number,
   ): void;
 
-  update?(q: UpdateSelf, ctx: UpdateCtx, set: Record<string, unknown>): void;
+  update?(q: UpdateSelf, ctx: UpdateCtx, set: RecordUnknown): void;
 }

--- a/packages/qb/pqb/src/common/utils.ts
+++ b/packages/qb/pqb/src/common/utils.ts
@@ -1,9 +1,9 @@
 import { cloneQuery, QueryData, toSQLCacheKey, ToSQLQuery } from '../sql';
 import type { Query } from '../query/query';
-import type { QueryColumn, QueryThen } from 'orchid-core';
+import type { QueryColumn } from 'orchid-core';
 import { RelationQuery } from '../relations';
 import { Expression } from 'orchid-core';
-import { QueryBase } from '../query/queryBase';
+import { QueryBase, QueryBaseThen } from '../query/queryBase';
 
 export type AliasOrTable<T extends Pick<Query, 'table' | 'meta'>> =
   T['meta']['as'] extends string
@@ -28,7 +28,7 @@ export type ExpressionOutput<
 
 export type ExpressionOrQueryReturning<T> =
   | Expression<QueryColumn<T>>
-  | (QueryBase & { then: QueryThen<T> });
+  | QueryBaseThen<T>;
 
 export const getClonedQueryData = (query: QueryData): QueryData => {
   const cloned = { ...query };

--- a/packages/qb/pqb/src/common/utils.ts
+++ b/packages/qb/pqb/src/common/utils.ts
@@ -2,10 +2,11 @@ import { cloneQuery, QueryData, toSQLCacheKey, ToSQLQuery } from '../sql';
 import type { Query } from '../query/query';
 import type { QueryColumn } from 'orchid-core';
 import { RelationQuery } from '../relations';
-import { Expression } from 'orchid-core';
+import { Expression, PickQueryMeta } from 'orchid-core';
 import { QueryBase, QueryBaseThen } from '../query/queryBase';
+import { PickQueryMetaTable } from '../query/query';
 
-export type AliasOrTable<T extends Pick<Query, 'table' | 'meta'>> =
+export type AliasOrTable<T extends PickQueryMetaTable> =
   T['meta']['as'] extends string
     ? T['meta']['as']
     : T['table'] extends string
@@ -13,12 +14,12 @@ export type AliasOrTable<T extends Pick<Query, 'table' | 'meta'>> =
     : never;
 
 export type SelectableOrExpression<
-  T extends Pick<QueryBase, 'meta'> = QueryBase,
+  T extends PickQueryMeta = QueryBase,
   C extends QueryColumn = QueryColumn,
 > = '*' | keyof T['meta']['selectable'] | Expression<C>;
 
 export type ExpressionOutput<
-  T extends QueryBase,
+  T extends PickQueryMeta,
   Expr extends SelectableOrExpression<T>,
 > = Expr extends keyof T['meta']['selectable']
   ? T['meta']['selectable'][Expr]['column']

--- a/packages/qb/pqb/src/errors.ts
+++ b/packages/qb/pqb/src/errors.ts
@@ -1,5 +1,5 @@
 import { Query } from './query/query';
-import { QueryColumns } from 'orchid-core';
+import { PickQueryShape } from 'orchid-core';
 
 export abstract class OrchidOrmError extends Error {
   abstract query: Query;
@@ -55,7 +55,7 @@ export type QueryErrorName =
   | 'notice';
 
 export abstract class QueryError<
-  T extends { shape: QueryColumns } = { shape: QueryColumns },
+  T extends PickQueryShape = PickQueryShape,
 > extends OrchidOrmInternalError {
   message!: string;
   name!: QueryErrorName;

--- a/packages/qb/pqb/src/modules/copyTableData.ts
+++ b/packages/qb/pqb/src/modules/copyTableData.ts
@@ -1,11 +1,12 @@
 import { Query, SetQueryKind } from '../query/query';
 import { CopyOptions } from '../sql';
+import { PickQueryMeta, PickQueryMetaShape, PickQueryShape } from 'orchid-core';
 
 // argument of the `copy` function can accept various options
-type CopyArg<T extends Query> = CopyOptions<keyof T['shape']>;
+type CopyArg<T extends PickQueryShape> = CopyOptions<keyof T['shape']>;
 
 // Result type for the `copy` method, simply setting a query kind.
-type CopyResult<T extends Query> = SetQueryKind<T, 'copy'>;
+type CopyResult<T extends PickQueryMeta> = SetQueryKind<T, 'copy'>;
 
 /**
  * `copyTableData` is a function to invoke a `COPY` SQL statement, it can copy from or to a file or a program.
@@ -55,14 +56,14 @@ type CopyResult<T extends Query> = SetQueryKind<T, 'copy'>;
  *
  * @param arg - object with copy options
  */
-export function copyTableData<T extends Query>(
+export function copyTableData<T extends PickQueryMetaShape>(
   query: T,
   arg: CopyArg<T>,
 ): CopyResult<T> {
-  const q = query.clone();
+  const q = (query as unknown as Query).clone();
   Object.assign(q.q, {
     type: 'copy',
     copy: arg,
   });
-  return q as CopyResult<T>;
+  return q as never;
 }

--- a/packages/qb/pqb/src/modules/getColumnInfo.ts
+++ b/packages/qb/pqb/src/modules/getColumnInfo.ts
@@ -1,6 +1,11 @@
 import { Query, SetQueryKind } from '../query/query';
 import { ColumnInfoQueryData } from '../sql';
-import { QueryCatch, QueryColumn, QueryThen } from 'orchid-core';
+import {
+  PickQueryMetaShape,
+  QueryCatch,
+  QueryColumn,
+  QueryThen,
+} from 'orchid-core';
 
 /**
  * Result type for `columnInfo` method.
@@ -8,7 +13,7 @@ import { QueryCatch, QueryColumn, QueryThen } from 'orchid-core';
  * the value is a {@link GetColumnInfo} object or a Record with keys for column names and ColumnInfo objects as values.
  **/
 export type SetQueryReturnsColumnInfo<
-  T extends Pick<Query, 'shape' | 'meta'>,
+  T extends PickQueryMetaShape,
   Column extends keyof T['shape'] | undefined,
   Result = Column extends keyof T['shape']
     ? GetColumnInfo
@@ -77,7 +82,7 @@ const rowToColumnInfo = (row: unknown): GetColumnInfo => {
  * @param column - optional: select info for only a single column if provided, or for all table columns if not
  */
 export function getColumnInfo<
-  T extends Pick<Query, 'shape' | 'meta'>,
+  T extends PickQueryMetaShape,
   Column extends keyof T['shape'] | undefined = undefined,
 >(query: T, column?: Column): SetQueryReturnsColumnInfo<T, Column> {
   const q = (query as unknown as Query).clone();

--- a/packages/qb/pqb/src/modules/getColumnInfo.ts
+++ b/packages/qb/pqb/src/modules/getColumnInfo.ts
@@ -8,20 +8,22 @@ import { QueryCatch, QueryColumn, QueryThen } from 'orchid-core';
  * the value is a {@link GetColumnInfo} object or a Record with keys for column names and ColumnInfo objects as values.
  **/
 export type SetQueryReturnsColumnInfo<
-  T extends Query,
+  T extends Pick<Query, 'shape' | 'meta'>,
   Column extends keyof T['shape'] | undefined,
   Result = Column extends keyof T['shape']
     ? GetColumnInfo
     : Record<keyof T['shape'], GetColumnInfo>,
-> = Omit<
-  SetQueryKind<T, 'columnInfo'>,
-  'result' | 'returnType' | 'then' | 'catch'
-> & {
-  result: { value: QueryColumn<Result> };
-  returnType: 'value';
-  then: QueryThen<Result>;
-  catch: QueryCatch<Result>;
-};
+> =
+  // Omit is optimal
+  Omit<
+    SetQueryKind<T, 'columnInfo'>,
+    'result' | 'returnType' | 'then' | 'catch'
+  > & {
+    result: { value: QueryColumn<Result> };
+    returnType: 'value';
+    then: QueryThen<Result>;
+    catch: QueryCatch<Result>;
+  };
 
 // column info pulled from a database
 export type GetColumnInfo = {
@@ -75,10 +77,10 @@ const rowToColumnInfo = (row: unknown): GetColumnInfo => {
  * @param column - optional: select info for only a single column if provided, or for all table columns if not
  */
 export function getColumnInfo<
-  T extends Query,
+  T extends Pick<Query, 'shape' | 'meta'>,
   Column extends keyof T['shape'] | undefined = undefined,
 >(query: T, column?: Column): SetQueryReturnsColumnInfo<T, Column> {
-  const q = query.clone();
+  const q = (query as unknown as Query).clone();
   q.q.type = 'columnInfo';
   q.q.returnType = 'all';
 

--- a/packages/qb/pqb/src/query/db.test.ts
+++ b/packages/qb/pqb/src/query/db.test.ts
@@ -9,7 +9,7 @@ import {
   testDbOptions,
   useTestDatabase,
 } from 'test-utils';
-import { TransactionState } from 'orchid-core';
+import { RecordUnknown, TransactionState } from 'orchid-core';
 import { raw } from '../sql/rawSql';
 
 describe('db connection', () => {
@@ -200,8 +200,7 @@ describe('db', () => {
     });
 
     expect(
-      (db.adapter.pool as unknown as { options: Record<string, unknown> })
-        .options.ssl,
+      (db.adapter.pool as unknown as { options: RecordUnknown }).options.ssl,
     ).toBe(true);
   });
 

--- a/packages/qb/pqb/src/query/db.ts
+++ b/packages/qb/pqb/src/query/db.ts
@@ -46,6 +46,7 @@ import {
   ColumnSchemaConfig,
   QueryColumns,
   QueryColumnsInit,
+  RecordUnknown,
 } from 'orchid-core';
 import { inspect } from 'node:util';
 import { AsyncLocalStorage } from 'node:async_hooks';
@@ -335,7 +336,7 @@ export class Db<
         if (q.and) s.and = q.and;
         if (q.or) s.or = q.or;
 
-        (scopes as Record<string, unknown>)[key] = s;
+        (scopes as RecordUnknown)[key] = s;
       }
 
       if (scopes.default) {
@@ -653,7 +654,7 @@ export const createDb = <
 
   // Set all methods from prototype to the db instance (needed for transaction at least):
   for (const name of Object.getOwnPropertyNames(Db.prototype)) {
-    (db as unknown as Record<string, unknown>)[name] =
+    (db as unknown as RecordUnknown)[name] =
       Db.prototype[name as keyof typeof Db.prototype];
   }
 

--- a/packages/qb/pqb/src/query/db.ts
+++ b/packages/qb/pqb/src/query/db.ts
@@ -129,7 +129,8 @@ export interface Db<
   Scopes extends CoreQueryScopes | undefined = EmptyObject,
   Data = QueryDefaultReturnData<Shape>,
 > extends DbBase<Adapter, Table, Shape, ColumnTypes, ShapeWithComputed>,
-    QueryMethods<ColumnTypes> {
+    QueryMethods<ColumnTypes>,
+    QueryBase {
   new (
     adapter: Adapter,
     queryBuilder: Db<Table, Shape, Relations, ColumnTypes>,
@@ -137,7 +138,7 @@ export interface Db<
     shape?: Shape,
     options?: DbTableOptions<Table, ShapeWithComputed>,
   ): this;
-  internal: QueryInternal;
+  result: Pick<Shape, DefaultSelectColumns<Shape>[number]>;
   queryBuilder: Db;
   onQueryBuilder: Query['onQueryBuilder'];
   primaryKeys: Query['primaryKeys'];

--- a/packages/qb/pqb/src/query/query.ts
+++ b/packages/qb/pqb/src/query/query.ts
@@ -35,30 +35,29 @@ export type SelectableFromShape<
 export type WithDataItem = { table: string; shape: QueryColumns };
 export type WithDataBase = Record<never, WithDataItem>;
 
-export type Query = QueryBase &
-  QueryMethods<unknown> & {
-    queryBuilder: Db;
-    columnTypes: unknown;
-    onQueryBuilder: typeof OnQueryBuilder;
-    table?: string;
-    shape: QueryColumns;
-    singlePrimaryKey: string;
-    primaryKeys: string[];
-    inputType: RecordUnknown;
-    q: QueryData;
-    result: QueryColumns;
-    then: QueryThen<unknown>;
-    catch: QueryCatch<unknown>;
-    windows: EmptyObject;
-    defaultSelectColumns: string[];
-    relations: RelationsBase;
-    withData: WithDataBase;
-    error: new (
-      message: string,
-      length: number,
-      name: QueryErrorName,
-    ) => QueryError;
-  };
+export interface Query extends QueryBase, QueryMethods<unknown> {
+  queryBuilder: Db;
+  columnTypes: unknown;
+  onQueryBuilder: typeof OnQueryBuilder;
+  table?: string;
+  shape: QueryColumns;
+  singlePrimaryKey: string;
+  primaryKeys: string[];
+  inputType: RecordUnknown;
+  q: QueryData;
+  result: QueryColumns;
+  then: QueryThen<unknown>;
+  catch: QueryCatch<unknown>;
+  windows: EmptyObject;
+  defaultSelectColumns: string[];
+  relations: RelationsBase;
+  withData: WithDataBase;
+  error: new (
+    message: string,
+    length: number,
+    name: QueryErrorName,
+  ) => QueryError;
+}
 
 export type SelectableOfType<T extends Pick<QueryBase, 'meta'>, Type> = {
   [K in keyof T['meta']['selectable']]: T['meta']['selectable'][K]['column']['type'] extends Type | null

--- a/packages/qb/pqb/src/query/query.ts
+++ b/packages/qb/pqb/src/query/query.ts
@@ -17,6 +17,7 @@ import {
   QueryColumn,
   QueryColumns,
   QueryThen,
+  RecordUnknown,
   Spread,
 } from 'orchid-core';
 import { QueryBase } from './queryBase';
@@ -43,7 +44,7 @@ export type Query = QueryBase &
     shape: QueryColumns;
     singlePrimaryKey: string;
     primaryKeys: string[];
-    inputType: Record<string, unknown>;
+    inputType: RecordUnknown;
     q: QueryData;
     result: QueryColumns;
     then: QueryThen<unknown>;

--- a/packages/qb/pqb/src/query/query.ts
+++ b/packages/qb/pqb/src/query/query.ts
@@ -109,19 +109,13 @@ export type GetQueryResult<
   : ReturnType extends 'oneOrThrow'
   ? ColumnShapeOutput<Result>
   : ReturnType extends 'value'
-  ? Result extends { value: QueryColumn }
-    ? Result['value']['outputType'] | undefined
-    : never
+  ? Result['value']['outputType'] | undefined
   : ReturnType extends 'valueOrThrow'
-  ? Result extends { value: QueryColumn }
-    ? Result['value']['outputType']
-    : never
+  ? Result['value']['outputType']
   : ReturnType extends 'rows'
   ? ColumnShapeOutput<Result>[keyof Result][][]
   : ReturnType extends 'pluck'
-  ? Result extends { pluck: QueryColumn }
-    ? Result['pluck']['outputType'][]
-    : never
+  ? Result['pluck']['outputType'][]
   : ReturnType extends 'rowCount'
   ? number
   : ReturnType extends 'void'

--- a/packages/qb/pqb/src/query/query.ts
+++ b/packages/qb/pqb/src/query/query.ts
@@ -13,6 +13,9 @@ import {
   ColumnShapeOutput,
   EmptyObject,
   Expression,
+  PickOutputType,
+  PickOutputTypeAndOperators,
+  PickType,
   QueryCatch,
   QueryColumn,
   QueryColumns,
@@ -64,7 +67,7 @@ export type SelectableOfType<T extends Pick<QueryBase, 'meta'>, Type> = {
 
 export type SelectableOrExpressionOfType<
   T extends Pick<Query, 'meta'>,
-  C extends QueryColumn,
+  C extends PickType,
 > = SelectableOfType<T, C['type']> | Expression<QueryColumn<C['type'] | null>>;
 
 export interface QueryWithTable extends Query {
@@ -251,7 +254,7 @@ export type SetQueryReturnsValue<
   T extends Pick<Query, 'meta'>,
   Arg extends GetStringArg<T>,
   ReturnType extends 'value' | 'valueOrThrow' = 'valueOrThrow',
-  Column extends QueryColumn = Arg extends keyof T['meta']['selectable']
+  Column extends PickOutputTypeAndOperators = Arg extends keyof T['meta']['selectable']
     ? T['meta']['selectable'][Arg]['column']
     : Arg extends Query
     ? Arg['result']['value']
@@ -260,12 +263,12 @@ export type SetQueryReturnsValue<
 
 export type SetQueryReturnsColumnOptional<
   T,
-  Column extends QueryColumn,
+  Column extends PickOutputType,
 > = SetQueryReturnsColumn<T, Column, 'value'>;
 
 export type SetQueryReturnsColumn<
   T,
-  Column extends QueryColumn,
+  Column extends PickOutputType,
   ReturnType extends 'value' | 'valueOrThrow' = 'valueOrThrow',
   Data = ReturnType extends 'value'
     ? Column['outputType'] | undefined

--- a/packages/qb/pqb/src/query/query.ts
+++ b/packages/qb/pqb/src/query/query.ts
@@ -1,8 +1,8 @@
 import {
   GetStringArg,
   OnQueryBuilder,
+  QueryMetaHasWhere,
   QueryMethods,
-  WhereResult,
 } from '../queryMethods';
 import { QueryData } from '../sql';
 import { AliasOrTable } from '../common/utils';
@@ -14,11 +14,18 @@ import {
   EmptyObject,
   Expression,
   PickOutputType,
-  PickOutputTypeAndOperators,
+  PickQueryMeta,
+  PickQueryMetaResult,
+  PickQueryResult,
+  PickQueryReturnType,
+  PickQueryShape,
+  PickQueryTable,
   PickType,
   QueryCatch,
   QueryColumn,
   QueryColumns,
+  QueryInternal,
+  QueryReturnType,
   QueryThen,
   RecordUnknown,
   Spread,
@@ -35,8 +42,16 @@ export type SelectableFromShape<
   };
 };
 
-export type WithDataItem = { table: string; shape: QueryColumns };
-export type WithDataBase = Record<never, WithDataItem>;
+export interface WithDataItem {
+  table: string;
+  shape: QueryColumns;
+}
+
+export interface WithDataItems {
+  [K: string]: WithDataItem;
+}
+
+export type WithDataBase = EmptyObject;
 
 export interface Query extends QueryBase, QueryMethods<unknown> {
   queryBuilder: Db;
@@ -59,31 +74,134 @@ export interface Query extends QueryBase, QueryMethods<unknown> {
   ) => QueryError;
 }
 
-export type SelectableOfType<T extends Pick<QueryBase, 'meta'>, Type> = {
+export interface PickQueryWithData {
+  withData: WithDataBase;
+}
+
+export interface PickQueryWindows {
+  windows: EmptyObject;
+}
+
+export interface PickQueryRelations {
+  relations: RelationsBase;
+}
+
+export interface PickQueryQ {
+  q: QueryData;
+}
+
+export interface PickQueryInternal {
+  internal: QueryInternal;
+}
+
+export interface PickQueryBaseQuery {
+  baseQuery: Query;
+}
+
+export interface PickQueryMetaRelations
+  extends PickQueryMeta,
+    PickQueryRelations {}
+
+export interface PickQueryMetaResultRelations
+  extends PickQueryResult,
+    PickQueryMeta,
+    PickQueryRelations {}
+
+export interface PickQueryMetaResultRelationsWindows
+  extends PickQueryMetaResultRelations,
+    PickQueryWindows {}
+
+export interface PickQueryMetaResultRelationsWindowsColumnTypes
+  extends PickQueryMetaResultRelationsWindows {
+  columnTypes: unknown;
+}
+
+export interface PickQueryMetaResultReturnType
+  extends PickQueryMeta,
+    PickQueryResult,
+    PickQueryReturnType {}
+
+export interface PickQueryMetaTable extends PickQueryMeta, PickQueryTable {}
+
+export interface PickQueryMetaTableShape
+  extends PickQueryMetaTable,
+    PickQueryShape {}
+
+export interface PickQueryMetaWithData
+  extends PickQueryMeta,
+    PickQueryWithData {}
+
+export interface PickQueryRelationsWithData
+  extends PickQueryWithData,
+    PickQueryRelations {}
+
+export interface PickQueryMetaShapeRelationsWithData
+  extends PickQueryMeta,
+    PickQueryShape,
+    PickQueryRelations,
+    PickQueryWithData {}
+
+export interface PickQueryMetaResultRelationsWithDataReturnType
+  extends PickQueryMeta,
+    PickQueryResult,
+    PickQueryRelations,
+    PickQueryWithData,
+    PickQueryReturnType {}
+
+export interface PickQueryMetaTableShapeReturnTypeWithData
+  extends PickQueryMetaTableShape,
+    PickQueryReturnType,
+    PickQueryMetaWithData {}
+
+export interface PickQueryMetaResultRelationsWithDataReturnTypeShape
+  extends PickQueryMetaResultRelationsWithDataReturnType,
+    PickQueryShape {}
+
+export interface PickQueryMetaResultReturnTypeWithDataWindows
+  extends PickQueryMetaResultReturnType,
+    PickQueryWithData,
+    PickQueryWindows {}
+
+export interface PickQueryMetaResultReturnTypeWithDataWindowsTable<
+  Table extends string | undefined,
+> extends PickQueryMetaResultReturnType,
+    PickQueryWithData,
+    PickQueryWindows {
+  table: Table;
+}
+
+export interface PickQueryQAndInternal extends PickQueryQ, PickQueryInternal {}
+
+export interface PickQueryQAndBaseQuery
+  extends PickQueryQ,
+    PickQueryBaseQuery {}
+
+export interface PickQuerySinglePrimaryKey {
+  singlePrimaryKey: string;
+}
+
+export interface PickQueryShapeSinglePrimaryKey
+  extends PickQueryShape,
+    PickQuerySinglePrimaryKey {}
+
+export interface PickQueryShapeResultSinglePrimaryKey
+  extends PickQueryShapeSinglePrimaryKey,
+    PickQueryResult {}
+
+export type SelectableOfType<T extends PickQueryMeta, Type> = {
   [K in keyof T['meta']['selectable']]: T['meta']['selectable'][K]['column']['type'] extends Type | null
     ? K
     : never;
 }[keyof T['meta']['selectable']];
 
 export type SelectableOrExpressionOfType<
-  T extends Pick<Query, 'meta'>,
+  T extends PickQueryMeta,
   C extends PickType,
 > = SelectableOfType<T, C['type']> | Expression<QueryColumn<C['type'] | null>>;
 
 export interface QueryWithTable extends Query {
   table: string;
 }
-
-export type QueryReturnType =
-  | 'all'
-  | 'one'
-  | 'oneOrThrow'
-  | 'rows'
-  | 'pluck'
-  | 'value'
-  | 'valueOrThrow'
-  | 'rowCount'
-  | 'void';
 
 export const queryTypeWithLimitOne = {
   one: true,
@@ -125,102 +243,111 @@ export type GetQueryResult<
   : never;
 
 export type AddQuerySelect<
-  T extends Pick<Query, 'result' | 'meta' | 'returnType'>,
+  T extends PickQueryMetaResultReturnType,
   Result extends QueryColumns,
-  Data = GetQueryResult<T['returnType'], Result>,
-> = T['meta']['hasSelect'] extends true
-  ? MergeSelect<T, Result, Data>
-  : SetSelect<T, Result, Data>;
-
-type MergeSelect<
-  T extends Pick<Query, 'result'>,
-  Result extends QueryColumns,
-  Data,
 > = {
   [K in keyof T]: K extends 'result'
     ? {
-        [K in keyof T['result'] | keyof Result]: K extends keyof Result
+        [K in
+          | (T['meta']['hasSelect'] extends true ? keyof T['result'] : never)
+          | keyof Result]: K extends keyof Result
           ? Result[K]
           : K extends keyof T['result']
           ? T['result'][K]
           : never;
       }
     : K extends 'then'
-    ? QueryThen<Data>
+    ? QueryThen<GetQueryResult<T['returnType'], Result>>
     : K extends 'catch'
-    ? QueryCatch<Data>
+    ? QueryCatch<GetQueryResult<T['returnType'], Result>>
     : T[K];
-};
+} & QueryMetaHasSelect;
 
-type SetSelect<
-  T extends Pick<Query, 'result' | 'meta'>,
-  Result extends QueryColumns,
-  Data,
-> = {
-  [K in keyof T]: K extends 'meta'
-    ? T['meta'] & { hasSelect: true }
-    : K extends 'result'
-    ? Result
-    : K extends 'then'
-    ? QueryThen<Data>
-    : K extends 'catch'
-    ? QueryCatch<Data>
-    : T[K];
-};
+// Merge { hasSelect: true } into 'meta' if it's not true yet.
+export interface QueryMetaHasSelect {
+  meta: {
+    hasSelect: true;
+  };
+}
 
-export type SetQueryReturns<
-  T extends Pick<Query, 'result'>,
-  R extends QueryReturnType,
-  Data = GetQueryResult<R, T['result']>,
-> = {
+// Change the query type to return multiple object records.
+// It wraps the query with `WhereResult` to allow updating and deleting all records when the `all` method is used.
+export type SetQueryReturnsAll<T extends PickQueryResult> = {
   [K in keyof T]: K extends 'returnType'
-    ? R
+    ? 'all'
     : K extends 'then'
-    ? QueryThen<Data>
+    ? QueryThen<ColumnShapeOutput<T['result']>[]>
     : K extends 'catch'
-    ? QueryCatch<Data>
+    ? QueryCatch<ColumnShapeOutput<T['result']>[]>
     : T[K];
-};
+} & QueryMetaHasWhere;
 
-export type SetQueryReturnsKind<
-  T extends Pick<Query, 'meta' | 'result'>,
-  R extends QueryReturnType,
+export type SetQueryReturnsAllKind<
+  T extends PickQueryMetaResult,
   Kind extends string,
-  Data = GetQueryResult<R, T['result']>,
 > = {
   [K in keyof T]: K extends 'meta'
     ? {
         [K in keyof T['meta']]: K extends 'kind' ? Kind : T['meta'][K];
       }
     : K extends 'returnType'
-    ? R
+    ? 'all'
     : K extends 'then'
-    ? QueryThen<Data>
+    ? QueryThen<ColumnShapeOutput<T['result']>[]>
     : K extends 'catch'
-    ? QueryCatch<Data>
+    ? QueryCatch<ColumnShapeOutput<T['result']>[]>
+    : T[K];
+} & QueryMetaHasWhere;
+
+export type SetQueryReturnsOneOptional<T extends PickQueryResult> = {
+  [K in keyof T]: K extends 'returnType'
+    ? 'one'
+    : K extends 'then'
+    ? QueryThen<ColumnShapeOutput<T['result']> | undefined>
+    : K extends 'catch'
+    ? QueryCatch<ColumnShapeOutput<T['result']> | undefined>
     : T[K];
 };
 
-// Change the query type to return multiple object records.
-// It wraps the query with `WhereResult` to allow updating and deleting all records when the `all` method is used.
-export type SetQueryReturnsAll<T extends Pick<Query, 'result'>> =
-  SetQueryReturns<WhereResult<T>, 'all'>;
-
-export type SetQueryReturnsOneOptional<T extends Pick<Query, 'result'>> =
-  SetQueryReturns<T, 'one'>;
-
-export type SetQueryReturnsOne<T extends Pick<Query, 'result'>> =
-  SetQueryReturns<T, 'oneOrThrow'>;
+export type SetQueryReturnsOne<T extends PickQueryResult> = {
+  [K in keyof T]: K extends 'returnType'
+    ? 'oneOrThrow'
+    : K extends 'then'
+    ? QueryThen<ColumnShapeOutput<T['result']>>
+    : K extends 'catch'
+    ? QueryCatch<ColumnShapeOutput<T['result']>>
+    : T[K];
+};
 
 export type SetQueryReturnsOneKind<
-  T extends Pick<Query, 'result' | 'meta'>,
+  T extends PickQueryMetaResult,
   Kind extends string,
-> = SetQueryReturnsKind<T, 'oneOrThrow', Kind>;
+> = {
+  [K in keyof T]: K extends 'meta'
+    ? {
+        [K in keyof T['meta']]: K extends 'kind' ? Kind : T['meta'][K];
+      }
+    : K extends 'returnType'
+    ? 'oneOrThrow'
+    : K extends 'then'
+    ? QueryThen<ColumnShapeOutput<T['result']>>
+    : K extends 'catch'
+    ? QueryCatch<ColumnShapeOutput<T['result']>>
+    : T[K];
+};
 
-export type SetQueryReturnsRows<T extends Query> = SetQueryReturns<T, 'rows'>;
+export type SetQueryReturnsRows<T extends PickQueryResult> = {
+  [K in keyof T]: K extends 'returnType'
+    ? 'rows'
+    : K extends 'then'
+    ? QueryThen<ColumnShapeOutput<T['result']>[keyof T['result']][][]>
+    : K extends 'catch'
+    ? QueryCatch<ColumnShapeOutput<T['result']>[keyof T['result']][][]>
+    : T[K];
+};
 
 export type SetQueryReturnsPluck<
-  T extends Pick<Query, 'meta'>,
+  T extends PickQueryMeta,
   S extends keyof T['meta']['selectable'] | Expression,
 > = SetQueryReturnsPluckColumn<
   T,
@@ -232,9 +359,7 @@ export type SetQueryReturnsPluck<
 >;
 
 export type SetQueryReturnsPluckColumn<T, C extends QueryColumn> = {
-  [K in keyof T]: K extends 'meta'
-    ? T[K] & { hasSelect: true }
-    : K extends 'result'
+  [K in keyof T]: K extends 'result'
     ? { pluck: C }
     : K extends 'returnType'
     ? 'pluck'
@@ -243,82 +368,129 @@ export type SetQueryReturnsPluckColumn<T, C extends QueryColumn> = {
     : K extends 'catch'
     ? QueryCatch<C['outputType'][]>
     : T[K];
-};
+} & QueryMetaHasSelect;
 
-export type SetQueryReturnsValueOptional<
-  T extends Pick<Query, 'meta'>,
-  Arg extends GetStringArg<T>,
-> = SetQueryReturnsValue<T, Arg, 'value'>;
-
-export type SetQueryReturnsValue<
-  T extends Pick<Query, 'meta'>,
-  Arg extends GetStringArg<T>,
-  ReturnType extends 'value' | 'valueOrThrow' = 'valueOrThrow',
-  Column extends PickOutputTypeAndOperators = Arg extends keyof T['meta']['selectable']
-    ? T['meta']['selectable'][Arg]['column']
-    : Arg extends Query
-    ? Arg['result']['value']
-    : never,
-> = SetQueryReturnsColumn<T, Column, ReturnType> & Column['operators'];
-
-export type SetQueryReturnsColumnOptional<
-  T,
-  Column extends PickOutputType,
-> = SetQueryReturnsColumn<T, Column, 'value'>;
-
-export type SetQueryReturnsColumn<
-  T,
-  Column extends PickOutputType,
-  ReturnType extends 'value' | 'valueOrThrow' = 'valueOrThrow',
-  Data = ReturnType extends 'value'
-    ? Column['outputType'] | undefined
-    : Column['outputType'],
-> = {
-  [K in keyof T]: K extends 'result'
-    ? { value: Column }
-    : K extends 'returnType'
-    ? ReturnType
-    : K extends 'then'
-    ? QueryThen<Data>
-    : K extends 'catch'
-    ? QueryCatch<Data>
-    : T[K];
-} & { meta: { hasSelect: true } };
-
-export type SetQueryReturnsColumnKind<
-  T extends Pick<Query, 'meta'>,
-  Column extends QueryColumn,
+export type SetQueryReturnsPluckColumnKind<
+  T extends PickQueryMetaResult,
   Kind extends string,
-  ReturnType extends 'value' | 'valueOrThrow' = 'valueOrThrow',
-  Data = ReturnType extends 'value'
-    ? Column['outputType'] | undefined
-    : Column['outputType'],
 > = {
   [K in keyof T]: K extends 'meta'
     ? {
         [K in keyof T['meta']]: K extends 'kind' ? Kind : T['meta'][K];
       }
     : K extends 'result'
+    ? { pluck: T['result']['value'] }
+    : K extends 'returnType'
+    ? 'pluck'
+    : K extends 'then'
+    ? QueryThen<T['result']['value']['outputType'][]>
+    : K extends 'catch'
+    ? QueryCatch<T['result']['value']['outputType'][]>
+    : T[K];
+} & QueryMetaHasSelect;
+
+export type SetQueryReturnsValueOrThrow<
+  T extends PickQueryMeta,
+  Arg extends GetStringArg<T>,
+> = SetQueryReturnsColumnOrThrow<T, T['meta']['selectable'][Arg]['column']> &
+  T['meta']['selectable'][Arg]['column']['operators'];
+
+export type SetQueryReturnsValueOptional<
+  T extends PickQueryMeta,
+  Arg extends GetStringArg<T>,
+> = SetQueryReturnsColumnOptional<T, T['meta']['selectable'][Arg]['column']> &
+  T['meta']['selectable'][Arg]['column']['operators'];
+
+export type SetQueryReturnsColumnOrThrow<T, Column extends PickOutputType> = {
+  [K in keyof T]: K extends 'result'
     ? { value: Column }
     : K extends 'returnType'
-    ? ReturnType
+    ? 'valueOrThrow'
     : K extends 'then'
-    ? QueryThen<Data>
+    ? QueryThen<Column['outputType']>
     : K extends 'catch'
-    ? QueryCatch<Data>
+    ? QueryCatch<Column['outputType']>
     : T[K];
-} & { meta: { hasSelect: true } };
+} & QueryMetaHasSelect;
+
+export type SetQueryReturnsColumnOptional<T, Column extends PickOutputType> = {
+  [K in keyof T]: K extends 'result'
+    ? { value: Column }
+    : K extends 'returnType'
+    ? 'value'
+    : K extends 'then'
+    ? QueryThen<Column['outputType'] | undefined>
+    : K extends 'catch'
+    ? QueryCatch<Column['outputType'] | undefined>
+    : T[K];
+} & QueryMetaHasSelect;
+
+export type SetQueryReturnsColumnKind<
+  T extends PickQueryMetaResult,
+  Kind extends string,
+> = {
+  [K in keyof T]: K extends 'meta'
+    ? {
+        [K in keyof T['meta']]: K extends 'kind' ? Kind : T['meta'][K];
+      }
+    : K extends 'result'
+    ? { value: T['result']['pluck'] }
+    : K extends 'returnType'
+    ? 'valueOrThrow'
+    : K extends 'then'
+    ? QueryThen<T['result']['pluck']['outputType']>
+    : K extends 'catch'
+    ? QueryCatch<T['result']['pluck']['outputType']>
+    : T[K];
+} & QueryMetaHasSelect;
 
 export type SetQueryReturnsRowCount<
-  T extends Pick<Query, 'result' | 'meta'>,
+  T extends PickQueryMetaResult,
   Kind extends string,
-> = SetQueryReturnsKind<T, 'rowCount', Kind>;
+> = {
+  [K in keyof T]: K extends 'meta'
+    ? {
+        [K in keyof T['meta']]: K extends 'kind' ? Kind : T['meta'][K];
+      }
+    : K extends 'returnType'
+    ? 'rowCount'
+    : K extends 'then'
+    ? QueryThen<number>
+    : K extends 'catch'
+    ? QueryCatch<number>
+    : T[K];
+};
 
-export type SetQueryReturnsVoid<T extends Query> = SetQueryReturns<T, 'void'>;
+export type SetQueryReturnsVoid<T> = {
+  [K in keyof T]: K extends 'returnType'
+    ? 'void'
+    : K extends 'then'
+    ? QueryThen<void>
+    : K extends 'catch'
+    ? QueryCatch<void>
+    : T[K];
+};
+
+export type SetQueryReturnsVoidKind<
+  T extends PickQueryMeta,
+  Kind extends string,
+> = {
+  [K in keyof T]: K extends 'meta'
+    ? {
+        [K in keyof T['meta']]: K extends 'kind' ? Kind : T['meta'][K];
+      }
+    : K extends 'returnType'
+    ? 'void'
+    : K extends 'then'
+    ? QueryThen<void>
+    : K extends 'catch'
+    ? QueryCatch<void>
+    : T[K];
+};
 
 // Set the kind of the query, can be 'select', 'update', 'create', etc.
 // `update` method is using the kind of query to allow only 'select' as a callback return for a column.
-export type SetQueryKind<T extends Pick<Query, 'meta'>, Kind extends string> = {
+export type SetQueryKind<T extends PickQueryMeta, Kind extends string> = {
   [K in keyof T]: K extends 'meta'
     ? {
         [K in keyof T['meta']]: K extends 'kind' ? Kind : T['meta'][K];
@@ -327,7 +499,7 @@ export type SetQueryKind<T extends Pick<Query, 'meta'>, Kind extends string> = {
 };
 
 export type SetQueryTableAlias<
-  T extends Pick<Query, 'table' | 'meta' | 'shape'>,
+  T extends PickQueryMetaTableShape,
   As extends string,
 > = {
   [K in keyof T]: K extends 'meta'
@@ -349,12 +521,11 @@ export type SetQueryTableAlias<
     : T[K];
 };
 
-export type SetQueryWith<
-  T extends Query,
-  WithData extends Record<string, WithDataItem>,
-> = { [K in keyof T]: K extends 'withData' ? WithData : T[K] };
+export type SetQueryWith<T, WithData extends WithDataItems> = {
+  [K in keyof T]: K extends 'withData' ? WithData : T[K];
+};
 
 export type AddQueryWith<
-  T extends Query,
+  T extends PickQueryWithData,
   With extends WithDataItem,
 > = SetQueryWith<T, Spread<[T['withData'], { [K in With['table']]: With }]>>;

--- a/packages/qb/pqb/src/query/queryBase.ts
+++ b/packages/qb/pqb/src/query/queryBase.ts
@@ -7,6 +7,7 @@ import {
   QueryMetaBase,
   QueryColumns,
   RecordKeyTrue,
+  QueryThen,
 } from 'orchid-core';
 import { RelationsBase } from '../relations';
 import { getClonedQueryData } from '../common/utils';
@@ -37,4 +38,8 @@ export abstract class QueryBase<Scopes extends RecordKeyTrue = EmptyObject>
   internal!: QueryInternal;
   meta!: QueryMetaBase<Scopes>;
   returnType!: QueryReturnType;
+}
+
+export interface QueryBaseThen<T> extends QueryBase {
+  then: QueryThen<T>;
 }

--- a/packages/qb/pqb/src/query/queryBase.ts
+++ b/packages/qb/pqb/src/query/queryBase.ts
@@ -27,6 +27,7 @@ export abstract class QueryBase<Scopes extends RecordKeyTrue = EmptyObject>
     return cloned;
   }
   abstract result: QueryColumns;
+  __isQuery!: true;
   q = {} as QueryData;
   table?: string;
   shape!: QueryColumns;

--- a/packages/qb/pqb/src/query/queryBase.ts
+++ b/packages/qb/pqb/src/query/queryBase.ts
@@ -1,4 +1,4 @@
-import { Query, QueryReturnType, WithDataBase } from './query';
+import { Query, WithDataBase } from './query';
 import { QueryData } from '../sql';
 import {
   EmptyObject,
@@ -8,6 +8,7 @@ import {
   QueryColumns,
   RecordKeyTrue,
   QueryThen,
+  QueryReturnType,
 } from 'orchid-core';
 import { RelationsBase } from '../relations';
 import { getClonedQueryData } from '../common/utils';
@@ -22,9 +23,9 @@ export abstract class QueryBase<Scopes extends RecordKeyTrue = EmptyObject>
    *
    * Used under the hood, and not really needed on the app side.
    */
-  clone<T extends Pick<QueryBase, 'baseQuery' | 'q'>>(this: T): T {
-    const cloned = Object.create(this.baseQuery);
-    cloned.q = getClonedQueryData(this.q);
+  clone<T>(this: T): T {
+    const cloned = Object.create((this as unknown as Query).baseQuery);
+    cloned.q = getClonedQueryData((this as unknown as Query).q);
     return cloned;
   }
   __isQuery!: true;

--- a/packages/qb/pqb/src/query/queryBase.ts
+++ b/packages/qb/pqb/src/query/queryBase.ts
@@ -26,8 +26,8 @@ export abstract class QueryBase<Scopes extends RecordKeyTrue = EmptyObject>
     cloned.q = getClonedQueryData(this.q);
     return cloned;
   }
-  abstract result: QueryColumns;
   __isQuery!: true;
+  result!: QueryColumns;
   q = {} as QueryData;
   table?: string;
   shape!: QueryColumns;

--- a/packages/qb/pqb/src/query/queryUtils.ts
+++ b/packages/qb/pqb/src/query/queryUtils.ts
@@ -5,7 +5,7 @@ import {
   RecordUnknown,
 } from 'orchid-core';
 import { OrchidOrmInternalError } from '../errors';
-import { Query } from './query';
+import { PickQueryQ, PickQueryQAndBaseQuery, Query } from './query';
 import { QueryBase } from './queryBase';
 import { getClonedQueryData } from '../common/utils';
 
@@ -35,7 +35,7 @@ export const pushQueryArray = <T extends { q: QueryData }>(
  * @param key - key to get the array
  * @param value - new element to push
  */
-export const pushQueryValue = <T extends { q: QueryData }>(
+export const pushQueryValue = <T extends PickQueryQ>(
   q: T,
   key: string,
   value: unknown,
@@ -76,7 +76,7 @@ export const setQueryObjectValue = <T extends { q: QueryData }>(
  * @param q - query
  * @param method - 'update' or 'delete'
  */
-export const throwIfNoWhere = (q: Pick<Query, 'q'>, method: string): void => {
+export const throwIfNoWhere = (q: PickQueryQ, method: string): void => {
   if (!q.q.or && !q.q.and && !q.q.all) {
     throw new OrchidOrmInternalError(
       q as Query,
@@ -113,7 +113,7 @@ export const saveSearchAlias = (
  * @param methods - methods to add
  */
 export const extendQuery = <
-  T extends Pick<Query, 'q' | 'baseQuery'>,
+  T extends PickQueryQAndBaseQuery,
   Methods extends RecordUnknown,
 >(
   q: T,

--- a/packages/qb/pqb/src/query/queryUtils.ts
+++ b/packages/qb/pqb/src/query/queryUtils.ts
@@ -1,5 +1,9 @@
 import { QueryData } from '../sql';
-import { emptyObject, pushOrNewArrayToObject } from 'orchid-core';
+import {
+  emptyObject,
+  pushOrNewArrayToObject,
+  RecordUnknown,
+} from 'orchid-core';
 import { OrchidOrmInternalError } from '../errors';
 import { Query } from './query';
 import { QueryBase } from './queryBase';
@@ -18,8 +22,7 @@ export const pushQueryArray = <T extends { q: QueryData }>(
   key: string,
   value: unknown,
 ): T => {
-  if (!q.q[key as keyof typeof q.q])
-    (q.q as Record<string, unknown>)[key] = value;
+  if (!q.q[key as keyof typeof q.q]) (q.q as RecordUnknown)[key] = value;
   else
     (q.q[key as keyof typeof q.q] as unknown[]).push(...(value as unknown[]));
   return q as T;
@@ -60,12 +63,10 @@ export const setQueryObjectValue = <T extends { q: QueryData }>(
   value: unknown,
 ): T => {
   if (!q.q[object as keyof typeof q.q])
-    (q.q as unknown as Record<string, Record<string, unknown>>)[object] = {
+    (q.q as unknown as Record<string, RecordUnknown>)[object] = {
       [key]: value,
     };
-  else
-    (q.q as unknown as Record<string, Record<string, unknown>>)[object][key] =
-      value;
+  else (q.q as unknown as Record<string, RecordUnknown>)[object][key] = value;
   return q as unknown as T;
 };
 
@@ -113,7 +114,7 @@ export const saveSearchAlias = (
  */
 export const extendQuery = <
   T extends Pick<Query, 'q' | 'baseQuery'>,
-  Methods extends Record<string, unknown>,
+  Methods extends RecordUnknown,
 >(
   q: T,
   methods: Methods,

--- a/packages/qb/pqb/src/queryMethods/as.ts
+++ b/packages/qb/pqb/src/queryMethods/as.ts
@@ -1,15 +1,16 @@
-import { Query, SetQueryTableAlias } from '../query/query';
-
-export type AsQueryArg = Pick<
+import {
+  PickQueryMetaTableShape,
   Query,
-  'table' | 'meta' | 'q' | 'clone' | 'baseQuery' | 'shape'
->;
+  SetQueryTableAlias,
+} from '../query/query';
+
+export type AsQueryArg = PickQueryMetaTableShape;
 
 export const _queryAs = <T extends AsQueryArg, As extends string>(
   self: T,
   as: As,
 ): SetQueryTableAlias<T, As> => {
-  self.q.as = as;
+  (self as unknown as Query).q.as = as;
   return self as SetQueryTableAlias<T, As>;
 };
 
@@ -30,6 +31,6 @@ export abstract class AsMethods {
     this: T,
     as: As,
   ): SetQueryTableAlias<T, As> {
-    return _queryAs(this.clone(), as);
+    return _queryAs((this as unknown as Query).clone(), as) as never;
   }
 }

--- a/packages/qb/pqb/src/queryMethods/as.ts
+++ b/packages/qb/pqb/src/queryMethods/as.ts
@@ -1,5 +1,4 @@
 import { Query, SetQueryTableAlias } from '../query/query';
-import { QueryBase } from '../query/queryBase';
 
 export type AsQueryArg = Pick<
   Query,
@@ -14,7 +13,7 @@ export const _queryAs = <T extends AsQueryArg, As extends string>(
   return self as SetQueryTableAlias<T, As>;
 };
 
-export abstract class AsMethods extends QueryBase {
+export abstract class AsMethods {
   /**
    * Sets table alias:
    *

--- a/packages/qb/pqb/src/queryMethods/clear.ts
+++ b/packages/qb/pqb/src/queryMethods/clear.ts
@@ -1,5 +1,5 @@
 import { Query } from '../query/query';
-import { isExpression } from 'orchid-core';
+import { isExpression, RecordUnknown } from 'orchid-core';
 
 export type ClearStatement =
   | 'with'
@@ -28,7 +28,7 @@ export class Clear {
             if (!isExpression(item) && typeof item !== 'function') {
               let removed = false;
               for (const key in item) {
-                const value = item[key] as Record<string, unknown>;
+                const value = item[key] as RecordUnknown;
                 if (
                   typeof value === 'object' &&
                   (value.op === '+' || value.op === '-')
@@ -46,7 +46,7 @@ export class Clear {
           });
         }
       } else {
-        delete (q.q as Record<string, unknown>)[clear];
+        delete (q.q as RecordUnknown)[clear];
       }
     });
     return q;

--- a/packages/qb/pqb/src/queryMethods/create.ts
+++ b/packages/qb/pqb/src/queryMethods/create.ts
@@ -75,9 +75,8 @@ export type CreateColumn<
   | Expression
   | T['inputType'][Key]
   | {
-      [K in keyof Query]: K extends 'then'
-        ? QueryThen<T['inputType'][Key]>
-        : Query[K];
+      __isQuery: true;
+      then: QueryThen<T['inputType'][Key]>;
     };
 
 // Combine data of the table with data that can be set for relations

--- a/packages/qb/pqb/src/queryMethods/delete.ts
+++ b/packages/qb/pqb/src/queryMethods/delete.ts
@@ -12,7 +12,7 @@ export type DeleteArgs<T extends DeleteSelf> =
 export type DeleteResult<T extends DeleteSelf> =
   T['meta']['hasSelect'] extends true
     ? SetQueryKind<T, 'delete'>
-    : SetQueryReturnsRowCount<SetQueryKind<T, 'delete'>>;
+    : SetQueryReturnsRowCount<T, 'delete'>;
 
 export const _queryDelete = <T extends DeleteSelf>(q: T): DeleteResult<T> => {
   if (!q.q.select) {

--- a/packages/qb/pqb/src/queryMethods/delete.ts
+++ b/packages/qb/pqb/src/queryMethods/delete.ts
@@ -1,31 +1,32 @@
 import { Query, SetQueryKind, SetQueryReturnsRowCount } from '../query/query';
 import { throwIfNoWhere } from '../query/queryUtils';
-import { CloneSelfKeys } from '../query/queryBase';
-
-export type DeleteSelf = Pick<Query, 'meta' | 'result' | CloneSelfKeys>;
+import { EmptyTuple, PickQueryMetaResult } from 'orchid-core';
 
 export type DeleteMethodsNames = 'delete';
 
-export type DeleteArgs<T extends DeleteSelf> =
-  T['meta']['hasWhere'] extends true ? [] : [never];
+export type DeleteArgs<T extends PickQueryMetaResult> =
+  T['meta']['hasWhere'] extends true ? EmptyTuple : [never];
 
-export type DeleteResult<T extends DeleteSelf> =
+export type DeleteResult<T extends PickQueryMetaResult> =
   T['meta']['hasSelect'] extends true
     ? SetQueryKind<T, 'delete'>
     : SetQueryReturnsRowCount<T, 'delete'>;
 
-export const _queryDelete = <T extends DeleteSelf>(q: T): DeleteResult<T> => {
-  if (!q.q.select) {
-    if (q.q.returnType === 'oneOrThrow' || q.q.returnType === 'valueOrThrow') {
-      q.q.throwOnNotFound = true;
+export const _queryDelete = <T extends PickQueryMetaResult>(
+  query: T,
+): DeleteResult<T> => {
+  const q = (query as unknown as Query).q;
+  if (!q.select) {
+    if (q.returnType === 'oneOrThrow' || q.returnType === 'valueOrThrow') {
+      q.throwOnNotFound = true;
     }
-    q.q.returnType = 'rowCount';
+    q.returnType = 'rowCount';
   }
 
-  throwIfNoWhere(q, 'delete');
+  throwIfNoWhere(query as unknown as Query, 'delete');
 
-  q.q.type = 'delete';
-  return q as unknown as DeleteResult<T>;
+  q.type = 'delete';
+  return query as never;
 };
 
 export class Delete {
@@ -78,10 +79,10 @@ export class Delete {
    * ```
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  delete<T extends DeleteSelf>(
+  delete<T extends PickQueryMetaResult>(
     this: T,
     ..._args: DeleteArgs<T>
   ): DeleteResult<T> {
-    return _queryDelete(this.clone());
+    return _queryDelete((this as unknown as Query).clone()) as never;
   }
 }

--- a/packages/qb/pqb/src/queryMethods/from.ts
+++ b/packages/qb/pqb/src/queryMethods/from.ts
@@ -52,14 +52,19 @@ export type FromResult<
   : Args[0] extends string
   ? T['withData'] extends Record<string, WithDataItem>
     ? Args[0] extends keyof T['withData']
-      ? Omit<T, 'meta'> & {
-          meta: Omit<T['meta'], 'as' | 'selectable'> & {
-            as?: string;
-            selectable: SelectableFromShape<
-              T['withData'][Args[0]]['shape'],
-              Args[0]
-            >;
-          };
+      ? {
+          [K in keyof T]: K extends 'meta'
+            ? {
+                [K in keyof T['meta']]: K extends 'as'
+                  ? string | undefined
+                  : K extends 'selectable'
+                  ? SelectableFromShape<
+                      T['withData'][Args[0]]['shape'],
+                      Args[0]
+                    >
+                  : T['meta'][K];
+              }
+            : T[K];
         }
       : SetQueryTableAlias<T, Args[0]>
     : SetQueryTableAlias<T, Args[0]>
@@ -81,9 +86,14 @@ type FromQueryResult<
   Data = GetQueryResult<T['returnType'], Q['result']>,
 > = {
   [K in keyof T]: K extends 'meta'
-    ? Omit<T['meta'], 'hasSelect' | 'as' | 'selectable'> & {
-        as: AliasOrTable<Q>;
-        selectable: Selectable;
+    ? {
+        [K in keyof T['meta']]: K extends 'hasSelect'
+          ? undefined
+          : K extends 'as'
+          ? AliasOrTable<Q>
+          : K extends 'selectable'
+          ? Selectable
+          : T['meta'][K];
       }
     : K extends 'result'
     ? Q['result']

--- a/packages/qb/pqb/src/queryMethods/get.ts
+++ b/packages/qb/pqb/src/queryMethods/get.ts
@@ -25,11 +25,11 @@ export class QueryGet {
    *
    * @param arg - string for a column to get, or a raw SQL
    */
-  get<T extends Query, Arg extends GetArg<T>>(
+  get<T extends QueryGetSelf, Arg extends GetArg<T>>(
     this: T,
     arg: Arg,
   ): GetResult<T, Arg> {
-    return _queryGet(this.clone(), arg);
+    return _queryGet((this as unknown as Query).clone(), arg) as never;
   }
 
   /**
@@ -45,6 +45,6 @@ export class QueryGet {
     this: T,
     arg: Arg,
   ): GetResultOptional<T, Arg> {
-    return _queryGetOptional(this.clone(), arg);
+    return _queryGetOptional((this as unknown as Query).clone(), arg) as never;
   }
 }

--- a/packages/qb/pqb/src/queryMethods/get.utils.ts
+++ b/packages/qb/pqb/src/queryMethods/get.utils.ts
@@ -19,7 +19,11 @@ import {
 } from './select';
 import { getQueryAs } from '../common/utils';
 import { SelectItemExpression } from '../common/selectItemExpression';
-import { Operators, setQueryOperators } from '../columns/operators';
+import {
+  BaseOperators,
+  Operators,
+  setQueryOperators,
+} from '../columns/operators';
 
 export type QueryGetSelf = Pick<
   Query,
@@ -100,7 +104,7 @@ const _get = <
 
   return setQueryOperators(
     q,
-    type?.operators || Operators.any,
+    (type?.operators || Operators.any) as BaseOperators,
   ) as unknown as GetResult<T, Arg> & GetResultOptional<T, Arg>;
 };
 

--- a/packages/qb/pqb/src/queryMethods/join/_join.ts
+++ b/packages/qb/pqb/src/queryMethods/join/_join.ts
@@ -11,7 +11,6 @@ import { RelationQueryBase } from '../../relations';
 import { pushQueryValue, setQueryObjectValue } from '../../query/queryUtils';
 import {
   JoinArgs,
-  JoinCallback,
   JoinFirstArg,
   JoinLateralCallback,
   JoinLateralResult,
@@ -41,7 +40,7 @@ export const _join = <
   q: T,
   require: RequireJoined,
   type: string,
-  args: [arg: Arg, ...args: Args] | [arg: Arg, cb: JoinCallback<T, Arg>],
+  args: [arg: Arg, ...args: Args],
 ): JoinResult<T, Arg, RequireJoined, RequireMain> => {
   let joinKey: string | undefined;
   let shape: QueryColumns | undefined;
@@ -121,7 +120,7 @@ export const _join = <
  * @param as - alias of the joined table, it is set the join lateral happens when selecting a relation in `select`
  */
 export const _joinLateral = <
-  T extends Pick<Query, 'meta' | 'shape' | 'relations' | 'withData'>,
+  T extends QueryBase,
   Arg extends JoinFirstArg<T>,
   R extends QueryBase,
   RequireJoined extends boolean,

--- a/packages/qb/pqb/src/queryMethods/join/_join.ts
+++ b/packages/qb/pqb/src/queryMethods/join/_join.ts
@@ -28,7 +28,8 @@ import { QueryBase } from '../../query/queryBase';
  * @param q - query object to join to
  * @param require - true for INNER kind of JOIN
  * @param type - SQL of the JOIN kind: JOIN, LEFT JOIN, RIGHT JOIN, etc.
- * @param args - join arguments to join a query, or `with` table, or a callback returning a query, etc.
+ * @param first - the first argument of join: join target
+ * @param args - rest join arguments: columns to join with, or a callback
  */
 export const _join = <
   T extends Query,
@@ -104,7 +105,7 @@ export const _join = <
     first,
     args,
     isSubQuery,
-  }) as unknown as JoinResult<T, Arg, RequireJoined, RequireMain>;
+  }) as never;
 };
 
 /**
@@ -177,5 +178,5 @@ export const _joinLateral = <
     type,
     result,
     as || getQueryAs(result),
-  ]) as JoinLateralResult<T, R, RequireJoined>;
+  ]) as never;
 };

--- a/packages/qb/pqb/src/queryMethods/join/_join.ts
+++ b/packages/qb/pqb/src/queryMethods/join/_join.ts
@@ -114,24 +114,26 @@ export const _join = <
  * Adds column parsers of the joined table into `joinedParsers`.
  * Adds join data into `join` of the query data.
  *
- * @param q - query object to join to
+ * @param self - query object to join to
  * @param type - SQL of the JOIN kind: JOIN or LEFT JOIN
  * @param arg - join target: a query, or a relation name, or a `with` table name, or a callback returning a query.
  * @param cb - callback where you can use `on` to join by columns, select needed data from the joined table, add where conditions, etc.
  * @param as - alias of the joined table, it is set the join lateral happens when selecting a relation in `select`
  */
 export const _joinLateral = <
-  T extends Query,
+  T extends Pick<Query, 'meta' | 'shape' | 'relations' | 'withData'>,
   Arg extends JoinFirstArg<T>,
   R extends QueryBase,
   RequireJoined extends boolean,
 >(
-  q: T,
+  self: T,
   type: string,
   arg: Arg,
   cb: JoinLateralCallback<T, Arg, R>,
   as?: string,
 ): JoinLateralResult<T, R, RequireJoined> => {
+  const q = self as unknown as Query;
+
   let relation: RelationQueryBase | undefined;
   if (typeof arg === 'string') {
     relation = q.relations[arg];
@@ -140,7 +142,7 @@ export const _joinLateral = <
     } else {
       const shape = q.q.withShapes?.[arg];
       if (shape) {
-        const t = Object.create(q.queryBuilder);
+        const t = Object.create((q as unknown as Query).queryBuilder);
         t.table = arg;
         t.shape = shape;
         t.q = {
@@ -161,7 +163,7 @@ export const _joinLateral = <
   if (relation) {
     result = relation.relationConfig.joinQuery(
       result as unknown as Query,
-      q,
+      q as unknown as Query,
     ) as unknown as R;
   }
 

--- a/packages/qb/pqb/src/queryMethods/join/_join.ts
+++ b/packages/qb/pqb/src/queryMethods/join/_join.ts
@@ -40,23 +40,22 @@ export const _join = <
   q: T,
   require: RequireJoined,
   type: string,
-  args: [arg: Arg, ...args: Args],
+  first: Arg,
+  args: Args,
 ): JoinResult<T, Arg, RequireJoined, RequireMain> => {
   let joinKey: string | undefined;
   let shape: QueryColumns | undefined;
   let parsers: ColumnsParsers | undefined;
   let isSubQuery = false;
 
-  if (typeof args[0] === 'function') {
-    args[0] = (args[0] as (q: Record<string, Query>) => Arg)(q.relations);
+  if (typeof first === 'function') {
+    first = (first as (q: Record<string, Query>) => Arg)(q.relations);
     (
-      args[0] as unknown as { joinQueryAfterCallback: unknown }
+      first as unknown as { joinQueryAfterCallback: unknown }
     ).joinQueryAfterCallback = (
-      args[0] as unknown as { joinQuery: unknown }
+      first as unknown as { joinQuery: unknown }
     ).joinQuery;
   }
-
-  const first = args[0];
 
   if (typeof first === 'object') {
     isSubQuery = getIsJoinSubQuery(first.q, first.baseQuery.q);
@@ -67,8 +66,8 @@ export const _join = <
       parsers = first.q.parsers;
 
       if (isSubQuery) {
-        args[0] = first.clone() as Arg;
-        (args[0] as Query).shape = shape as ColumnsShapeBase;
+        first = first.clone() as Arg;
+        (first as Query).shape = shape as ColumnsShapeBase;
       }
     }
   } else {
@@ -102,6 +101,7 @@ export const _join = <
 
   return pushQueryValue(q, 'join', {
     type,
+    first,
     args,
     isSubQuery,
   }) as unknown as JoinResult<T, Arg, RequireJoined, RequireMain>;

--- a/packages/qb/pqb/src/queryMethods/join/join.test.ts
+++ b/packages/qb/pqb/src/queryMethods/join/join.test.ts
@@ -72,11 +72,11 @@ describe.each`
     const q = User.clone();
     q.clone = (() => q) as unknown as typeof q.clone;
 
-    const args = [Message, 'authorId', 'id'] as const;
+    const args = ['authorId', 'id'] as const;
 
-    q[method as 'join'](...args);
+    q[method as 'join'](Message, ...args);
 
-    expect(_join).toBeCalledWith(q, require, sql, args);
+    expect(_join).toBeCalledWith(q, require, sql, Message, args);
   });
 });
 

--- a/packages/qb/pqb/src/queryMethods/join/join.ts
+++ b/packages/qb/pqb/src/queryMethods/join/join.ts
@@ -366,6 +366,16 @@ export type JoinLateralCallback<
   Q extends QueryBase = JoinArgToQuery<T, Arg>,
 > = (q: Q & OnQueryBuilder<T, Q>) => R;
 
+export type JoinQueryMethod = <
+  T extends Query,
+  Arg extends JoinFirstArg<T>,
+  Args extends JoinArgs<T, Arg>,
+>(
+  this: T,
+  arg: Arg,
+  ...args: Args
+) => JoinResultFromArgs<T, Arg, Args, true, true>;
+
 export class Join {
   /**
    * ## Select relation
@@ -740,10 +750,7 @@ export class Join {
     arg: Arg,
     ...args: Args
   ): JoinResultFromArgs<T, Arg, Args, true, true> {
-    return _join(this.clone(), true, 'JOIN', [
-      arg,
-      ...(args as never),
-    ]) as never;
+    return _join(this.clone(), true, 'JOIN', arg, args) as never;
   }
 
   /**
@@ -779,10 +786,7 @@ export class Join {
     arg: Arg,
     ...args: Args
   ): JoinResultFromArgs<T, Arg, Args, false, true> {
-    return _join(this.clone(), false, 'LEFT JOIN', [
-      arg,
-      ...(args as never),
-    ]) as never;
+    return _join(this.clone(), false, 'LEFT JOIN', arg, args) as never;
   }
 
   /**
@@ -815,10 +819,7 @@ export class Join {
     arg: Arg,
     ...args: Args
   ): JoinResultFromArgs<T, Arg, Args, true, false> {
-    return _join(this.clone(), true, 'RIGHT JOIN', [
-      arg,
-      ...(args as never),
-    ]) as never;
+    return _join(this.clone(), true, 'RIGHT JOIN', arg, args) as never;
   }
 
   /**
@@ -851,10 +852,7 @@ export class Join {
     arg: Arg,
     ...args: Args
   ): JoinResultFromArgs<T, Arg, Args, false, false> {
-    return _join(this.clone(), false, 'FULL JOIN', [
-      arg,
-      ...(args as never),
-    ]) as never;
+    return _join(this.clone(), false, 'FULL JOIN', arg, args) as never;
   }
 
   /**

--- a/packages/qb/pqb/src/queryMethods/join/join.ts
+++ b/packages/qb/pqb/src/queryMethods/join/join.ts
@@ -283,6 +283,7 @@ type JoinWithArgToQuery<
     };
   },
 > = {
+  __isQuery: true;
   q: QueryData;
   table: With['table'];
   clone<T extends Pick<QueryBase, 'baseQuery' | 'q'>>(this: T): T;

--- a/packages/qb/pqb/src/queryMethods/json.test.ts
+++ b/packages/qb/pqb/src/queryMethods/json.test.ts
@@ -3,12 +3,12 @@ import {
   Snake,
   User,
   userData,
-  UserDefaultTypes,
+  UserZodTypes,
 } from '../test-utils/test-utils';
 import {
   assertType,
   expectSql,
-  testColumnTypes as t,
+  testZodColumnTypes as t,
   useTestDatabase,
 } from 'test-utils';
 
@@ -168,7 +168,7 @@ describe('json methods', () => {
 
       it('should work inside `update` callback', () => {
         // using user with default types because of issue https://github.com/romeerez/orchid-orm/issues/230
-        const q = UserDefaultTypes.all().update({
+        const q = UserZodTypes.all().update({
           data: (q) => q.jsonSet('data', ['name'], 'new name'),
         });
 

--- a/packages/qb/pqb/src/queryMethods/json.ts
+++ b/packages/qb/pqb/src/queryMethods/json.ts
@@ -1,15 +1,20 @@
 import {
   AddQuerySelect,
+  PickQueryMetaResultReturnType,
   Query,
   SetQueryReturnsColumnOptional,
 } from '../query/query';
 import { pushQueryValue } from '../query/queryUtils';
 import { JsonItem } from '../sql';
-import { QueryColumn } from 'orchid-core';
+import {
+  PickQueryMeta,
+  PickQueryMetaShapeResultReturnType,
+  QueryColumn,
+} from 'orchid-core';
 import { queryJson } from './json.utils';
 
 // union of column names that have a `jsonb` type
-type JsonColumnName<T extends Pick<Query, 'meta'>> = {
+type JsonColumnName<T extends PickQueryMeta> = {
   [K in keyof T['meta']['selectable']]: T['meta']['selectable'][K]['column']['dataType'] extends 'jsonb'
     ? K
     : never;
@@ -17,29 +22,40 @@ type JsonColumnName<T extends Pick<Query, 'meta'>> = {
   string;
 
 // union of `jsonb` column names, or a JsonItem type for nesting json methods one in other
-type ColumnOrJsonMethod<T extends Pick<Query, 'meta'>> =
-  | JsonColumnName<T>
-  | JsonItem;
+type ColumnOrJsonMethod<T extends PickQueryMeta> = JsonColumnName<T> | JsonItem;
 
 // result of `jsonSet`:
 // adds a select to a query,
 // adds a `JsonItem` properties that allows nesting of json methods
 type JsonSetResult<
-  T extends Pick<Query, 'meta' | 'shape' | 'result' | 'returnType'>,
+  T extends PickQueryMetaShapeResultReturnType,
   Column extends ColumnOrJsonMethod<T>,
   As extends string,
-  Type extends QueryColumn = Column extends keyof T['shape']
+> = JsonItem<
+  As,
+  Column extends keyof T['shape']
     ? T['shape'][Column]
     : Column extends JsonItem
     ? Column['__json'][2]
-    : QueryColumn,
-> = JsonItem<As, Type> & AddQuerySelect<T, Record<As, Type>>;
+    : QueryColumn
+> &
+  AddQuerySelect<
+    T,
+    Record<
+      As,
+      Column extends keyof T['shape']
+        ? T['shape'][Column]
+        : Column extends JsonItem
+        ? Column['__json'][2]
+        : QueryColumn
+    >
+  >;
 
 // result of `jsonPathQuery`:
 // adds a select to a query,
 // adds a `JsonItem` properties that allows nesting of json methods
 type JsonPathQueryResult<
-  T extends Pick<Query, 'result' | 'meta' | 'returnType'>,
+  T extends PickQueryMetaResultReturnType,
   As extends string,
   Type extends QueryColumn,
 > = JsonItem &
@@ -78,7 +94,7 @@ export abstract class JsonModifiers {
    * @param options - `as` to alias the json value when selecting, `createIfMissing: true` will create a new JSON property if it didn't exist before
    */
   jsonSet<
-    T extends Pick<Query, 'meta' | 'shape' | 'result' | 'returnType'>,
+    T extends PickQueryMetaShapeResultReturnType,
     Column extends ColumnOrJsonMethod<T>,
     As extends string = Column extends JsonItem ? Column['__json'][1] : Column,
   >(
@@ -148,7 +164,7 @@ export abstract class JsonModifiers {
    * @param options - `as` to alias the json value when selecting, `insertAfter: true` to insert after the specified position
    */
   jsonInsert<
-    T extends Pick<Query, 'meta' | 'shape' | 'result' | 'returnType'>,
+    T extends PickQueryMetaShapeResultReturnType,
     Column extends ColumnOrJsonMethod<T>,
     As extends string = Column extends JsonItem ? Column['__json'][1] : Column,
   >(
@@ -211,7 +227,7 @@ export abstract class JsonModifiers {
    * @param options - `as` to alias the json value when selecting
    */
   jsonRemove<
-    T extends Pick<Query, 'meta' | 'shape' | 'result' | 'returnType'>,
+    T extends PickQueryMetaShapeResultReturnType,
     Column extends ColumnOrJsonMethod<T>,
     As extends string = Column extends JsonItem ? Column['__json'][1] : Column,
   >(
@@ -282,7 +298,7 @@ export abstract class JsonModifiers {
    * @param options - supports `vars` and `silent`, check Postgres docs of `json_path_query` for these
    */
   jsonPathQuery<
-    T extends Pick<Query, 'meta' | 'shape' | 'result' | 'returnType'>,
+    T extends PickQueryMetaShapeResultReturnType,
     As extends string,
     Type extends QueryColumn,
   >(

--- a/packages/qb/pqb/src/queryMethods/log.ts
+++ b/packages/qb/pqb/src/queryMethods/log.ts
@@ -2,23 +2,23 @@ import { Query } from '../query/query';
 import { quote } from '../quote';
 import { Sql } from 'orchid-core';
 
-export type QueryLogObject = {
+export interface QueryLogObject {
   colors: boolean;
   beforeQuery(sql: Sql): unknown;
   afterQuery(sql: Sql, logData: unknown): void;
   onError(error: Error, sql: Sql, logData: unknown): void;
-};
+}
 
-export type QueryLogger = {
+export interface QueryLogger {
   log(message: string): void;
   warn(message: string): void;
   error(message: string): void;
-};
+}
 
-export type QueryLogOptions = {
+export interface QueryLogOptions {
   log?: boolean | Partial<QueryLogObject>;
   logger?: QueryLogger;
-};
+}
 
 export const logColors = {
   boldCyanBright: (message: string) =>
@@ -113,9 +113,9 @@ export const logParamToLogObject = (
 };
 
 export class QueryLog {
-  log<T extends Query>(this: T, log = true): T {
-    const q = this.clone();
+  log<T>(this: T, log = true): T {
+    const q = (this as Query).clone();
     q.q.log = logParamToLogObject(q.q.logger, log);
-    return q;
+    return q as T;
   }
 }

--- a/packages/qb/pqb/src/queryMethods/merge.test.ts
+++ b/packages/qb/pqb/src/queryMethods/merge.test.ts
@@ -12,7 +12,7 @@ import {
 import {
   assertType,
   expectSql,
-  testColumnTypes as t,
+  testZodColumnTypes as t,
   testDb,
 } from 'test-utils';
 import { Expression, getValueKey } from 'orchid-core';

--- a/packages/qb/pqb/src/queryMethods/merge.test.ts
+++ b/packages/qb/pqb/src/queryMethods/merge.test.ts
@@ -371,10 +371,10 @@ describe('merge queries', () => {
       i2.columns = ['name'];
       i1.values = [[1]];
       i2.values = [['name']];
-      i1.using = [{ type: 'a', args: ['a'], isSubQuery: false }];
-      i2.using = [{ type: 'b', args: ['b'], isSubQuery: false }];
-      i1.join = [{ type: 'a', args: ['a'], isSubQuery: false }];
-      i2.join = [{ type: 'b', args: ['b'], isSubQuery: false }];
+      i1.using = [{ type: 'a', first: 'a', args: [], isSubQuery: false }];
+      i2.using = [{ type: 'b', first: 'b', args: [], isSubQuery: false }];
+      i1.join = [{ type: 'a', first: 'a', args: [], isSubQuery: false }];
+      i2.join = [{ type: 'b', first: 'b', args: [], isSubQuery: false }];
       i1.onConflict = { type: 'ignore' };
       i2.onConflict = { type: 'merge' };
       i1.beforeCreate = [() => {}];

--- a/packages/qb/pqb/src/queryMethods/merge.test.ts
+++ b/packages/qb/pqb/src/queryMethods/merge.test.ts
@@ -1,5 +1,4 @@
 import { Message, Profile, User } from '../test-utils/test-utils';
-import { QueryReturnType } from '../query/query';
 import { logParamToLogObject } from './log';
 import {
   ColumnInfoQueryData,
@@ -15,7 +14,7 @@ import {
   testZodColumnTypes as t,
   testDb,
 } from 'test-utils';
-import { Expression, getValueKey } from 'orchid-core';
+import { Expression, getValueKey, QueryReturnType } from 'orchid-core';
 
 describe('merge queries', () => {
   describe('select', () => {

--- a/packages/qb/pqb/src/queryMethods/merge.ts
+++ b/packages/qb/pqb/src/queryMethods/merge.ts
@@ -6,6 +6,7 @@ import {
   QueryCatch,
   QueryColumns,
   QueryThen,
+  RecordUnknown,
 } from 'orchid-core';
 
 export type MergeQuery<
@@ -64,8 +65,8 @@ const mergableObjects: Record<string, boolean> = {
 export class MergeQueryMethods {
   merge<T extends Query, Q extends Query>(this: T, q: Q): MergeQuery<T, Q> {
     const query = this.clone();
-    const a = query.q as Record<string, unknown>;
-    const b = q.q as Record<string, unknown>;
+    const a = query.q as RecordUnknown;
+    const b = q.q as RecordUnknown;
 
     for (const key in b) {
       const value = b[key];
@@ -80,7 +81,7 @@ export class MergeQueryMethods {
             a[key] = a[key] ? [...(a[key] as unknown[]), ...value] : value;
           } else if (mergableObjects[key]) {
             a[key] = a[key]
-              ? { ...(a[key] as Record<string, unknown>), ...value }
+              ? { ...(a[key] as RecordUnknown), ...value }
               : value;
           } else {
             a[key] = value;

--- a/packages/qb/pqb/src/queryMethods/queryMethods.ts
+++ b/packages/qb/pqb/src/queryMethods/queryMethods.ts
@@ -147,11 +147,15 @@ type QueryHelper<T extends Query, Args extends unknown[], Result> = {
         : K extends 'result'
         ? QueryColumns
         : K extends 'meta'
-        ? Omit<T['meta'], 'as' | 'selectable'> & {
-            selectable: Omit<
-              T['meta']['selectable'],
-              `${AliasOrTable<T>}.${Extract<keyof T['shape'], string>}`
-            >;
+        ? {
+            [K in keyof T['meta']]: K extends 'as'
+              ? string | undefined
+              : K extends 'selectable'
+              ? Omit<
+                  T['meta']['selectable'],
+                  `${AliasOrTable<T>}.${Extract<keyof T['shape'], string>}`
+                >
+              : T['meta'][K];
           }
         : T[K];
     },
@@ -186,14 +190,14 @@ export class ColumnRefExpression<T extends QueryColumn> extends Expression<T> {
 }
 
 export interface QueryMethods<ColumnTypes>
-  extends Omit<AsMethods, 'result'>,
+  extends AsMethods,
     AggregateMethods,
     Select,
     From,
     Join,
     With,
     Union,
-    Omit<JsonModifiers, 'result'>,
+    JsonModifiers,
     JsonMethods,
     Create,
     Update,

--- a/packages/qb/pqb/src/queryMethods/queryMethods.ts
+++ b/packages/qb/pqb/src/queryMethods/queryMethods.ts
@@ -38,13 +38,7 @@ import { Update } from './update';
 import { Delete } from './delete';
 import { Transaction } from './transaction';
 import { For } from './for';
-import {
-  _queryWhere,
-  Where,
-  WhereArg,
-  WhereQueryBase,
-  WhereResult,
-} from './where/where';
+import { _queryWhere, Where, WhereArg, WhereResult } from './where/where';
 import { SearchMethods } from './search';
 import { Clear } from './clear';
 import { Having } from './having';
@@ -78,16 +72,15 @@ import { queryWrap } from './queryMethods.utils';
 // argument of the window method
 // it is an object where keys are name of windows
 // and values can be a window options or a raw SQL
-export type WindowArg<T extends Query> = Record<
-  string,
-  WindowArgDeclaration<T> | Expression
->;
+export interface WindowArg<T extends Query> {
+  [K: string]: WindowArgDeclaration<T> | Expression;
+}
 
 // SQL window options to specify partitionBy and order of the window
-export type WindowArgDeclaration<T extends Query = Query> = {
+export interface WindowArgDeclaration<T extends Query = Query> {
   partitionBy?: SelectableOrExpression<T> | SelectableOrExpression<T>[];
   order?: OrderArg<T>;
-};
+}
 
 // add new windows to a query
 type WindowResult<T extends Query, W extends WindowArg<T>> = T & {
@@ -204,13 +197,13 @@ export interface QueryMethods<ColumnTypes>
     Delete,
     Transaction,
     For,
-    Omit<Where, 'result'>,
+    Where,
     SearchMethods,
     Clear,
     Having,
     Then,
     QueryLog,
-    Omit<QueryHooks, 'result'>,
+    QueryHooks,
     QueryUpsertOrCreate,
     QueryGet,
     MergeQueryMethods,
@@ -248,14 +241,14 @@ export const _queryExec = <T extends Query>(q: T) => {
   return q as unknown as SetQueryReturnsVoid<T>;
 };
 
-export const _queryFindBy = <T extends WhereQueryBase>(
+export const _queryFindBy = <T extends QueryBase>(
   q: T,
   args: WhereArg<T>[],
 ): SetQueryReturnsOne<WhereResult<T>> => {
   return _queryTake(_queryWhere(q, args));
 };
 
-export const _queryFindByOptional = <T extends WhereQueryBase>(
+export const _queryFindByOptional = <T extends QueryBase>(
   q: T,
   args: WhereArg<T>[],
 ): SetQueryReturnsOneOptional<WhereResult<T>> => {
@@ -489,7 +482,7 @@ export class QueryMethods<ColumnTypes> {
    *
    * @param args - `where` conditions
    */
-  findBy<T extends WhereQueryBase>(
+  findBy<T extends QueryBase>(
     this: T,
     ...args: WhereArg<T>[]
   ): SetQueryReturnsOne<WhereResult<T>> {
@@ -508,7 +501,7 @@ export class QueryMethods<ColumnTypes> {
    *
    * @param args - `where` conditions
    */
-  findByOptional<T extends WhereQueryBase>(
+  findByOptional<T extends QueryBase>(
     this: T,
     ...args: WhereArg<T>[]
   ): SetQueryReturnsOneOptional<WhereResult<T>> {

--- a/packages/qb/pqb/src/queryMethods/queryMethods.utils.ts
+++ b/packages/qb/pqb/src/queryMethods/queryMethods.utils.ts
@@ -1,15 +1,13 @@
 import { SetQueryTableAlias } from '../query/query';
 import { _queryAs } from './as';
 import { queryFrom } from './from';
-import { WrapQuerySelf, WrapQueryArg } from './queryMethods';
+import { WrapQueryArg } from './queryMethods';
+import { PickQueryTableMetaResult } from 'orchid-core';
 
 export function queryWrap<
-  T extends WrapQuerySelf,
+  T extends PickQueryTableMetaResult,
   Q extends WrapQueryArg,
   As extends string = 't',
 >(self: T, query: Q, as: As = 't' as As): SetQueryTableAlias<Q, As> {
-  return _queryAs(
-    queryFrom(query, [self]),
-    as,
-  ) as unknown as SetQueryTableAlias<Q, As>;
+  return _queryAs(queryFrom(query, [self]), as) as never;
 }

--- a/packages/qb/pqb/src/queryMethods/rawSql.ts
+++ b/packages/qb/pqb/src/queryMethods/rawSql.ts
@@ -1,9 +1,7 @@
 import { StaticSQLArgs, DynamicSQLArg, QueryColumn } from 'orchid-core';
 import { DynamicRawSQL, raw, RawSQL } from '../sql/rawSql';
 
-export class RawSqlMethods<ColumnTypes> {
-  columnTypes!: ColumnTypes;
-
+export abstract class RawSqlMethods<ColumnTypes> {
   /**
    * When there is a need to use a piece of raw SQL, use the `sql` method from tables, or a `raw` function imported from `orchid-orm`.
    *
@@ -161,7 +159,7 @@ export class RawSqlMethods<ColumnTypes> {
     this: { columnTypes: ColumnTypes },
     ...args: [DynamicSQLArg]
   ): DynamicRawSQL<QueryColumn<T>, ColumnTypes>;
-  sql(...args: unknown[]) {
+  sql(this: { columnTypes: ColumnTypes }, ...args: unknown[]) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sql = (raw as any)(...args);
     sql.columnTypes = this.columnTypes;

--- a/packages/qb/pqb/src/queryMethods/scope.ts
+++ b/packages/qb/pqb/src/queryMethods/scope.ts
@@ -5,6 +5,13 @@ import { pushQueryArray, setQueryObjectValue } from '../query/queryUtils';
 import { Where, WhereResult } from './where/where';
 import { SelectableFromShape } from '../query/query';
 
+interface ScopeArgumentQueryMeta<
+  Table extends string | undefined,
+  Shape extends QueryColumns,
+> extends QueryMetaBase {
+  selectable: SelectableFromShape<Shape, Table>;
+}
+
 export interface ScopeArgumentQuery<
   Table extends string | undefined,
   Shape extends QueryColumns,
@@ -12,9 +19,7 @@ export interface ScopeArgumentQuery<
     QueryBase {
   table: Table;
   shape: Shape;
-  meta: Omit<QueryMetaBase, 'selectable'> & {
-    selectable: SelectableFromShape<Shape, Table>;
-  };
+  meta: ScopeArgumentQueryMeta<Table, Shape>;
 }
 
 /**

--- a/packages/qb/pqb/src/queryMethods/scope.ts
+++ b/packages/qb/pqb/src/queryMethods/scope.ts
@@ -1,9 +1,9 @@
 import { QueryBase } from '../query/queryBase';
-import { QueryColumns, QueryMetaBase } from 'orchid-core';
+import { PickQueryMeta, QueryColumns, QueryMetaBase } from 'orchid-core';
 import { QueryScopes, SelectQueryData, WhereItem } from '../sql';
 import { pushQueryArray, setQueryObjectValue } from '../query/queryUtils';
 import { Where, WhereResult } from './where/where';
-import { SelectableFromShape } from '../query/query';
+import { Query, SelectableFromShape } from '../query/query';
 
 interface ScopeArgumentQueryMeta<
   Table extends string | undefined,
@@ -68,14 +68,14 @@ export class ScopeMethods {
    *
    * @param scope - name of the scope to apply
    */
-  scope<T extends QueryBase>(
+  scope<T extends PickQueryMeta>(
     this: T,
     scope: keyof T['meta']['scopes'],
   ): WhereResult<T> {
-    const q = this.clone();
+    const q = (this as unknown as Query).clone();
 
     if (!q.q.scopes?.[scope as string]) {
-      const s = (this.internal.scopes as QueryScopes)[scope as string];
+      const s = (q.internal.scopes as QueryScopes)[scope as string];
 
       if (s.and) pushQueryArray(q, 'and', s.and);
       if (s.or) pushQueryArray(q, 'or', s.or);
@@ -83,7 +83,7 @@ export class ScopeMethods {
       setQueryObjectValue(q, 'scopes', scope as string, s);
     }
 
-    return q as WhereResult<T>;
+    return q as never;
   }
 
   /**
@@ -98,8 +98,11 @@ export class ScopeMethods {
    *
    * @param scope - name of the scope to remove from the query
    */
-  unscope<T extends QueryBase>(this: T, scope: keyof T['meta']['scopes']): T {
-    const q = this.clone();
+  unscope<T extends PickQueryMeta>(
+    this: T,
+    scope: keyof T['meta']['scopes'],
+  ): T {
+    const q = (this as unknown as Query).clone();
     const data = q.q as SelectQueryData;
 
     const s = q.q.scopes?.[scope as string];
@@ -118,6 +121,6 @@ export class ScopeMethods {
       delete (q.q.scopes as QueryScopes)[scope as string];
     }
 
-    return q as WhereResult<T>;
+    return q as never;
   }
 }

--- a/packages/qb/pqb/src/queryMethods/select.test.ts
+++ b/packages/qb/pqb/src/queryMethods/select.test.ts
@@ -32,6 +32,12 @@ const insertUserAndProfile = async () => {
 describe('select', () => {
   useTestDatabase();
 
+  it('should respect previous select', () => {
+    const q = User.select('id').select('name');
+
+    assertType<Awaited<typeof q>, { id: number; name: string }[]>();
+  });
+
   // testing this issue: https://github.com/romeerez/orchid-orm/issues/45
   it('should handle nested sub selects', async () => {
     await User.create(userData);

--- a/packages/qb/pqb/src/queryMethods/select.test.ts
+++ b/packages/qb/pqb/src/queryMethods/select.test.ts
@@ -18,7 +18,7 @@ import { UnknownColumn } from '../columns/unknown';
 import {
   assertType,
   expectSql,
-  testColumnTypes as t,
+  testZodColumnTypes as t,
   useTestDatabase,
 } from 'test-utils';
 import { raw } from '../sql/rawSql';

--- a/packages/qb/pqb/src/queryMethods/select.ts
+++ b/packages/qb/pqb/src/queryMethods/select.ts
@@ -338,7 +338,7 @@ export const processSelectArg = <T extends SelectSelf>(
         value.q.joinedForSelect = asOverride;
 
         _joinLateral(
-          q,
+          q as unknown as QueryBase,
           value.q.innerJoinLateral ? 'JOIN' : 'LEFT JOIN',
           query,
           (q) => q,

--- a/packages/qb/pqb/src/queryMethods/softDelete.ts
+++ b/packages/qb/pqb/src/queryMethods/softDelete.ts
@@ -1,4 +1,10 @@
-import { QueryColumns, QueryColumnsInit, RecordUnknown } from 'orchid-core';
+import {
+  PickQueryMetaResult,
+  QueryColumns,
+  QueryColumnsInit,
+  QueryMetaBase,
+  RecordUnknown,
+} from 'orchid-core';
 import { pushQueryValue } from '../query/queryUtils';
 import { QueryScopes } from '../sql';
 import { Query } from '../query/query';
@@ -54,9 +60,9 @@ const _softDelete = (column: PropertyKey) => {
   };
 };
 
-export type QueryWithSoftDelete = Query & {
-  meta: { scopes: { nonDeleted: unknown } };
-};
+export interface QueryWithSoftDelete extends PickQueryMetaResult {
+  meta: QueryMetaBase & { scopes: { nonDeleted: unknown } };
+}
 
 /**
  * `softDelete` configures the table to set `deletedAt` to current time instead of deleting records.
@@ -98,7 +104,7 @@ export class SoftDeleteMethods {
    * ```
    */
   includeDeleted<T extends QueryWithSoftDelete>(this: T): T {
-    return this.unscope('nonDeleted');
+    return (this as unknown as Query).unscope('nonDeleted' as never) as never;
   }
 
   /**
@@ -113,6 +119,8 @@ export class SoftDeleteMethods {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ..._args: DeleteArgs<T>
   ): DeleteResult<T> {
-    return _queryDelete(this.clone().unscope('nonDeleted' as never));
+    return _queryDelete(
+      (this as unknown as Query).clone().unscope('nonDeleted' as never),
+    ) as never;
   }
 }

--- a/packages/qb/pqb/src/queryMethods/softDelete.ts
+++ b/packages/qb/pqb/src/queryMethods/softDelete.ts
@@ -1,4 +1,4 @@
-import { QueryColumns, QueryColumnsInit } from 'orchid-core';
+import { QueryColumns, QueryColumnsInit, RecordUnknown } from 'orchid-core';
 import { pushQueryValue } from '../query/queryUtils';
 import { QueryScopes } from '../sql';
 import { Query } from '../query/query';
@@ -34,7 +34,7 @@ export function enableSoftDelete(
     and: [{ [column]: null }],
   };
 
-  (scopes as Record<string, unknown>).deleted = scope;
+  (scopes as RecordUnknown).deleted = scope;
   pushQueryValue(q, 'and', scope.and[0]);
   (q.q.scopes ??= {}).nonDeleted = scope;
 

--- a/packages/qb/pqb/src/queryMethods/then.ts
+++ b/packages/qb/pqb/src/queryMethods/then.ts
@@ -1,4 +1,4 @@
-import { Query, QueryReturnType } from '../query/query';
+import { Query } from '../query/query';
 import { NotFoundError, QueryError } from '../errors';
 import { QueryArraysResult, QueryResult } from '../adapter';
 import {
@@ -15,6 +15,7 @@ import {
   ColumnsParsers,
   emptyArray,
   getValueKey,
+  QueryReturnType,
   RecordString,
   RecordUnknown,
   Sql,
@@ -59,7 +60,7 @@ let getThen: (this: Query) => typeof Then.prototype.then;
 
 // workaround for the bun issue: https://github.com/romeerez/orchid-orm/issues/198
 if (process.versions.bun) {
-  getThen = function (this: Query) {
+  getThen = function () {
     queryError = new Error();
 
     // In rake-db `then` might be called on a lightweight query object that has no `internal`.

--- a/packages/qb/pqb/src/queryMethods/then.ts
+++ b/packages/qb/pqb/src/queryMethods/then.ts
@@ -15,6 +15,8 @@ import {
   ColumnsParsers,
   emptyArray,
   getValueKey,
+  RecordString,
+  RecordUnknown,
   Sql,
   TransactionState,
 } from 'orchid-core';
@@ -159,7 +161,7 @@ function maybeWrappedThen(
   }
 }
 
-const queriesNames: Record<string, string> = {};
+const queriesNames: RecordString = {};
 let nameI = 0;
 
 const callAfterHook = function (
@@ -430,9 +432,9 @@ const filterResult = (
   if (returnType === 'all') {
     const pick = getSelectPick(queryResult, hookSelect);
     return (result as unknown[]).map((full) => {
-      const filtered: Record<string, unknown> = {};
+      const filtered: RecordUnknown = {};
       for (const key of pick) {
-        filtered[key] = (full as Record<string, unknown>)[key];
+        filtered[key] = (full as RecordUnknown)[key];
       }
       return filtered;
     });
@@ -447,9 +449,7 @@ const filterResult = (
       result = {};
       for (const key in row) {
         if (!hookSelect.includes(key)) {
-          (result as Record<string, unknown>)[key] = (
-            row as Record<string, unknown>
-          )[key];
+          (result as RecordUnknown)[key] = (row as RecordUnknown)[key];
         }
       }
       return result;
@@ -457,13 +457,11 @@ const filterResult = (
   }
 
   if (returnType === 'value') {
-    return (result as Record<string, unknown>[])[0]?.[
-      queryResult.fields[0].name
-    ];
+    return (result as RecordUnknown[])[0]?.[queryResult.fields[0].name];
   }
 
   if (returnType === 'valueOrThrow') {
-    const row = (result as Record<string, unknown>[])[0];
+    const row = (result as RecordUnknown[])[0];
     if (!row) throw new NotFoundError(q);
     return row[queryResult.fields[0].name];
   }
@@ -474,13 +472,13 @@ const filterResult = (
 
   if (returnType === 'pluck') {
     const key = queryResult.fields[0].name;
-    return (result as Record<string, unknown>[]).map((row) => row[key]);
+    return (result as RecordUnknown[]).map((row) => row[key]);
   }
 
   if (returnType === 'rows') {
     const pick = getSelectPick(queryResult, hookSelect);
     return (result as unknown[]).map((full) =>
-      pick.map((key) => (full as Record<string, unknown>)[key]),
+      pick.map((key) => (full as RecordUnknown)[key]),
     );
   }
 

--- a/packages/qb/pqb/src/queryMethods/transaction.ts
+++ b/packages/qb/pqb/src/queryMethods/transaction.ts
@@ -1,4 +1,4 @@
-import { Query } from '../query/query';
+import { PickQueryQAndInternal } from '../query/query';
 import {
   AfterCommitHook,
   emptyArray,
@@ -8,8 +8,6 @@ import {
   TransactionState,
 } from 'orchid-core';
 import { QueryBase } from '../query/queryBase';
-
-export type TransactionSelf = Pick<Query, 'q' | 'internal'>;
 
 const commitSql = {
   text: 'COMMIT',
@@ -27,23 +25,23 @@ export type IsolationLevel =
   | 'READ COMMITTED'
   | 'READ UNCOMMITTED';
 
-export type TransactionOptions = {
+export interface TransactionOptions {
   level: IsolationLevel;
   readOnly?: boolean;
   deferrable?: boolean;
-};
+}
 
 export class Transaction {
-  transaction<T extends TransactionSelf, Result>(
+  transaction<T extends PickQueryQAndInternal, Result>(
     this: T,
     cb: () => Promise<Result>,
   ): Promise<Result>;
-  transaction<T extends TransactionSelf, Result>(
+  transaction<T extends PickQueryQAndInternal, Result>(
     this: T,
     options: IsolationLevel | TransactionOptions,
     cb: () => Promise<Result>,
   ): Promise<Result>;
-  async transaction<T extends TransactionSelf, Result>(
+  async transaction<T extends PickQueryQAndInternal, Result>(
     this: T,
     cbOrOptions: IsolationLevel | TransactionOptions | (() => Promise<Result>),
     cb?: () => Promise<Result>,

--- a/packages/qb/pqb/src/queryMethods/transform.ts
+++ b/packages/qb/pqb/src/queryMethods/transform.ts
@@ -14,19 +14,16 @@ export type QueryTransformFn<T extends Query> = (
 // Changes the `returnType` to `valueOrThrow`,
 // because it's always returning a single value - the result of the transform function.
 // Changes the query result to a type returned by the transform function.
-export type QueryTransform<
-  T extends QueryBase,
-  Fn extends QueryTransformFn<Query>,
-  Data = ReturnType<Fn>,
-> = {
-  [K in keyof QueryBase]: K extends 'returnType'
+export type QueryTransform<T extends QueryBase, Data> = {
+  [K in keyof T]: K extends 'returnType'
     ? 'valueOrThrow'
     : K extends 'result'
     ? { value: QueryColumn<Data> }
+    : K extends 'then'
+    ? QueryThen<Data>
+    : K extends 'catch'
+    ? QueryCatch<Data>
     : T[K];
-} & {
-  then: QueryThen<Data>;
-  catch: QueryCatch<Data>;
 };
 
 export class TransformMethods {
@@ -84,10 +81,7 @@ export class TransformMethods {
   transform<T extends Query, Fn extends QueryTransformFn<T>>(
     this: T,
     fn: Fn,
-  ): QueryTransform<T, Fn> {
-    return pushQueryValue(this.clone(), 'transform', fn) as QueryTransform<
-      T,
-      Fn
-    >;
+  ): QueryTransform<T, ReturnType<Fn>> {
+    return pushQueryValue(this.clone(), 'transform', fn) as never;
   }
 }

--- a/packages/qb/pqb/src/queryMethods/union.ts
+++ b/packages/qb/pqb/src/queryMethods/union.ts
@@ -1,11 +1,11 @@
-import { Query } from '../query/query';
 import { pushQueryArray } from '../query/queryUtils';
-import { Expression } from 'orchid-core';
+import { Expression, PickQueryResult } from 'orchid-core';
+import { Query } from '../query/query';
 
 // argument of `union`-like query methods.
 // it supports query objects with the same result as in the previous query,
 // or a raw SQL
-export type UnionArg<T extends Pick<Query, 'result'>> =
+export type UnionArg<T extends PickQueryResult> =
   | {
       result: { [K in keyof T['result']]: Pick<T['result'][K], 'dataType'> };
     }
@@ -29,16 +29,16 @@ export class Union {
    * @param args - array of queries or raw SQLs
    * @param wrap - provide `true` if you want the queries to be wrapped into parentheses
    */
-  union<T extends Pick<Query, 'clone' | 'result' | 'q' | 'baseQuery'>>(
+  union<T extends PickQueryResult>(
     this: T,
     args: UnionArg<T>[],
     wrap?: boolean,
   ): T {
     return pushQueryArray(
-      this.clone() as T,
+      (this as unknown as Query).clone(),
       'union',
       args.map((arg) => ({ arg, kind: 'UNION' as const, wrap })),
-    );
+    ) as never;
   }
 
   /**
@@ -47,12 +47,16 @@ export class Union {
    * @param args - array of queries or raw SQLs
    * @param wrap - provide `true` if you want the queries to be wrapped into parentheses
    */
-  unionAll<T extends Query>(this: T, args: UnionArg<T>[], wrap?: boolean): T {
+  unionAll<T extends PickQueryResult>(
+    this: T,
+    args: UnionArg<T>[],
+    wrap?: boolean,
+  ): T {
     return pushQueryArray(
-      this.clone(),
+      (this as unknown as Query).clone(),
       'union',
       args.map((arg) => ({ arg, kind: 'UNION ALL' as const, wrap })),
-    );
+    ) as never;
   }
 
   /**
@@ -61,12 +65,16 @@ export class Union {
    * @param args - array of queries or raw SQLs
    * @param wrap - provide `true` if you want the queries to be wrapped into parentheses
    */
-  intersect<T extends Query>(this: T, args: UnionArg<T>[], wrap?: boolean): T {
+  intersect<T extends PickQueryResult>(
+    this: T,
+    args: UnionArg<T>[],
+    wrap?: boolean,
+  ): T {
     return pushQueryArray(
-      this.clone(),
+      (this as unknown as Query).clone(),
       'union',
       args.map((arg) => ({ arg, kind: 'INTERSECT' as const, wrap })),
-    );
+    ) as never;
   }
 
   /**
@@ -75,16 +83,16 @@ export class Union {
    * @param args - array of queries or raw SQLs
    * @param wrap - provide `true` if you want the queries to be wrapped into parentheses
    */
-  intersectAll<T extends Query>(
+  intersectAll<T extends PickQueryResult>(
     this: T,
     args: UnionArg<T>[],
     wrap?: boolean,
   ): T {
     return pushQueryArray(
-      this.clone(),
+      (this as unknown as Query).clone(),
       'union',
       args.map((arg) => ({ arg, kind: 'INTERSECT ALL' as const, wrap })),
-    );
+    ) as never;
   }
 
   /**
@@ -93,12 +101,16 @@ export class Union {
    * @param args - array of queries or raw SQLs
    * @param wrap - provide `true` if you want the queries to be wrapped into parentheses
    */
-  except<T extends Query>(this: T, args: UnionArg<T>[], wrap?: boolean): T {
+  except<T extends PickQueryResult>(
+    this: T,
+    args: UnionArg<T>[],
+    wrap?: boolean,
+  ): T {
     return pushQueryArray(
-      this.clone(),
+      (this as unknown as Query).clone(),
       'union',
       args.map((arg) => ({ arg, kind: 'EXCEPT' as const, wrap })),
-    );
+    ) as never;
   }
 
   /**
@@ -107,11 +119,15 @@ export class Union {
    * @param args - array of queries or raw SQLs
    * @param wrap - provide `true` if you want the queries to be wrapped into parentheses
    */
-  exceptAll<T extends Query>(this: T, args: UnionArg<T>[], wrap?: boolean): T {
+  exceptAll<T extends PickQueryResult>(
+    this: T,
+    args: UnionArg<T>[],
+    wrap?: boolean,
+  ): T {
     return pushQueryArray(
-      this.clone(),
+      (this as unknown as Query).clone(),
       'union',
       args.map((arg) => ({ arg, kind: 'EXCEPT ALL' as const, wrap })),
-    );
+    ) as never;
   }
 }

--- a/packages/qb/pqb/src/queryMethods/update.ts
+++ b/packages/qb/pqb/src/queryMethods/update.ts
@@ -21,6 +21,7 @@ import {
   callWithThis,
   TemplateLiteralArgs,
   emptyObject,
+  RecordUnknown,
 } from 'orchid-core';
 import { QueryResult } from '../adapter';
 import { JsonModifiers } from './json';
@@ -109,7 +110,7 @@ type ChangeCountArg<T extends Pick<Query, 'shape'>> =
 // It's being used by relations logic in the ORM.
 export type UpdateCtx = {
   queries?: ((queryResult: QueryResult) => Promise<void>)[];
-  updateData?: Record<string, unknown>;
+  updateData?: RecordUnknown;
 };
 
 // apply `increment` or a `decrement`,
@@ -164,7 +165,7 @@ export const _queryUpdate = <T extends UpdateSelf>(
 ): UpdateResult<T> => {
   const { q } = query;
 
-  const set: Record<string, unknown> = { ...arg };
+  const set: RecordUnknown = { ...arg };
   pushQueryValue(query, 'updateData', set);
 
   const { shape } = q;

--- a/packages/qb/pqb/src/queryMethods/upsertOrCreate.ts
+++ b/packages/qb/pqb/src/queryMethods/upsertOrCreate.ts
@@ -1,7 +1,7 @@
 import {
   Query,
   SetQueryKind,
-  SetQueryReturnsOne,
+  SetQueryReturnsOneKind,
   SetQueryReturnsVoid,
 } from '../query/query';
 import { _queryUpdate, UpdateData } from './update';
@@ -44,7 +44,7 @@ type UpsertArgWithData<
 
 // unless upsert query has a select, it returns void
 export type UpsertResult<T extends Query> = T['meta']['hasSelect'] extends true
-  ? SetQueryReturnsOne<SetQueryKind<T, 'upsert'>>
+  ? SetQueryReturnsOneKind<T, 'upsert'>
   : SetQueryReturnsVoid<SetQueryKind<T, 'upsert'>>;
 
 // Require type of query object to query only one record
@@ -208,7 +208,7 @@ export class QueryUpsertOrCreate {
     }
 
     if (!isObjectEmpty(updateData)) {
-      _queryUpdate(q, updateData as UpdateData<WhereResult<Query>>);
+      _queryUpdate(q, updateData as unknown as UpdateData<WhereResult<Query>>);
     }
 
     return orCreate(q, data.create, updateData, mergeData);

--- a/packages/qb/pqb/src/queryMethods/with.test.ts
+++ b/packages/qb/pqb/src/queryMethods/with.test.ts
@@ -9,7 +9,7 @@ import {
 import {
   assertType,
   expectSql,
-  testColumnTypes as t,
+  testZodColumnTypes as t,
   testDb,
 } from 'test-utils';
 

--- a/packages/qb/pqb/src/queryMethods/with.ts
+++ b/packages/qb/pqb/src/queryMethods/with.ts
@@ -1,5 +1,5 @@
 import { WithOptions } from '../sql';
-import { AddQueryWith, Query } from '../query/query';
+import { AddQueryWith, PickQueryWithData, Query } from '../query/query';
 import { Db } from '../query/db';
 import { pushQueryValue, setQueryObjectValue } from '../query/queryUtils';
 import {
@@ -54,7 +54,7 @@ type WithShape<Args extends WithArgs> = Args[1] extends Query
 
 // Adds a `withData` entry to a query
 type WithResult<
-  T extends Query,
+  T extends PickQueryWithData,
   Args extends WithArgs,
   Shape extends QueryColumns,
 > = AddQueryWith<
@@ -133,11 +133,11 @@ export class With {
    * @param args - first argument is an alias for this CTE, other arguments can be column shape, query object, or raw SQL.
    */
   with<
-    T extends Query,
+    T extends PickQueryWithData,
     Args extends WithArgs,
     Shape extends QueryColumns = WithShape<Args>,
   >(this: T, ...args: Args): WithResult<T, Args, Shape> {
-    const q = this.clone();
+    const q = (this as unknown as Query).clone();
 
     let options =
       (args.length === 3 && !isExpression(args[2])) || args.length === 4
@@ -167,11 +167,6 @@ export class With {
 
     pushQueryValue(q, 'with', [args[0], options || emptyObject, query]);
 
-    return setQueryObjectValue(
-      q,
-      'withShapes',
-      args[0],
-      shape,
-    ) as unknown as WithResult<T, Args, Shape>;
+    return setQueryObjectValue(q, 'withShapes', args[0], shape) as never;
   }
 }

--- a/packages/qb/pqb/src/relations.ts
+++ b/packages/qb/pqb/src/relations.ts
@@ -8,7 +8,7 @@ export type RelationJoinQuery = (
   baseQuery: Query,
 ) => Query;
 
-export type RelationConfigBase = {
+export interface RelationConfigBase {
   query: Query;
   methodQuery: Query;
   joinQuery: RelationJoinQuery;
@@ -27,14 +27,16 @@ export type RelationConfigBase = {
   dataForUpdate: unknown;
   dataForUpdateOne: unknown;
   params: RecordUnknown;
-};
+}
 
-export type RelationConfigDataForCreate = {
+export interface RelationConfigDataForCreate {
   columns: RecordUnknown;
   nested: RecordUnknown;
-};
+}
 
-export type RelationsBase = Record<string, RelationQueryBase>;
+export interface RelationsBase {
+  [K: string]: RelationQueryBase;
+}
 
 export interface RelationQueryBase extends Query {
   relationConfig: RelationConfigBase;

--- a/packages/qb/pqb/src/relations.ts
+++ b/packages/qb/pqb/src/relations.ts
@@ -36,9 +36,9 @@ export type RelationConfigDataForCreate = {
 
 export type RelationsBase = Record<string, RelationQueryBase>;
 
-export type RelationQueryBase = Query & {
+export interface RelationQueryBase extends Query {
   relationConfig: RelationConfigBase;
-};
+}
 
 export type RelationQuery<
   Config extends RelationConfigBase = RelationConfigBase,

--- a/packages/qb/pqb/src/relations.ts
+++ b/packages/qb/pqb/src/relations.ts
@@ -1,4 +1,5 @@
 import { Query } from './query/query';
+import { RecordUnknown } from 'orchid-core';
 
 export type RelationsChain = (Query | RelationQuery)[];
 
@@ -25,12 +26,12 @@ export type RelationConfigBase = {
   optionalDataForCreate: unknown;
   dataForUpdate: unknown;
   dataForUpdateOne: unknown;
-  params: Record<string, unknown>;
+  params: RecordUnknown;
 };
 
 export type RelationConfigDataForCreate = {
-  columns: Record<string, unknown>;
-  nested: Record<string, unknown>;
+  columns: RecordUnknown;
+  nested: RecordUnknown;
 };
 
 export type RelationsBase = Record<string, RelationQueryBase>;

--- a/packages/qb/pqb/src/sql/common.ts
+++ b/packages/qb/pqb/src/sql/common.ts
@@ -1,5 +1,5 @@
 import { SelectableOrExpression } from '../common/utils';
-import { QueryData } from './data';
+import { PickQueryDataShapeAndJoinedShapes, QueryData } from './data';
 import { ToSQLCtx } from './toSQL';
 import {
   ColumnTypeBase,
@@ -160,7 +160,7 @@ export const ownColumnToSql = (
 
 export const rawOrColumnToSql = (
   ctx: ToSQLCtx,
-  data: Pick<QueryData, 'shape' | 'joinedShapes'>,
+  data: PickQueryDataShapeAndJoinedShapes,
   expr: SelectableOrExpression,
   quotedAs: string | undefined,
   shape: QueryColumns = data.shape,

--- a/packages/qb/pqb/src/sql/data.ts
+++ b/packages/qb/pqb/src/sql/data.ts
@@ -1,4 +1,4 @@
-import { Query, QueryReturnType } from '../query/query';
+import { PickQueryQ, Query } from '../query/query';
 import { QueryLogger, QueryLogObject } from '../queryMethods';
 import { Adapter, QueryResult } from '../adapter';
 import { toSQLCacheKey } from './toSQL';
@@ -27,8 +27,9 @@ import {
   QueryColumn,
   RecordString,
   RecordUnknown,
+  QueryReturnType,
+  PickQueryTable,
 } from 'orchid-core';
-import { QueryBase } from '../query/queryBase';
 import { BaseOperators } from '../columns/operators';
 import { RelationsChain } from '../relations';
 
@@ -55,7 +56,7 @@ export type QueryScopeData = {
   or?: WhereItem[][];
 };
 
-export type QueryDataJoinTo = Pick<QueryBase, 'table' | 'q'>;
+export interface QueryDataJoinTo extends PickQueryTable, PickQueryQ {}
 
 export type CommonQueryData = {
   adapter: Adapter;
@@ -271,6 +272,11 @@ export type QueryData =
   | TruncateQueryData
   | ColumnInfoQueryData
   | CopyQueryData;
+
+export interface PickQueryDataShapeAndJoinedShapes {
+  shape: ColumnsShapeBase;
+  joinedShapes?: JoinedShapes;
+}
 
 export const cloneQuery = (q: QueryData) => {
   if (q.with) q.with = q.with.slice(0);

--- a/packages/qb/pqb/src/sql/data.ts
+++ b/packages/qb/pqb/src/sql/data.ts
@@ -25,6 +25,8 @@ import {
   ColumnsParsers,
   Expression,
   QueryColumn,
+  RecordString,
+  RecordUnknown,
 } from 'orchid-core';
 import { QueryBase } from '../query/queryBase';
 import { BaseOperators } from '../columns/operators';
@@ -36,7 +38,7 @@ export type JoinedShapes = Record<string, ColumnsShapeBase>;
 export type JoinedParsers = Record<string, ColumnsParsers>;
 // Keep track of joined table names.
 // When joining the same table second time, this allows to add a numeric suffix to avoid name collisions.
-export type JoinOverrides = Record<string, string>;
+export type JoinOverrides = RecordString;
 
 export type QueryBeforeHook = (query: Query) => void | Promise<void>;
 export type QueryAfterHook<Data = unknown> = (
@@ -88,7 +90,7 @@ export type CommonQueryData = {
   coalesceValue?: unknown | Expression;
   parsers?: ColumnsParsers;
   notFoundDefault?: unknown;
-  defaults?: Record<string, unknown>;
+  defaults?: RecordUnknown;
   // run functions before any query
   before?: QueryBeforeHook[];
   // run functions after any query

--- a/packages/qb/pqb/src/sql/join.ts
+++ b/packages/qb/pqb/src/sql/join.ts
@@ -3,7 +3,12 @@ import { JoinItem, SimpleJoinItem } from './types';
 import { Query, QueryWithTable } from '../query/query';
 import { whereToSql } from './where';
 import { ToSQLCtx, ToSQLQuery } from './toSQL';
-import { JoinedShapes, QueryData, SelectQueryData } from './data';
+import {
+  JoinedShapes,
+  PickQueryDataShapeAndJoinedShapes,
+  QueryData,
+  SelectQueryData,
+} from './data';
 import { pushQueryArray } from '../query/queryUtils';
 import { QueryBase } from '../query/queryBase';
 import {
@@ -25,7 +30,7 @@ type ItemOf2Or3Length =
 export const processJoinItem = (
   ctx: ToSQLCtx,
   table: ToSQLQuery,
-  query: Pick<QueryData, 'shape' | 'joinedShapes'>,
+  query: PickQueryDataShapeAndJoinedShapes,
   item: Pick<SimpleJoinItem, 'first' | 'args' | 'isSubQuery'>,
   quotedAs: string | undefined,
 ): { target: string; conditions?: string } => {
@@ -156,7 +161,7 @@ const processArgs = (
   args: SimpleJoinItem['args'],
   ctx: ToSQLCtx,
   table: ToSQLQuery,
-  query: Pick<QueryData, 'shape' | 'joinedShapes'>,
+  query: PickQueryDataShapeAndJoinedShapes,
   first:
     | string
     | (QueryWithTable & {
@@ -259,7 +264,7 @@ const processArgs = (
 
 const getConditionsFor3Or4LengthItem = (
   ctx: ToSQLCtx,
-  query: Pick<QueryData, 'shape' | 'joinedShapes'>,
+  query: PickQueryDataShapeAndJoinedShapes,
   target: string,
   quotedAs: string | undefined,
   args: ItemOf2Or3Length,
@@ -281,7 +286,7 @@ const getConditionsFor3Or4LengthItem = (
 
 const getObjectOrRawConditions = (
   ctx: ToSQLCtx,
-  query: Pick<QueryData, 'shape' | 'joinedShapes'>,
+  query: PickQueryDataShapeAndJoinedShapes,
   data: Record<string, string | Expression> | Expression | true,
   quotedAs: string | undefined,
   joinAs: string,

--- a/packages/qb/pqb/src/sql/join.ts
+++ b/packages/qb/pqb/src/sql/join.ts
@@ -6,7 +6,12 @@ import { ToSQLCtx, ToSQLQuery } from './toSQL';
 import { JoinedShapes, QueryData, SelectQueryData } from './data';
 import { pushQueryArray } from '../query/queryUtils';
 import { QueryBase } from '../query/queryBase';
-import { Expression, isExpression, QueryColumns } from 'orchid-core';
+import {
+  Expression,
+  isExpression,
+  QueryColumns,
+  RecordUnknown,
+} from 'orchid-core';
 import { RelationJoinQuery } from '../relations';
 
 type ItemOf3Or4Length =
@@ -365,8 +370,7 @@ export const getIsJoinSubQuery = (query: QueryData, baseQuery: QueryData) => {
   for (const key in query) {
     if (
       !skipQueryKeysForSubQuery[key] &&
-      (query as Record<string, unknown>)[key] !==
-        (baseQuery as Record<string, unknown>)[key]
+      (query as RecordUnknown)[key] !== (baseQuery as RecordUnknown)[key]
     ) {
       return true;
     }

--- a/packages/qb/pqb/src/sql/toSQL.ts
+++ b/packages/qb/pqb/src/sql/toSQL.ts
@@ -42,6 +42,7 @@ type ToSqlOptionsInternal = ToSQLOptions & {
 
 export type ToSQLQuery = Pick<
   Query,
+  | '__isQuery'
   | 'q'
   | 'queryBuilder'
   | 'table'

--- a/packages/qb/pqb/src/sql/types.ts
+++ b/packages/qb/pqb/src/sql/types.ts
@@ -8,6 +8,7 @@ import {
   MaybeArray,
   TemplateLiteralArgs,
   SelectableBase,
+  RecordUnknown,
 } from 'orchid-core';
 import { QueryBase } from '../query/queryBase';
 
@@ -275,5 +276,5 @@ export type OnConflictItem = string | string[] | Expression;
 export type OnConflictMergeUpdate =
   | string
   | string[]
-  | Record<string, unknown>
+  | RecordUnknown
   | Expression;

--- a/packages/qb/pqb/src/sql/types.ts
+++ b/packages/qb/pqb/src/sql/types.ts
@@ -192,13 +192,12 @@ export type SimpleJoinItem = {
 export type JoinLateralItem = [type: string, joined: Query, as: string];
 
 export type WhereItem =
-  | (Omit<
-      Record<
-        string,
-        unknown | Record<string, unknown | Query | Expression> | Expression
-      >,
-      'NOT' | 'AND' | 'OR' | 'IN' | 'EXISTS' | 'ON' | 'ON_JSON_PATH_EQUALS'
-    > & {
+  | {
+      [K: string]:
+        | unknown
+        | Record<string, unknown | Query | Expression>
+        | Expression;
+
       NOT?: MaybeArray<WhereItem>;
       AND?: MaybeArray<WhereItem>;
       OR?: MaybeArray<WhereItem>[];
@@ -206,7 +205,7 @@ export type WhereItem =
       EXISTS?: MaybeArray<SimpleJoinItem['args']>;
       ON?: WhereOnItem | WhereJsonPathEqualsItem;
       SEARCH?: MaybeArray<WhereSearchItem>;
-    })
+    }
   | ((q: unknown) => QueryBase | RelationQuery | Expression)
   | Query
   | Expression;

--- a/packages/qb/pqb/src/sql/types.ts
+++ b/packages/qb/pqb/src/sql/types.ts
@@ -50,17 +50,17 @@ export type WithItem = [
   query: Query | Expression,
 ];
 
-export type WithOptions = {
+export interface WithOptions {
   columns?: string[];
   recursive?: true;
   materialized?: true;
   notMaterialized?: true;
-};
+}
 
-export type JsonItem<
+export interface JsonItem<
   As extends string = string,
   Type extends QueryColumn = QueryColumn,
-> = {
+> {
   __json:
     | [
         kind: 'set',
@@ -102,22 +102,26 @@ export type JsonItem<
           silent?: boolean;
         },
       ];
-};
+}
 
 export type SelectItem = string | SelectAs | JsonItem | Expression;
 
-export type SelectAs = {
-  selectAs: Record<string, string | Query | Expression>;
-};
+export interface SelectAs {
+  selectAs: SelectAsValue;
+}
 
-export type OrderTsQueryConfig =
-  | true
-  | {
-      coverDensity?: boolean;
-      weights?: number[];
-      normalization?: number;
-      dir?: SortDir;
-    };
+interface SelectAsValue {
+  [K: string]: string | Query | Expression;
+}
+
+export type OrderTsQueryConfig = true | OrderTsQueryConfigObject;
+
+interface OrderTsQueryConfigObject {
+  coverDensity?: boolean;
+  weights?: number[];
+  normalization?: number;
+  dir?: SortDir;
+}
 
 export type QuerySourceItem = {
   queryAs: string;
@@ -162,7 +166,7 @@ export type QuerySourceItem = {
 
 export type JoinItem = SimpleJoinItem | JoinLateralItem;
 
-export type SimpleJoinItem = {
+export interface SimpleJoinItem {
   type: string;
   first: string | QueryWithTable;
   args:
@@ -182,7 +186,7 @@ export type SimpleJoinItem = {
       ];
   // available only for QueryWithTable as first argument
   isSubQuery: boolean;
-};
+}
 
 export type JoinLateralItem = [type: string, joined: Query, as: string];
 
@@ -205,10 +209,10 @@ export type WhereItem =
   | Query
   | Expression;
 
-export type WhereInItem = {
+export interface WhereInItem {
   columns: string[];
   values: unknown[][] | Query | Expression;
-};
+}
 
 export type WhereJsonPathEqualsItem = [
   leftColumn: string,
@@ -217,22 +221,22 @@ export type WhereJsonPathEqualsItem = [
   rightPath: string,
 ];
 
-export type WhereOnItem = {
+export interface WhereOnItem {
   joinFrom: WhereOnJoinItem;
   joinTo: WhereOnJoinItem;
   on:
     | [leftFullColumn: string, rightFullColumn: string]
     | [leftFullColumn: string, op: string, rightFullColumn: string];
-};
+}
 
 export type WhereOnJoinItem = { table?: string; q: { as?: string } } | string;
 
 export type SearchWeight = 'A' | 'B' | 'C' | 'D';
 
-export type WhereSearchItem = {
+export interface WhereSearchItem {
   as: string;
   vectorSQL: string;
-};
+}
 
 export type SortDir = 'ASC' | 'DESC' | 'ASC NULLS FIRST' | 'DESC NULLS LAST';
 
@@ -250,10 +254,10 @@ export type HavingItem = TemplateLiteralArgs | Expression[];
 
 export type WindowItem = Record<string, WindowDeclaration | Expression>;
 
-export type WindowDeclaration = {
+export interface WindowDeclaration {
   partitionBy?: SelectableOrExpression | SelectableOrExpression[];
   order?: OrderItem;
-};
+}
 
 export type UnionItem = Query | Expression;
 

--- a/packages/qb/pqb/src/sql/types.ts
+++ b/packages/qb/pqb/src/sql/types.ts
@@ -164,23 +164,18 @@ export type JoinItem = SimpleJoinItem | JoinLateralItem;
 
 export type SimpleJoinItem = {
   type: string;
+  first: string | QueryWithTable;
   args:
-    | [relation: string]
+    | []
     | [
-        arg: string | QueryWithTable,
         conditions:
           | Record<string, string | Expression>
           | Expression
           | ((q: unknown) => QueryBase)
           | true,
       ]
+    | [leftColumn: string | Expression, rightColumn: string | Expression]
     | [
-        arg: string | QueryWithTable,
-        leftColumn: string | Expression,
-        rightColumn: string | Expression,
-      ]
-    | [
-        arg: string | QueryWithTable,
         leftColumn: string | Expression,
         op: string,
         rightColumn: string | Expression,

--- a/packages/qb/pqb/src/sql/where.ts
+++ b/packages/qb/pqb/src/sql/where.ts
@@ -25,7 +25,7 @@ import {
   RecordUnknown,
   toArray,
 } from 'orchid-core';
-import { Operator } from '../columns/operators';
+import { BaseOperators, Operator } from '../columns/operators';
 
 export const pushWhereStatementSql = (
   ctx: ToSQLCtx,
@@ -297,7 +297,7 @@ const processWhere = (
           ands.push(`${quotedColumn} = (${(value as Query).toSQL(ctx).text})`);
         } else {
           for (const op in value) {
-            const operator = column.operators[op];
+            const operator = (column.operators as BaseOperators)[op];
             if (!operator) {
               // TODO: custom error classes
               throw new Error(`Unknown operator ${op} provided to condition`);

--- a/packages/qb/pqb/src/sql/where.ts
+++ b/packages/qb/pqb/src/sql/where.ts
@@ -17,7 +17,11 @@ import {
 import { getClonedQueryData, getQueryAs } from '../common/utils';
 import { processJoinItem } from './join';
 import { makeSQL, ToSQLCtx, ToSQLQuery } from './toSQL';
-import { JoinedShapes, QueryData } from './data';
+import {
+  JoinedShapes,
+  PickQueryDataShapeAndJoinedShapes,
+  QueryData,
+} from './data';
 import {
   Expression,
   isExpression,
@@ -332,7 +336,7 @@ const getJoinItemSource = (joinItem: WhereOnJoinItem) => {
 
 const pushIn = (
   ctx: ToSQLCtx,
-  query: Pick<QueryData, 'shape' | 'joinedShapes'>,
+  query: PickQueryDataShapeAndJoinedShapes,
   ands: string[],
   quotedAs: string | undefined,
   arg: {

--- a/packages/qb/pqb/src/sql/where.ts
+++ b/packages/qb/pqb/src/sql/where.ts
@@ -18,7 +18,13 @@ import { getClonedQueryData, getQueryAs } from '../common/utils';
 import { processJoinItem } from './join';
 import { makeSQL, ToSQLCtx, ToSQLQuery } from './toSQL';
 import { JoinedShapes, QueryData } from './data';
-import { Expression, isExpression, MaybeArray, toArray } from 'orchid-core';
+import {
+  Expression,
+  isExpression,
+  MaybeArray,
+  RecordUnknown,
+  toArray,
+} from 'orchid-core';
 import { Operator } from '../columns/operators';
 
 export const pushWhereStatementSql = (
@@ -136,7 +142,7 @@ const processWhere = (
   }
 
   for (const key in data) {
-    const value = (data as Record<string, unknown>)[key];
+    const value = (data as RecordUnknown)[key];
     if (value === undefined) continue;
 
     if (key === 'AND') {

--- a/packages/qb/pqb/src/sql/where.ts
+++ b/packages/qb/pqb/src/sql/where.ts
@@ -233,7 +233,11 @@ const processWhere = (
     } else if (key === 'EXISTS') {
       const joinItems = (
         Array.isArray((value as unknown[])[0]) ? value : [value]
-      ) as { args: SimpleJoinItem['args']; isSubQuery: boolean }[];
+      ) as {
+        first: SimpleJoinItem['first'];
+        args: SimpleJoinItem['args'];
+        isSubQuery: boolean;
+      }[];
 
       for (const args of joinItems) {
         const { target, conditions } = processJoinItem(

--- a/packages/qb/pqb/src/test-utils/test-utils.ts
+++ b/packages/qb/pqb/src/test-utils/test-utils.ts
@@ -1,11 +1,23 @@
 import { Query } from '../query/query';
 import { quote } from '../quote';
-import { expectSql, testDb, testDbDefaultTypes } from 'test-utils';
+import { expectSql, testDb, testDbZodTypes } from 'test-utils';
 import { z } from 'zod';
+import { RecordUnknown } from 'orchid-core';
 
 export type UserRecord = typeof User.outputType;
 export type UserInsert = typeof User.inputType;
 export const User = testDb('user', (t) => ({
+  id: t.identity().primaryKey(),
+  name: t.text(),
+  password: t.text(),
+  picture: t.text().nullable(),
+  data: t.json<{ name: string; tags: string[] }>().nullable(),
+  age: t.integer().nullable(),
+  active: t.boolean().nullable(),
+  ...t.timestamps(),
+}));
+
+export const UserZodTypes = testDbZodTypes('user', (t) => ({
   id: t.identity().primaryKey(),
   name: t.text(),
   password: t.text(),
@@ -18,17 +30,6 @@ export const User = testDb('user', (t) => ({
       }),
     )
     .nullable(),
-  age: t.integer().nullable(),
-  active: t.boolean().nullable(),
-  ...t.timestamps(),
-}));
-
-export const UserDefaultTypes = testDbDefaultTypes('user', (t) => ({
-  id: t.identity().primaryKey(),
-  name: t.text(0, Infinity),
-  password: t.text(0, Infinity),
-  picture: t.text(0, Infinity).nullable(),
-  data: t.json<{ name: string; tags: string[] }>().nullable(),
   age: t.integer().nullable(),
   active: t.boolean().nullable(),
   ...t.timestamps(),
@@ -115,9 +116,7 @@ export const expectQueryNotMutated = (q: Query) => {
   expectSql(q.toSQL(), `SELECT * FROM "${q.table}"`);
 };
 
-export const insert = async <
-  T extends Record<string, unknown> & { id: number },
->(
+export const insert = async <T extends RecordUnknown & { id: number }>(
   table: string,
   record: T,
 ): Promise<T> => {

--- a/packages/qb/pqb/src/testTransaction.ts
+++ b/packages/qb/pqb/src/testTransaction.ts
@@ -9,7 +9,7 @@ class Rollback extends Error {}
 const trxForTest: unique symbol = Symbol('trxForTest');
 
 // The state of `testTransaction` that will be stored in the `db.internal`.
-type TrxData = {
+interface TrxData {
   // promise of the full transaction lifecycle, from start to rollback.
   promise?: Promise<void>;
   // reject function of the transaction.
@@ -22,12 +22,12 @@ type TrxData = {
     arrays: unknown;
     transaction: unknown;
   };
-};
+}
 
 // Type to store transaction data on `db.internal`.
-type Internal = {
+interface Internal {
   [trxForTest]?: TrxData[];
-};
+}
 
 // Argument of the transaction, $queryBuilder is to use ORM instance, Query to use any other queryable instance.
 type Arg = { $queryBuilder: Query } | Query;

--- a/packages/rake-db/src/ast.ts
+++ b/packages/rake-db/src/ast.ts
@@ -22,7 +22,7 @@ export type RakeDbAst =
   | RakeDbAst.View;
 
 export namespace RakeDbAst {
-  export type Table = {
+  export interface Table extends TableData {
     type: 'table';
     action: 'create' | 'drop';
     schema?: string;
@@ -33,9 +33,9 @@ export namespace RakeDbAst {
     dropIfExists?: boolean;
     dropMode?: DropMode;
     comment?: string;
-  } & TableData;
+  }
 
-  export type ChangeTable = {
+  export interface ChangeTable {
     type: 'changeTable';
     schema?: string;
     name: string;
@@ -43,7 +43,7 @@ export namespace RakeDbAst {
     shape: Record<string, ChangeTableItem>;
     add: TableData;
     drop: TableData;
-  };
+  }
 
   export type ChangeTableItem =
     | ChangeTableItem.Column
@@ -51,27 +51,27 @@ export namespace RakeDbAst {
     | ChangeTableItem.Rename;
 
   export namespace ChangeTableItem {
-    export type Column = {
+    export interface Column {
       type: 'add' | 'drop';
       item: ColumnType;
       dropMode?: DropMode;
-    };
+    }
 
-    export type Change = {
+    export interface Change {
       type: 'change';
       name?: string;
       from: ColumnChange;
       to: ColumnChange;
       using?: RawSQLBase;
-    };
+    }
 
-    export type Rename = {
+    export interface Rename {
       type: 'rename';
       name: string;
-    };
+    }
   }
 
-  export type ColumnChange = {
+  export interface ColumnChange {
     column?: ColumnType;
     type?: string;
     collate?: string;
@@ -87,23 +87,23 @@ export namespace RakeDbAst {
     } & ForeignKeyOptions)[];
     indexes?: Omit<SingleColumnIndexOptions, 'column' | 'expression'>[];
     identity?: TableData.Identity;
-  };
+  }
 
-  export type RenameTable = {
+  export interface RenameTable {
     type: 'renameTable';
     fromSchema?: string;
     from: string;
     toSchema?: string;
     to: string;
-  };
+  }
 
-  export type Schema = {
+  export interface Schema {
     type: 'schema';
     action: 'create' | 'drop';
     name: string;
-  };
+  }
 
-  export type Extension = {
+  export interface Extension {
     type: 'extension';
     action: 'create' | 'drop';
     name: string;
@@ -112,9 +112,9 @@ export namespace RakeDbAst {
     cascade?: boolean;
     createIfNotExists?: boolean;
     dropIfExists?: boolean;
-  };
+  }
 
-  export type Enum = {
+  export interface Enum {
     type: 'enum';
     action: 'create' | 'drop';
     schema?: string;
@@ -122,9 +122,9 @@ export namespace RakeDbAst {
     values: [string, ...string[]];
     cascade?: boolean;
     dropIfExists?: boolean;
-  };
+  }
 
-  export type Domain = {
+  export interface Domain {
     type: 'domain';
     action: 'create' | 'drop';
     schema?: string;
@@ -135,10 +135,10 @@ export namespace RakeDbAst {
     default?: RawSQLBase;
     check?: RawSQLBase;
     cascade?: boolean;
-  };
+  }
 
   // Database collation.
-  export type Collation = {
+  export interface Collation {
     // Type of RakeDb.AST for the collation.
     type: 'collation';
     // Create or drop the collation.
@@ -174,21 +174,21 @@ export namespace RakeDbAst {
     dropIfExists?: boolean;
     // Add CASCADE when dropping a collation.
     cascade?: boolean;
-  };
+  }
 
-  export type EnumOptions = {
+  export interface EnumOptions {
     createIfNotExists?: boolean;
     dropIfExists?: boolean;
-  };
+  }
 
-  export type Constraint = {
+  export interface Constraint extends TableData.Constraint {
     type: 'constraint';
     action: 'create';
     tableSchema?: string;
     tableName: string;
-  } & TableData.Constraint;
+  }
 
-  export type View = {
+  export interface View {
     type: 'view';
     action: 'create' | 'drop';
     schema?: string;
@@ -196,9 +196,9 @@ export namespace RakeDbAst {
     shape: ColumnsShape;
     sql: RawSQLBase;
     options: ViewOptions;
-  };
+  }
 
-  export type ViewOptions = {
+  export interface ViewOptions {
     createOrReplace?: boolean;
     dropIfExists?: boolean;
     dropMode?: DropMode;
@@ -210,5 +210,5 @@ export namespace RakeDbAst {
       securityBarrier?: boolean;
       securityInvoker?: boolean;
     };
-  };
+  }
 }

--- a/packages/rake-db/src/commands/createOrDrop.test.ts
+++ b/packages/rake-db/src/commands/createOrDrop.test.ts
@@ -7,10 +7,11 @@ import {
 import { migrate } from './migrateOrRollback';
 import { testConfig } from '../rake-db.test-utils';
 import { asMock } from 'test-utils';
+import { RecordUnknown } from 'orchid-core';
 
 jest.mock('../common', () => ({
   ...jest.requireActual('../common'),
-  setAdminCredentialsToOptions: jest.fn((options: Record<string, unknown>) => ({
+  setAdminCredentialsToOptions: jest.fn((options: RecordUnknown) => ({
     ...options,
     user: 'admin-user',
     password: 'admin-password',

--- a/packages/rake-db/src/commands/createOrDrop.ts
+++ b/packages/rake-db/src/commands/createOrDrop.ts
@@ -1,5 +1,10 @@
 import { Adapter, AdapterOptions } from 'pqb';
-import { ColumnSchemaConfig, MaybeArray, toArray } from 'orchid-core';
+import {
+  ColumnSchemaConfig,
+  MaybeArray,
+  RecordUnknown,
+  toArray,
+} from 'orchid-core';
 import {
   getDatabaseAndUserFromOptions,
   setAdminCredentialsToOptions,
@@ -22,7 +27,7 @@ const execute = async (
     await db.query(sql);
     return 'ok';
   } catch (error) {
-    const err = error as Record<string, unknown>;
+    const err = error as RecordUnknown;
 
     if (
       typeof err.message === 'string' &&

--- a/packages/rake-db/src/migration/changeTable.ts
+++ b/packages/rake-db/src/migration/changeTable.ts
@@ -50,7 +50,11 @@ import {
 import { tableMethods } from './tableMethods';
 import { TableQuery } from './createTable';
 
-type ChangeTableData = { add: TableData; drop: TableData };
+interface ChangeTableData {
+  add: TableData;
+  drop: TableData;
+}
+
 const newChangeTableData = (): ChangeTableData => ({
   add: {},
   drop: {},
@@ -358,11 +362,11 @@ const makeAst = (
   };
 };
 
-type PrimaryKeys = {
+interface PrimaryKeys {
   columns: string[];
   change?: true;
   options?: { name?: string };
-};
+}
 
 const astToQueries = (
   ast: RakeDbAst.ChangeTable,

--- a/packages/rake-db/src/migration/createTable.ts
+++ b/packages/rake-db/src/migration/createTable.ts
@@ -37,18 +37,18 @@ import { tableMethods } from './tableMethods';
 import { NoPrimaryKey } from '../errors';
 import { emptyObject, snakeCaseKey } from 'orchid-core';
 
-export type TableQuery = {
+export interface TableQuery {
   text: string;
   values?: unknown[];
   then?(result: QueryArraysResult): void;
-};
+}
 
-export type CreateTableResult<
+export interface CreateTableResult<
   Table extends string,
   Shape extends ColumnsShape,
-> = {
+> {
   table: Db<Table, Shape>;
-};
+}
 
 export const createTable = async <
   CT extends RakeDbColumnTypes,

--- a/packages/rake-db/src/migration/manageMigratedVersions.ts
+++ b/packages/rake-db/src/migration/manageMigratedVersions.ts
@@ -5,7 +5,7 @@ import {
   RakeDbConfig,
 } from '../common';
 import { SilentQueries } from './migration';
-import { ColumnSchemaConfig } from 'orchid-core';
+import { ColumnSchemaConfig, RecordUnknown } from 'orchid-core';
 
 export const saveMigratedVersion = async <
   SchemaConfig extends ColumnSchemaConfig,
@@ -50,7 +50,7 @@ export const getMigratedVersionsMap = async <
     );
     return Object.fromEntries(result.rows.map((row) => [row[0], true]));
   } catch (err) {
-    if ((err as Record<string, unknown>).code === '42P01') {
+    if ((err as RecordUnknown).code === '42P01') {
       await createSchemaMigrations(db, config);
       return {};
     }

--- a/packages/rake-db/src/migration/migration.ts
+++ b/packages/rake-db/src/migration/migration.ts
@@ -21,6 +21,7 @@ import {
   MaybeArray,
   QueryInput,
   RawSQLBase,
+  RecordUnknown,
   singleQuote,
   Sql,
 } from 'orchid-core';
@@ -145,8 +146,7 @@ export const createMigrationInterface = <
 
   const { prototype: proto } = Migration;
   for (const key of Object.getOwnPropertyNames(proto)) {
-    (db as unknown as Record<string, unknown>)[key] =
-      proto[key as keyof typeof proto];
+    (db as unknown as RecordUnknown)[key] = proto[key as keyof typeof proto];
   }
 
   db.migratedAsts = asts;

--- a/packages/rake-db/src/pull/dbStructure.ts
+++ b/packages/rake-db/src/pull/dbStructure.ts
@@ -1,23 +1,23 @@
 import { Adapter } from 'pqb';
 
 export namespace DbStructure {
-  export type Table = {
+  export interface Table {
     schemaName: string;
     name: string;
     comment?: string;
     columns: Column[];
-  };
+  }
 
-  export type View = {
+  export interface View {
     schemaName: string;
     name: string;
     isRecursive: boolean;
     with?: string[]; // ['check_option=LOCAL', 'security_barrier=true']
     columns: Column[];
     sql: string;
-  };
+  }
 
-  export type Procedure = {
+  export interface Procedure {
     schemaName: string;
     name: string;
     returnSet: boolean;
@@ -28,9 +28,9 @@ export namespace DbStructure {
     argTypes: string[];
     argModes: ('i' | 'o')[];
     argNames?: string[];
-  };
+  }
 
-  export type Column = {
+  export interface Column {
     schemaName: string;
     tableName: string;
     name: string;
@@ -55,9 +55,9 @@ export namespace DbStructure {
       cache?: number;
       cycle?: boolean;
     };
-  };
+  }
 
-  export type Index = {
+  export interface Index {
     schemaName: string;
     tableName: string;
     name: string;
@@ -73,21 +73,21 @@ export namespace DbStructure {
     with?: string;
     tablespace?: string;
     where?: string;
-  };
+  }
 
   // a = no action, r = restrict, c = cascade, n = set null, d = set default
   type ForeignKeyAction = 'a' | 'r' | 'c' | 'n' | 'd';
 
-  export type Constraint = {
+  export interface Constraint {
     schemaName: string;
     tableName: string;
     name: string;
     primaryKey?: string[];
     references?: References;
     check?: Check;
-  };
+  }
 
-  export type References = {
+  export interface References {
     foreignSchema: string;
     foreignTable: string;
     columns: string[];
@@ -95,14 +95,14 @@ export namespace DbStructure {
     match: 'f' | 'p' | 's'; // FULL | PARTIAL | SIMPLE
     onUpdate: ForeignKeyAction;
     onDelete: ForeignKeyAction;
-  };
+  }
 
-  export type Check = {
+  export interface Check {
     columns?: string[];
     expression: string;
-  };
+  }
 
-  export type Trigger = {
+  export interface Trigger {
     schemaName: string;
     tableName: string;
     triggerSchema: string;
@@ -111,21 +111,21 @@ export namespace DbStructure {
     activation: string;
     condition?: string;
     definition: string;
-  };
+  }
 
-  export type Extension = {
+  export interface Extension {
     schemaName: string;
     name: string;
     version?: string;
-  };
+  }
 
-  export type Enum = {
+  export interface Enum {
     schemaName: string;
     name: string;
     values: [string, ...string[]];
-  };
+  }
 
-  export type Domain = {
+  export interface Domain {
     schemaName: string;
     name: string;
     type: string;
@@ -139,9 +139,9 @@ export namespace DbStructure {
     collation?: string;
     default?: string;
     check?: string;
-  };
+  }
 
-  export type Collation = {
+  export interface Collation {
     schema: string;
     name: string;
     provider: string;
@@ -150,7 +150,7 @@ export namespace DbStructure {
     lcCType?: string;
     locale?: string;
     version?: string;
-  };
+  }
 }
 
 const filterSchema = (table: string) =>

--- a/packages/rake-db/src/pull/structureToAst.ts
+++ b/packages/rake-db/src/pull/structureToAst.ts
@@ -305,7 +305,7 @@ const getColumn = (
   const columnType = getColumnType(type, isSerial);
   const typeFn = ctx.columnsByType[columnType];
   if (typeFn) {
-    column = instantiateColumn(typeFn, params);
+    column = instantiateColumn(typeFn, params) as ColumnType;
   } else {
     const domainColumn = domains[`${typeSchema}.${type}`];
     if (domainColumn) {

--- a/packages/schema-to-zod/src/main.test.ts
+++ b/packages/schema-to-zod/src/main.test.ts
@@ -275,6 +275,7 @@ describe('zod schema config', () => {
   const char = t.char();
   const text = t.text(0, Infinity);
   const string = t.string();
+
   assertAllTypes<
     | typeof numeric
     | typeof decimal

--- a/packages/schema-to-zod/src/main.ts
+++ b/packages/schema-to-zod/src/main.ts
@@ -13,17 +13,36 @@ import {
   StringTypeData,
   ErrorMessages,
   setColumnData,
+  ColumnDataBase,
 } from 'orchid-core';
 import {
   ArrayColumn,
   ArrayColumnValue,
+  BigIntColumn,
+  BigSerialColumn,
+  CharColumn,
+  CitextColumn,
   columnCode,
   ColumnData,
   ColumnType,
   DateBaseColumn,
+  DateColumn,
+  DecimalColumn,
+  DoublePrecisionColumn,
   EnumColumn,
+  IntegerColumn,
+  MoneyColumn,
   Operators,
   OperatorsJson,
+  RealColumn,
+  SerialColumn,
+  SmallIntColumn,
+  SmallSerialColumn,
+  StringColumn,
+  TextColumn,
+  TimestampColumn,
+  TimestampTZColumn,
+  VarCharColumn,
 } from 'pqb';
 import {
   z,
@@ -91,7 +110,7 @@ type NumberMethodSchema<Key extends string> = {
 function applyMethod<
   Key extends string,
   T extends {
-    data: object;
+    data: ColumnDataBase;
     inputSchema: NumberMethodSchema<Key>;
     outputSchema: NumberMethodSchema<Key>;
     querySchema: NumberMethodSchema<Key>;
@@ -111,7 +130,7 @@ type NumberMethodSimpleSchema<Key extends string> = {
 function applySimpleMethod<
   Key extends string,
   T extends {
-    data: object;
+    data: ColumnDataBase;
     inputSchema: NumberMethodSimpleSchema<Key>;
     outputSchema: NumberMethodSimpleSchema<Key>;
     querySchema: NumberMethodSimpleSchema<Key>;
@@ -124,7 +143,7 @@ function applySimpleMethod<
   return cloned;
 }
 
-type ArrayMethods<Value> = {
+interface ArrayMethods<Value> {
   // Require a minimum length (inclusive)
   min<T extends ColumnTypeBase>(
     this: T,
@@ -148,7 +167,7 @@ type ArrayMethods<Value> = {
 
   // Require a value to be non-empty
   nonEmpty<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-};
+}
 
 const arrayMethods: ArrayMethods<Date> = {
   min(value, params) {
@@ -193,6 +212,396 @@ class ZodArrayColumn<Item extends ArrayColumnValue> extends ArrayColumn<
 
 Object.assign(ZodArrayColumn.prototype, arrayMethods);
 
+interface NumberMethods {
+  lt<T extends ColumnTypeBase>(
+    this: T,
+    value: number,
+    params?: ErrorMessage,
+  ): T;
+  lte<T extends ColumnTypeBase>(
+    this: T,
+    value: number,
+    params?: ErrorMessage,
+  ): T;
+  max<T extends ColumnTypeBase>(
+    this: T,
+    value: number,
+    params?: ErrorMessage,
+  ): T;
+  gt<T extends ColumnTypeBase>(
+    this: T,
+    value: number,
+    params?: ErrorMessage,
+  ): T;
+  gte<T extends ColumnTypeBase>(
+    this: T,
+    value: number,
+    params?: ErrorMessage,
+  ): T;
+  min<T extends ColumnTypeBase>(
+    this: T,
+    value: number,
+    params?: ErrorMessage,
+  ): T;
+  positive<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+  nonNegative<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+  negative<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+  nonPositive<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+  step<T extends ColumnTypeBase>(
+    this: T,
+    value: number,
+    params?: ErrorMessage,
+  ): T;
+  int<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+  finite<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+  safe<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+}
+
+const numberMethods: NumberMethods = {
+  // Require a value to be lower than a given number
+  lt(value, params) {
+    return applyMethod(this, 'lt', value, params);
+  },
+
+  // Require a value to be lower than or equal to a given number (the same as `max`)
+  lte(value, params) {
+    return applyMethod(this, 'lte', value, params);
+  },
+
+  // Require a value to be lower than or equal to a given number
+  max(value, params) {
+    return applyMethod(this, 'lte', value, params);
+  },
+
+  // Require a value to be greater than a given number
+  gt(value, params) {
+    return applyMethod(this, 'gt', value, params);
+  },
+
+  // Require a value to be greater than or equal to a given number (the same as `min`)
+  gte(value, params) {
+    return applyMethod(this, 'gte', value, params);
+  },
+
+  // Require a value to be greater than or equal to a given number
+  min(value, params) {
+    return applyMethod(this, 'gte', value, params);
+  },
+
+  // Require a value to be greater than 0
+  positive(params) {
+    return applyMethod(this, 'gt', 0, params);
+  },
+
+  // Require a value to be greater than or equal to 0
+  nonNegative(params) {
+    return applyMethod(this, 'gte', 0, params);
+  },
+
+  // Require a value to be lower than 0
+  negative(params) {
+    return applyMethod(this, 'lt', 0, params);
+  },
+
+  // Require a value to be lower than or equal to 0
+  nonPositive(params) {
+    return applyMethod(this, 'lte', 0, params);
+  },
+
+  // Require a value to be a multiple of a given number
+  step(value, params) {
+    return applyMethod(this, 'step', value, params);
+  },
+
+  // Require a value to be an integer
+  int(params) {
+    return applySimpleMethod(this, 'int', params);
+  },
+
+  // Exclude `Infinity` from being a valid value
+  finite(params) {
+    return applySimpleMethod(this, 'finite', params);
+  },
+
+  // Require the value to be less than or equal to Number.MAX_SAFE_INTEGER
+  safe(params) {
+    return applySimpleMethod(this, 'safe', params);
+  },
+};
+
+interface SmallIntColumnZod
+  extends SmallIntColumn<ZodSchemaConfig>,
+    NumberMethods {}
+
+class SmallIntColumnZod extends SmallIntColumn<ZodSchemaConfig> {}
+Object.assign(SmallIntColumnZod.prototype, numberMethods);
+
+interface IntegerColumnZod
+  extends IntegerColumn<ZodSchemaConfig>,
+    NumberMethods {}
+
+class IntegerColumnZod extends IntegerColumn<ZodSchemaConfig> {}
+Object.assign(IntegerColumnZod.prototype, numberMethods);
+
+interface RealColumnZod extends RealColumn<ZodSchemaConfig>, NumberMethods {}
+
+class RealColumnZod extends RealColumn<ZodSchemaConfig> {}
+Object.assign(RealColumnZod.prototype, numberMethods);
+
+interface SmallSerialColumnZod
+  extends SmallSerialColumn<ZodSchemaConfig>,
+    NumberMethods {}
+
+class SmallSerialColumnZod extends SmallSerialColumn<ZodSchemaConfig> {}
+Object.assign(SmallSerialColumnZod.prototype, numberMethods);
+
+interface SerialColumnZod
+  extends SerialColumn<ZodSchemaConfig>,
+    NumberMethods {}
+
+class SerialColumnZod extends SerialColumn<ZodSchemaConfig> {}
+Object.assign(SerialColumnZod.prototype, numberMethods);
+
+interface StringMethods extends ArrayMethods<number> {
+  // Check a value to be a valid email
+  email<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+
+  // Check a value to be a valid url
+  url<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+
+  // Check a value to be an emoji
+  emoji<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+
+  // Check a value to be a valid uuid
+  uuid<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+
+  // Check a value to be a valid cuid
+  cuid<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+
+  // Check a value to be a valid cuid2
+  cuid2<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+
+  // Check a value to be a valid ulid
+  ulid<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+
+  // Validate the value over the given regular expression
+  regex<T extends ColumnTypeBase>(
+    this: T,
+    value: RegExp,
+    params?: ErrorMessage,
+  ): T;
+
+  // Check a value to include a given string
+  includes<T extends ColumnTypeBase, Value extends string>(
+    this: T,
+    value: Value,
+    params?: ErrorMessage,
+  ): T;
+
+  // Check a value to start with a given string
+  startsWith<T extends ColumnTypeBase, Value extends string>(
+    this: T,
+    value: Value,
+    params?: ErrorMessage,
+  ): T;
+
+  // Check a value to end with a given string
+  endsWith<T extends ColumnTypeBase, Value extends string>(
+    this: T,
+    value: Value,
+    params?: ErrorMessage,
+  ): T;
+
+  // Check a value have a valid datetime string
+  datetime<T extends ColumnTypeBase>(
+    this: T,
+    params?: StringTypeData['datetime'] & Exclude<ErrorMessage, string>,
+  ): T;
+
+  // Check a value to be a valid ip address
+  ip<T extends ColumnTypeBase>(
+    this: T,
+    params?: StringTypeData['ip'] & Exclude<ErrorMessage, string>,
+  ): T;
+
+  // Trim the value during a validation
+  trim<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+
+  // Transform value to a lower case during a validation
+  toLowerCase<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+
+  // Transform value to an upper case during a validation
+  toUpperCase<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
+}
+
+const stringMethods: StringMethods = {
+  ...(arrayMethods as unknown as ArrayMethods<number>),
+
+  email(params) {
+    return applySimpleMethod(this, 'email', params);
+  },
+
+  url(params) {
+    return applySimpleMethod(this, 'url', params);
+  },
+
+  emoji(params) {
+    return applySimpleMethod(this, 'emoji', params);
+  },
+
+  uuid(params) {
+    return applySimpleMethod(this, 'uuid', params);
+  },
+
+  cuid(params) {
+    return applySimpleMethod(this, 'cuid', params);
+  },
+
+  cuid2(params) {
+    return applySimpleMethod(this, 'cuid2', params);
+  },
+
+  ulid(params) {
+    return applySimpleMethod(this, 'ulid', params);
+  },
+
+  regex(value, params) {
+    return applyMethod(this, 'regex', value, params);
+  },
+
+  includes(value, params) {
+    return applyMethod(this, 'includes', value, params);
+  },
+
+  startsWith(value, params) {
+    return applyMethod(this, 'startsWith', value, params);
+  },
+
+  endsWith(value, params) {
+    return applyMethod(this, 'endsWith', value, params);
+  },
+
+  datetime(params = {}) {
+    return applyMethod(this, 'datetime', params, params);
+  },
+
+  ip(params = {}) {
+    return applyMethod(this, 'ip', params, params);
+  },
+
+  trim(params) {
+    return applySimpleMethod(this, 'trim', params);
+  },
+
+  toLowerCase(params) {
+    return applySimpleMethod(this, 'toLowerCase', params);
+  },
+
+  toUpperCase(params) {
+    return applySimpleMethod(this, 'toUpperCase', params);
+  },
+};
+
+interface BigIntColumnZod
+  extends BigIntColumn<ZodSchemaConfig>,
+    StringMethods {}
+
+class BigIntColumnZod extends BigIntColumn<ZodSchemaConfig> {}
+Object.assign(BigIntColumnZod.prototype, stringMethods);
+
+interface DecimalColumnZod
+  extends DecimalColumn<ZodSchemaConfig>,
+    StringMethods {}
+
+class DecimalColumnZod extends DecimalColumn<ZodSchemaConfig> {}
+Object.assign(DecimalColumnZod.prototype, stringMethods);
+
+interface DoublePrecisionColumnZod
+  extends DoublePrecisionColumn<ZodSchemaConfig>,
+    StringMethods {}
+
+class DoublePrecisionColumnZod extends DoublePrecisionColumn<ZodSchemaConfig> {}
+Object.assign(DoublePrecisionColumnZod.prototype, stringMethods);
+
+interface BigSerialColumnZod
+  extends BigSerialColumn<ZodSchemaConfig>,
+    StringMethods {}
+
+class BigSerialColumnZod extends BigSerialColumn<ZodSchemaConfig> {}
+Object.assign(BigSerialColumnZod.prototype, stringMethods);
+
+interface MoneyColumnZod extends MoneyColumn<ZodSchemaConfig>, StringMethods {}
+
+class MoneyColumnZod extends MoneyColumn<ZodSchemaConfig> {}
+Object.assign(MoneyColumnZod.prototype, stringMethods);
+
+interface VarCharColumnZod
+  extends VarCharColumn<ZodSchemaConfig>,
+    StringMethods {}
+
+class VarCharColumnZod extends VarCharColumn<ZodSchemaConfig> {}
+Object.assign(VarCharColumnZod.prototype, stringMethods);
+
+interface CharColumnZod extends CharColumn<ZodSchemaConfig>, StringMethods {}
+
+class CharColumnZod extends CharColumn<ZodSchemaConfig> {}
+Object.assign(CharColumnZod.prototype, stringMethods);
+
+interface TextColumnZod extends TextColumn<ZodSchemaConfig>, StringMethods {}
+
+class TextColumnZod extends TextColumn<ZodSchemaConfig> {}
+Object.assign(TextColumnZod.prototype, stringMethods);
+
+interface StringColumnZod
+  extends StringColumn<ZodSchemaConfig>,
+    StringMethods {}
+
+class StringColumnZod extends StringColumn<ZodSchemaConfig> {}
+Object.assign(StringColumnZod.prototype, stringMethods);
+
+interface CitextColumnZod
+  extends CitextColumn<ZodSchemaConfig>,
+    StringMethods {}
+
+class CitextColumnZod extends CitextColumn<ZodSchemaConfig> {}
+Object.assign(CitextColumnZod.prototype, stringMethods);
+
+interface DateMethods {
+  // Require a value to be greater than or equal to a given Date object
+  min<T extends ColumnTypeBase>(this: T, value: Date, params?: ErrorMessage): T;
+
+  // Require a value to be lower than or equal to a given Date object
+  max<T extends ColumnTypeBase>(this: T, value: Date, params?: ErrorMessage): T;
+}
+
+const dateMethods: DateMethods = {
+  min(value, params) {
+    return applyMethod(this, 'min', value, params);
+  },
+  max(value, params) {
+    return applyMethod(this, 'max', value, params);
+  },
+};
+
+interface DateColumnZod extends DateColumn<ZodSchemaConfig>, DateMethods {}
+
+class DateColumnZod extends DateColumn<ZodSchemaConfig> {}
+Object.assign(DateColumnZod.prototype, dateMethods);
+
+interface TimestampNoTzColumnZod
+  extends TimestampColumn<ZodSchemaConfig>,
+    DateMethods {}
+
+class TimestampNoTzColumnZod extends TimestampColumn<ZodSchemaConfig> {}
+Object.assign(TimestampNoTzColumnZod.prototype, dateMethods);
+
+interface TimestampColumnZod
+  extends TimestampTZColumn<ZodSchemaConfig>,
+    DateMethods {}
+
+class TimestampColumnZod extends TimestampTZColumn<ZodSchemaConfig> {}
+Object.assign(TimestampColumnZod.prototype, dateMethods);
+
 export type ZodSchemaConfig = {
   type: ZodTypeAny;
 
@@ -226,56 +635,39 @@ export type ZodSchemaConfig = {
   >(
     this: T,
     types: Types,
-  ): Omit<
-    T,
-    | 'type'
-    | 'inputType'
-    | 'inputSchema'
-    | 'outputType'
-    | 'outputSchema'
-    | 'queryType'
-    | 'querySchema'
-  > & {
-    type: Type;
-    inputType: Types['input'] extends ZodTypeAny
-      ? Types['input']['_output']
-      : Type;
-    inputSchema: Types['input'] extends ZodTypeAny
-      ? Types['input']
-      : TypeSchema;
-    outputType: Types['output'] extends ZodTypeAny
-      ? Types['output']['_output']
-      : Type;
-    outputSchema: Types['output'] extends ZodTypeAny
-      ? Types['output']
-      : TypeSchema;
-    queryType: Types['query'] extends ZodTypeAny
-      ? Types['query']['_output']
-      : Type;
-    querySchema: Types['query'] extends ZodTypeAny
-      ? Types['query']
-      : TypeSchema;
+  ): {
+    [K in keyof T]: K extends 'type'
+      ? Type
+      : K extends 'inputType'
+      ? Types['input'] extends ZodTypeAny
+        ? Types['input']['_output']
+        : Type
+      : K extends 'inputSchema'
+      ? Types['input'] extends ZodTypeAny
+        ? Types['input']
+        : TypeSchema
+      : K extends 'outputType'
+      ? Types['output'] extends ZodTypeAny
+        ? Types['output']['_output']
+        : Type
+      : K extends 'outputSchema'
+      ? Types['output'] extends ZodTypeAny
+        ? Types['output']
+        : TypeSchema
+      : K extends 'queryType'
+      ? Types['query'] extends ZodTypeAny
+        ? Types['query']['_output']
+        : Type
+      : K extends 'querySchema'
+      ? Types['query'] extends ZodTypeAny
+        ? Types['query']
+        : TypeSchema
+      : T[K];
   };
 
   dateAsNumber(): ParseDateToNumber;
 
   dateAsDate(): ParseDateToDate;
-
-  dateMethods: {
-    // Require a value to be greater than or equal to a given Date object
-    min<T extends ColumnTypeBase>(
-      this: T,
-      value: Date,
-      params?: ErrorMessage,
-    ): T;
-
-    // Require a value to be lower than or equal to a given Date object
-    max<T extends ColumnTypeBase>(
-      this: T,
-      value: Date,
-      params?: ErrorMessage,
-    ): T;
-  };
 
   enum<U extends string, T extends [U, ...U[]]>(
     dataType: string,
@@ -301,126 +693,11 @@ export type ZodSchemaConfig = {
   buffer: ZodType<Buffer>;
   unknown: ZodUnknown;
   never: ZodNever;
-  string: ZodString;
+  stringSchema: ZodString;
   stringMin(max: number): ZodString;
   stringMax(max: number): ZodString;
   stringMinMax(min: number, max: number): ZodString;
-  stringMethods: ArrayMethods<number> & {
-    // Check a value to be a valid email
-    email<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-
-    // Check a value to be a valid url
-    url<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-
-    // Check a value to be an emoji
-    emoji<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-
-    // Check a value to be a valid uuid
-    uuid<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-
-    // Check a value to be a valid cuid
-    cuid<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-
-    // Check a value to be a valid cuid2
-    cuid2<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-
-    // Check a value to be a valid ulid
-    ulid<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-
-    // Validate the value over the given regular expression
-    regex<T extends ColumnTypeBase>(
-      this: T,
-      value: RegExp,
-      params?: ErrorMessage,
-    ): T;
-
-    // Check a value to include a given string
-    includes<T extends ColumnTypeBase, Value extends string>(
-      this: T,
-      value: Value,
-      params?: ErrorMessage,
-    ): T;
-
-    // Check a value to start with a given string
-    startsWith<T extends ColumnTypeBase, Value extends string>(
-      this: T,
-      value: Value,
-      params?: ErrorMessage,
-    ): T;
-
-    // Check a value to end with a given string
-    endsWith<T extends ColumnTypeBase, Value extends string>(
-      this: T,
-      value: Value,
-      params?: ErrorMessage,
-    ): T;
-
-    // Check a value have a valid datetime string
-    datetime<T extends ColumnTypeBase>(
-      this: T,
-      params?: StringTypeData['datetime'] & Exclude<ErrorMessage, string>,
-    ): T;
-
-    // Check a value to be a valid ip address
-    ip<T extends ColumnTypeBase>(
-      this: T,
-      params?: StringTypeData['ip'] & Exclude<ErrorMessage, string>,
-    ): T;
-
-    // Trim the value during a validation
-    trim<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-
-    // Transform value to a lower case during a validation
-    toLowerCase<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-
-    // Transform value to an upper case during a validation
-    toUpperCase<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-  };
   number: ZodNumber;
-  numberMethods: {
-    lt<T extends ColumnTypeBase>(
-      this: T,
-      value: number,
-      params?: ErrorMessage,
-    ): T;
-    lte<T extends ColumnTypeBase>(
-      this: T,
-      value: number,
-      params?: ErrorMessage,
-    ): T;
-    max<T extends ColumnTypeBase>(
-      this: T,
-      value: number,
-      params?: ErrorMessage,
-    ): T;
-    gt<T extends ColumnTypeBase>(
-      this: T,
-      value: number,
-      params?: ErrorMessage,
-    ): T;
-    gte<T extends ColumnTypeBase>(
-      this: T,
-      value: number,
-      params?: ErrorMessage,
-    ): T;
-    min<T extends ColumnTypeBase>(
-      this: T,
-      value: number,
-      params?: ErrorMessage,
-    ): T;
-    positive<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-    nonNegative<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-    negative<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-    nonPositive<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-    step<T extends ColumnTypeBase>(
-      this: T,
-      value: number,
-      params?: ErrorMessage,
-    ): T;
-    int<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-    finite<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-    safe<T extends ColumnTypeBase>(this: T, params?: ErrorMessage): T;
-  };
   int: ZodNumber;
   stringNumberDate: ZodDate;
   timeInterval: ZodObject<{
@@ -453,6 +730,27 @@ export type ZodSchemaConfig = {
   pkeySchema<T extends ColumnSchemaGetterTableClass>(this: T): PkeySchema<T>;
 
   errors<T extends ColumnTypeBase>(this: T, errors: ErrorMessages): T;
+
+  smallint(): SmallIntColumnZod;
+  integer(): IntegerColumnZod;
+  real(): RealColumnZod;
+  smallSerial(): SmallSerialColumnZod;
+  serial(): SerialColumnZod;
+
+  bigint(): BigIntColumnZod;
+  decimal(precision?: number, scale?: number): DecimalColumnZod;
+  doublePrecision(): DoublePrecisionColumnZod;
+  bigSerial(): BigSerialColumnZod;
+  money(): MoneyColumnZod;
+  varchar(limit?: number): VarCharColumnZod;
+  char(limit?: number): CharColumnZod;
+  text(min: number, max: number): TextColumnZod;
+  string(limit?: number): StringColumnZod;
+  citext(min: number, max: number): CitextColumnZod;
+
+  date(): DateColumnZod;
+  timestampNoTZ(precision?: number): TimestampNoTzColumnZod;
+  timestamp(precision?: number): TimestampColumnZod;
 };
 
 // parse a date string to number, with respect to null
@@ -493,14 +791,6 @@ export const zodSchemaConfig: ZodSchemaConfig = {
       parseDateToDate,
     ) as unknown as ParseDateToDate;
   },
-  dateMethods: {
-    min(value, params) {
-      return applyMethod(this, 'min', value, params);
-    },
-    max(value, params) {
-      return applyMethod(this, 'max', value, params);
-    },
-  },
   enum(dataType, type) {
     return new EnumColumn(zodSchemaConfig, dataType, type, z.enum(type));
   },
@@ -522,7 +812,7 @@ export const zodSchemaConfig: ZodSchemaConfig = {
   buffer: z.instanceof(Buffer),
   unknown: z.unknown(),
   never: z.never(),
-  string: z.string(),
+  stringSchema: z.string(),
   stringMin(min) {
     return z.string().min(min);
   },
@@ -532,146 +822,8 @@ export const zodSchemaConfig: ZodSchemaConfig = {
   stringMinMax(min, max) {
     return z.string().min(min).max(max);
   },
-  stringMethods: {
-    ...(arrayMethods as unknown as ArrayMethods<number>),
-
-    email(params) {
-      return applySimpleMethod(this, 'email', params);
-    },
-
-    url(params) {
-      return applySimpleMethod(this, 'url', params);
-    },
-
-    emoji(params) {
-      return applySimpleMethod(this, 'emoji', params);
-    },
-
-    uuid(params) {
-      return applySimpleMethod(this, 'uuid', params);
-    },
-
-    cuid(params) {
-      return applySimpleMethod(this, 'cuid', params);
-    },
-
-    cuid2(params) {
-      return applySimpleMethod(this, 'cuid2', params);
-    },
-
-    ulid(params) {
-      return applySimpleMethod(this, 'ulid', params);
-    },
-
-    regex(value, params) {
-      return applyMethod(this, 'regex', value, params);
-    },
-
-    includes(value, params) {
-      return applyMethod(this, 'includes', value, params);
-    },
-
-    startsWith(value, params) {
-      return applyMethod(this, 'startsWith', value, params);
-    },
-
-    endsWith(value, params) {
-      return applyMethod(this, 'endsWith', value, params);
-    },
-
-    datetime(params = {}) {
-      return applyMethod(this, 'datetime', params, params);
-    },
-
-    ip(params = {}) {
-      return applyMethod(this, 'ip', params, params);
-    },
-
-    trim(params) {
-      return applySimpleMethod(this, 'trim', params);
-    },
-
-    toLowerCase(params) {
-      return applySimpleMethod(this, 'toLowerCase', params);
-    },
-
-    toUpperCase(params) {
-      return applySimpleMethod(this, 'toUpperCase', params);
-    },
-  },
   number: z.number(),
   int: z.number().int(),
-  numberMethods: {
-    // Require a value to be lower than a given number
-    lt(value, params) {
-      return applyMethod(this, 'lt', value, params);
-    },
-
-    // Require a value to be lower than or equal to a given number (the same as `max`)
-    lte(value, params) {
-      return applyMethod(this, 'lte', value, params);
-    },
-
-    // Require a value to be lower than or equal to a given number
-    max(value, params) {
-      return applyMethod(this, 'lte', value, params);
-    },
-
-    // Require a value to be greater than a given number
-    gt(value, params) {
-      return applyMethod(this, 'gt', value, params);
-    },
-
-    // Require a value to be greater than or equal to a given number (the same as `min`)
-    gte(value, params) {
-      return applyMethod(this, 'gte', value, params);
-    },
-
-    // Require a value to be greater than or equal to a given number
-    min(value, params) {
-      return applyMethod(this, 'gte', value, params);
-    },
-
-    // Require a value to be greater than 0
-    positive(params) {
-      return applyMethod(this, 'gt', 0, params);
-    },
-
-    // Require a value to be greater than or equal to 0
-    nonNegative(params) {
-      return applyMethod(this, 'gte', 0, params);
-    },
-
-    // Require a value to be lower than 0
-    negative(params) {
-      return applyMethod(this, 'lt', 0, params);
-    },
-
-    // Require a value to be lower than or equal to 0
-    nonPositive(params) {
-      return applyMethod(this, 'lte', 0, params);
-    },
-
-    // Require a value to be a multiple of a given number
-    step(value, params) {
-      return applyMethod(this, 'step', value, params);
-    },
-
-    // Require a value to be an integer
-    int(params) {
-      return applySimpleMethod(this, 'int', params);
-    },
-
-    // Exclude `Infinity` from being a valid value
-    finite(params) {
-      return applySimpleMethod(this, 'finite', params);
-    },
-
-    // Require the value to be less than or equal to Number.MAX_SAFE_INTEGER
-    safe(params) {
-      return applySimpleMethod(this, 'safe', params);
-    },
-  },
 
   stringNumberDate: z.coerce.date(),
 
@@ -805,6 +957,29 @@ export const zodSchemaConfig: ZodSchemaConfig = {
 
     return setColumnData(this, 'errors', newErrors);
   },
+
+  smallint: () => new SmallIntColumnZod(zodSchemaConfig),
+  integer: () => new IntegerColumnZod(zodSchemaConfig),
+  real: () => new RealColumnZod(zodSchemaConfig),
+  smallSerial: () => new SmallSerialColumnZod(zodSchemaConfig),
+  serial: () => new SerialColumnZod(zodSchemaConfig),
+
+  bigint: () => new BigIntColumnZod(zodSchemaConfig),
+  decimal: (precision, scale) =>
+    new DecimalColumnZod(zodSchemaConfig, precision, scale),
+  doublePrecision: () => new DoublePrecisionColumnZod(zodSchemaConfig),
+  bigSerial: () => new BigSerialColumnZod(zodSchemaConfig),
+  money: () => new MoneyColumnZod(zodSchemaConfig),
+  varchar: (limit) => new VarCharColumnZod(zodSchemaConfig, limit),
+  char: (limit) => new CharColumnZod(zodSchemaConfig, limit),
+  text: (min, max) => new TextColumnZod(zodSchemaConfig, min, max),
+  string: (limit) => new StringColumnZod(zodSchemaConfig, limit),
+  citext: (min, max) => new CitextColumnZod(zodSchemaConfig, min, max),
+
+  date: () => new DateColumnZod(zodSchemaConfig),
+  timestampNoTZ: (precision) =>
+    new TimestampNoTzColumnZod(zodSchemaConfig, precision),
+  timestamp: (precision) => new TimestampColumnZod(zodSchemaConfig, precision),
 };
 
 type MapSchema<

--- a/packages/test-utils/src/test-utils.ts
+++ b/packages/test-utils/src/test-utils.ts
@@ -3,6 +3,7 @@ import {
   makeColumnTypes,
   createDb,
   testTransaction,
+  defaultSchemaConfig,
 } from '../../qb/pqb/src';
 import { MaybeArray, toArray } from 'orchid-core';
 import { z } from 'zod';
@@ -19,7 +20,7 @@ export const testSchemaConfig = zodSchemaConfig;
 
 export const testAdapter = new Adapter(testDbOptions);
 
-const columnTypes = makeColumnTypes(zodSchemaConfig);
+const columnTypes = makeColumnTypes(defaultSchemaConfig);
 
 export const testColumnTypes = {
   ...columnTypes,
@@ -27,23 +28,41 @@ export const testColumnTypes = {
     return columnTypes.text(min, max);
   },
   timestamp() {
-    return columnTypes.timestamp().parse(z.date(), (input) => new Date(input));
+    return columnTypes.timestamp().parse((input) => new Date(input));
   },
   timestampNoTZ() {
-    return columnTypes
-      .timestampNoTZ()
-      .parse(z.date(), (input) => new Date(input));
+    return columnTypes.timestampNoTZ().parse((input) => new Date(input));
   },
 };
 
 export const testDb = createDb({
   adapter: testAdapter,
-  schemaConfig: zodSchemaConfig,
   columnTypes: testColumnTypes,
 });
 
-export const testDbDefaultTypes = createDb({
+const zodColumnTypes = makeColumnTypes(zodSchemaConfig);
+
+export const testZodColumnTypes = {
+  ...zodColumnTypes,
+  text(min = 0, max = Infinity) {
+    return zodColumnTypes.text(min, max);
+  },
+  timestamp() {
+    return zodColumnTypes
+      .timestamp()
+      .parse(z.date(), (input) => new Date(input));
+  },
+  timestampNoTZ() {
+    return zodColumnTypes
+      .timestampNoTZ()
+      .parse(z.date(), (input) => new Date(input));
+  },
+};
+
+export const testDbZodTypes = createDb({
   adapter: testAdapter,
+  schemaConfig: zodSchemaConfig,
+  columnTypes: testZodColumnTypes,
 });
 
 export const line = (s: string) =>


### PR DESCRIPTION
Fixes https://github.com/romeerez/orchid-orm/issues/234 + type optimizations.

Optimizing types is quite an interesting way to spend time, TS behavior is mostly unpredictable and it's curious to find patterns in it. After collecting more shreds of evidence, I'm going to write an article about it, maybe in a month or two.

The main metric to evaluate TS performance is the "instantiations count" value that is shown when running `tsx --extendedDiagnostics`.

Before this PR:
- pqb: instantiations 6749047, memory used 513559K, check time 10.95s
- ORM: instantiations 2661113, memory used 466366K, check time 6.62s

After:
- pqb: instantiations 5180751, memory used 451966K, check time 6.81s
- ORM: instantiations 1859083, memory used 407520K, check time 5.08s

A few commits later:
- pqb: instantiations 1984344, memory used 375868K, check time 4.25s
- ORM: instantiations 890618, memory used 355881K, check time 3.93s