### PR TITLE
Refactor pqb quote

### DIFF
--- a/.changeset/wild-carrots-greet.md
+++ b/.changeset/wild-carrots-greet.md
@@ -1,0 +1,5 @@
+---
+'pqb': minor
+---
+
+Use ARRAY[] for arrays, support native JS bigint for raw values.

--- a/packages/qb/pqb/src/quote.test.ts
+++ b/packages/qb/pqb/src/quote.test.ts
@@ -3,6 +3,7 @@ import { quote } from './quote';
 describe('quote', () => {
   it('should quote different values', () => {
     expect(quote(123)).toBe('123');
+    expect(quote(12345678901234567890n)).toBe('12345678901234567890');
     expect(quote('string')).toBe("'string'");
     expect(quote(`str'ing`)).toBe(`'str''ing'`);
     expect(quote(true)).toBe('true');
@@ -18,6 +19,7 @@ describe('quote', () => {
     expect(
       quote([
         1,
+        12345678901234567890n,
         'string',
         'str"ing',
         `str'ing`,
@@ -27,9 +29,14 @@ describe('quote', () => {
         null,
         undefined,
         { key: `val'ue` },
+        [1, 2, 'str"ing', `str'ing`],
+        [
+          [1, 2],
+          [3, 4],
+        ],
       ]),
     ).toBe(
-      `'{1,"string","str\\"ing","str''ing",true,false,"${now.toISOString()}",NULL,NULL,"{\\"key\\":\\"val''ue\\"}"}'`,
+      `ARRAY[1,12345678901234567890,'string','str"ing','str''ing',true,false,'${now.toISOString()}',NULL,NULL,'{"key":"val''ue"}',[1,2,'str"ing','str''ing'],[[1,2],[3,4]]]`,
     );
   });
 });

--- a/packages/qb/pqb/src/quote.ts
+++ b/packages/qb/pqb/src/quote.ts
@@ -1,39 +1,21 @@
-const singleQuoteRegex = /'/g;
-const doubleQuoteRegex = /"/g;
-
 // eslint-disable-next-line
 type Value = any;
 
-const quoteValue = (value: Value): string => {
+const quoteValue = (value: Value, nested = false): string => {
   const type = typeof value;
-  if (type === 'number') return String(value);
-  else if (type === 'string')
-    return `"${(value as string)
-      .replace(doubleQuoteRegex, '\\"')
-      .replace(singleQuoteRegex, "''")}"`;
-  else if (type === 'boolean') return value ? 'true' : 'false';
-  else if (value instanceof Date) return `"${value.toISOString()}"`;
-  else if (Array.isArray(value)) return quoteArray(value);
-  else if (value === null || value === undefined) return 'NULL';
-  else
-    return `"${JSON.stringify(value)
-      .replace(doubleQuoteRegex, '\\"')
-      .replace(singleQuoteRegex, "''")}"`;
-};
-
-const quoteArray = (array: Value[]) => `'{${array.map(quoteValue).join(',')}}'`;
-
-export const quote = (value: Value): string => {
-  const type = typeof value;
-  if (type === 'number') return `${value}`;
+  if (type === 'number' || type === 'bigint') return String(value);
   else if (type === 'string') return quoteString(value);
   else if (type === 'boolean') return value ? 'true' : 'false';
   else if (value instanceof Date) return `'${value.toISOString()}'`;
-  else if (Array.isArray(value)) return quoteArray(value);
+  else if (Array.isArray(value))
+    return `${nested ? '' : 'ARRAY'}[${value
+      .map((el) => quoteValue(el, true))
+      .join(',')}]`;
   else if (value === null || value === undefined) return 'NULL';
-  else return `'${JSON.stringify(value).replace(singleQuoteRegex, "''")}'`;
+  else return quoteString(JSON.stringify(value));
 };
 
-export const quoteString = (value: string) => {
-  return `'${(value as string).replace(singleQuoteRegex, "''")}'`;
-};
+export const quote = (value: Value): string => quoteValue(value);
+
+export const quoteString = (value: string) =>
+  `'${value.replaceAll("'", "''")}'`;


### PR DESCRIPTION
Refactor pqb quote:

- Get rid of duplicated logic (use `ARRAY[]` for arrays and reuse quote function for array elements).
- Get rid of regexps.
- Support native JS bigint.