### PR TITLE
Remove zod references from schema-to-valibot

### DIFF
--- a/packages/schemaConfigs/valibot/README.md
+++ b/packages/schemaConfigs/valibot/README.md
@@ -1,4 +1,4 @@
-# Orchid ORM schema to zod converter
+# Orchid ORM schema to valibot converter
 
 [Valibot](https://valibot.dev/) integration for OrchidORM.
 

--- a/packages/schemaConfigs/valibot/tsconfig.json
+++ b/packages/schemaConfigs/valibot/tsconfig.json
@@ -8,7 +8,6 @@
       "orchid-core": ["../../core/src"],
       "pqb": ["../../qb/pqb/src"],
       "test-utils": ["../../test-utils/src"],
-      "schema-to-zod": ["../zod/src"]
     }
   }
 }


### PR DESCRIPTION
The first one is a typo, for the second one I'm not completely sure about it, but I believe it's not used.

TBH I think this one is not used, too:

https://github.com/romeerez/orchid-orm/blob/e936561438be2413e5fcf8077e6054f23ac02020/packages/schemaConfigs/zod/tsconfig.json#L13

but it's kinda out of scope.