### PR TITLE
Add `$afterCommit`

### DIFF
--- a/docs/src/guide/hooks.md
+++ b/docs/src/guide/hooks.md
@@ -309,7 +309,7 @@ class SomeTable extends BaseTable {
     });
 
     // named function
-    this.afterCreateCommit([], function myHook() => {
+    this.afterCreateCommit([], function myHook() {
       // ...
     });
   }

--- a/docs/src/guide/transactions.md
+++ b/docs/src/guide/transactions.md
@@ -144,6 +144,29 @@ db.$transaction(async () => {
 });
 ```
 
+## afterCommit
+
+Schedules a hook to run after the outermost transaction commits:
+
+```ts
+await db.$transaction(async () => {
+  await db.table.create(data)
+  await db.table.where({ ...conditions }).update({ key: 'value' })
+  await db.$afterCommit(async () => {
+    console.log('after commit')
+  })
+})
+```
+
+If used outside of the transaction, the hook will be executed immediately:
+
+```ts
+// Runs hook immediately.
+await db.$afterCommit(async () => {
+  console.log('after commit')
+})
+```
+
 ## testTransaction
 
 `Orchid ORM` has a special utility to wrap your tests in transactions which are rolled back after each test.

--- a/docs/src/guide/transactions.md
+++ b/docs/src/guide/transactions.md
@@ -158,7 +158,7 @@ await db.$transaction(async () => {
 })
 ```
 
-If used outside of the transaction, the hook will be executed immediately:
+If used outside the transaction, the hook will be executed immediately:
 
 ```ts
 // Runs hook immediately.

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -1,7 +1,6 @@
-import { QueryBaseCommon, Sql } from './query';
-import { emptyObject } from './utils';
 import { setTimeout } from 'timers/promises';
-import { QueryLogObject } from './log';
+import { Sql } from './query';
+import { emptyObject } from './utils';
 
 // Input type of adapter query methods.
 export type QueryInput = string | { text: string; values?: unknown[] };
@@ -112,35 +111,6 @@ export interface AdapterBase {
 // Database adapter type for transaction that contains a connected db client.
 export interface TransactionAdapterBase extends AdapterBase {
   client: unknown;
-}
-
-// Wrapper type for transactions.
-export interface TransactionState {
-  // Database adapter that is connected to a currently running transaction.
-  adapter: TransactionAdapterBase;
-  // Number of transaction nesting.
-  // Top transaction has id = 0, transaction inside of transaction will have id = 1, and so on.
-  transactionId: number;
-  // Array of data and functions to call after commit.
-  // 1st element is a query result, 2nd element is a query object, 3rd element is array of functions to call with the query result and object.
-  afterCommit?: TransactionAfterCommitHook[];
-  // To log all the queries inside a transaction.
-  log?: QueryLogObject;
-  // number of test transaction wrapping the current one
-  testTransactionCount?: number;
-}
-
-/**
- * Element of `afterCommit` transaction array. See {@link TransactionState.afterCommit}.
- */
-export type TransactionAfterCommitHook =
-  | unknown[]
-  | QueryBaseCommon
-  | AfterCommitHook[];
-
-// Function to call after transaction commit.
-export interface AfterCommitHook {
-  (data: unknown[], q: QueryBaseCommon): unknown | Promise<unknown>;
 }
 
 export const setAdapterConnectRetry = <Result>(

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,1 @@
+export abstract class OrchidOrmError extends Error {}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,3 +6,5 @@ export * from './query';
 export * from './raw';
 export * from './utils';
 export * from './log';
+export * from './transaction';
+export * from './errors';

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { TransactionState } from './adapter';
+import { TransactionState } from './transaction';
 import {
   EmptyObject,
   FnUnknownToUnknown,

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -90,7 +90,7 @@ export type AfterCommitErrorResult =
  *     });
  *
  *     // named function
- *     this.afterCreateCommit([], function myHook() => {
+ *     this.afterCreateCommit([], function myHook() {
  *       // ...
  *     });
  *   }

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -1,0 +1,120 @@
+import { TransactionAdapterBase } from './adapter';
+import { OrchidOrmError } from './errors';
+import { QueryLogObject } from './log';
+import { MaybePromise } from './utils';
+
+// Wrapper type for transactions.
+export interface TransactionState {
+  // Database adapter that is connected to a currently running transaction.
+  adapter: TransactionAdapterBase;
+  // Number of transaction nesting.
+  // Top transaction has id = 0, transaction inside of transaction will have id = 1, and so on.
+  transactionId: number;
+  // Array of functions to call after commit.
+  afterCommit?: AfterCommitHook[];
+  // The last attached catchAfterCommitError handler.
+  catchAfterCommitError?: AfterCommitErrorHandler;
+  // To log all the queries inside a transaction.
+  log?: QueryLogObject;
+  // number of test transaction wrapping the current one
+  testTransactionCount?: number;
+}
+
+/**
+ * Check if inside transaction started by user (not test transaction).
+ */
+export function isInUserTransaction(trx: TransactionState): boolean {
+  return (
+    !trx.testTransactionCount || trx.transactionId >= trx.testTransactionCount
+  );
+}
+
+/**
+ * Element of `afterCommit` transaction array. See {@link TransactionState.afterCommit}.
+ */
+export type AfterCommitHook = () => MaybePromise<unknown>;
+
+export type AfterCommitErrorHandler = (error: AfterCommitError) => void;
+
+export interface AfterCommitErrorFulfilledResult
+  extends PromiseFulfilledResult<unknown> {
+  name?: string;
+}
+
+export interface AfterCommitErrorRejectedResult extends PromiseRejectedResult {
+  name?: string;
+}
+
+export type AfterCommitErrorResult =
+  | AfterCommitErrorFulfilledResult
+  | AfterCommitErrorRejectedResult;
+
+/**
+ * `AfterCommitError` is thrown when one of after commit hooks throws.
+ *
+ * ```ts
+ * interface AfterCommitError extends OrchidOrmError {
+ *   // the result of transaction functions
+ *   result: unknown;
+ *
+ *   // Promise.allSettled result + optional function names
+ *   hookResults: (
+ *     | {
+ *         status: 'fulfilled';
+ *         value: unknown;
+ *         name?: string;
+ *       }
+ *     | {
+ *         status: 'rejected';
+ *         reason: any; // the error object thrown by a hook
+ *         name?: string;
+ *       }
+ *   )[];
+ * }
+ * ```
+ *
+ * Use `function name() {}` function syntax for hooks to give them names,
+ * so later they can be identified when handling after commit errors.
+ *
+ * ```ts
+ * class SomeTable extends BaseTable {
+ *   readonly table = 'someTable';
+ *   columns = this.setColumns((t) => ({
+ *     ...someColumns,
+ *   }));
+ *
+ *   init(orm: typeof db) {
+ *     // anonymous funciton - has no name
+ *     this.afterCreateCommit([], async () => {
+ *       // ...
+ *     });
+ *
+ *     // named function
+ *     this.afterCreateCommit([], function myHook() => {
+ *       // ...
+ *     });
+ *   }
+ * }
+ * ```
+ */
+export class AfterCommitError extends OrchidOrmError {
+  constructor(
+    public result: unknown,
+    public hookResults: AfterCommitErrorResult[],
+  ) {
+    super('After commit hooks have failed');
+  }
+}
+
+export const handleAfterCommitError = (
+  result: unknown,
+  hookResults: AfterCommitErrorResult[],
+  catchAfterCommitError?: AfterCommitErrorHandler,
+) => {
+  const err = new AfterCommitError(result, hookResults);
+  if (catchAfterCommitError) {
+    catchAfterCommitError(err);
+  } else {
+    throw err;
+  }
+};

--- a/packages/orm/src/orm.ts
+++ b/packages/orm/src/orm.ts
@@ -21,7 +21,7 @@ import {
   BaseTableClass,
 } from './baseTable';
 import { applyRelations } from './relations/relations';
-import { transaction, ensureTransaction, isInTransaction } from './transaction';
+import { transaction, ensureTransaction, isInTransaction, afterCommit } from './transaction';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   ColumnSchemaConfig,
@@ -52,6 +52,10 @@ export type OrchidORM<T extends TableClasses = TableClasses> = {
    * @see import('pqb').Transaction.prototype.ensureTransaction
    */
   $isInTransaction: typeof isInTransaction;
+  /**
+   * @see import('pqb').Transaction.prototype.afterCommit
+   */
+  $afterCommit: typeof afterCommit;
   $adapter: Adapter;
   $queryBuilder: Db;
 
@@ -174,6 +178,7 @@ export const orchidORM = <T extends TableClasses>(
     $transaction: transaction,
     $ensureTransaction: ensureTransaction,
     $isInTransaction: isInTransaction,
+    $afterCommit: afterCommit,
     $adapter: adapter,
     $queryBuilder: qb,
     $query: ((...args) => qb.query(...args)) as typeof qb.query,

--- a/packages/orm/src/transaction.ts
+++ b/packages/orm/src/transaction.ts
@@ -1,3 +1,4 @@
+import { AfterCommitHook } from 'orchid-core';
 import { Db, IsolationLevel, TransactionOptions } from 'pqb';
 
 export function transaction<Result>(
@@ -29,4 +30,11 @@ export function ensureTransaction<Result>(
 
 export function isInTransaction(this: { $queryBuilder: Db }): boolean {
   return this.$queryBuilder.isInTransaction();
+}
+
+export function afterCommit(
+  this: { $queryBuilder: Db },
+  hook: AfterCommitHook,
+): Promise<void> {
+  return this.$queryBuilder.afterCommit(hook);
 }

--- a/packages/qb/pqb/src/errors.ts
+++ b/packages/qb/pqb/src/errors.ts
@@ -1,7 +1,5 @@
 import { Query } from './query/query';
-import { PickQueryShape } from 'orchid-core';
-
-export abstract class OrchidOrmError extends Error {}
+import { OrchidOrmError, PickQueryShape } from 'orchid-core';
 
 /**
  * When we search for a single record, and it is not found, it can either throw an error, or return `undefined`.

--- a/packages/qb/pqb/src/queryMethods/hooks.test.ts
+++ b/packages/qb/pqb/src/queryMethods/hooks.test.ts
@@ -4,7 +4,7 @@ import { NotFoundError } from '../errors';
 import { noop, TransactionState } from 'orchid-core';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { Query } from '../query/query';
-import { AfterCommitError } from './transaction';
+import { AfterCommitError } from 'orchid-core';
 
 // make query ignore the transaction that is injected by `useTestDatabase`
 const ignoreTestTransactionOnce = (q: Query) => {
@@ -240,7 +240,10 @@ describe('hooks', () => {
   describe('after commit hooks', () => {
     afterEach(() => {
       const t = testDb.internal.transactionStorage.getStore();
-      if (t) delete t.afterCommit;
+      if (t) {
+        delete t.afterCommit;
+        delete t.catchAfterCommitError;
+      }
     });
 
     it('should work in a test transaction', async () => {

--- a/packages/qb/pqb/src/queryMethods/hooks.ts
+++ b/packages/qb/pqb/src/queryMethods/hooks.ts
@@ -1,8 +1,11 @@
-import { _clone, pushQueryValue } from '../query/queryUtils';
-import { PickQueryShape, QueryColumns } from 'orchid-core';
-import { QueryAfterHook, QueryBeforeHook } from '../sql';
+import {
+  AfterCommitErrorHandler,
+  PickQueryShape,
+  QueryColumns,
+} from 'orchid-core';
 import { PickQueryQ } from '../query/query';
-import { AfterCommitError } from './transaction';
+import { _clone, pushQueryValue } from '../query/queryUtils';
+import { QueryAfterHook, QueryBeforeHook } from '../sql';
 
 // A function type for after-hook. Constructs type of data argument based on selected columns.
 export type AfterHook<
@@ -406,7 +409,7 @@ export abstract class QueryHooks {
    * result.id;
    * ```
    */
-  catchAfterCommitError<T>(this: T, fn: (error: AfterCommitError) => void): T {
+  catchAfterCommitError<T>(this: T, fn: AfterCommitErrorHandler): T {
     const q = _clone(this);
     q.q.catchAfterCommitError = fn;
     return q as T;

--- a/packages/qb/pqb/src/queryMethods/transaction.test.ts
+++ b/packages/qb/pqb/src/queryMethods/transaction.test.ts
@@ -1,7 +1,7 @@
 import pg, { Client } from 'pg';
 import { assertType, testDb, useTestDatabase } from 'test-utils';
 import { User, userColumnsSql } from '../test-utils/test-utils';
-import { noop } from 'orchid-core';
+import { AfterCommitError, noop } from 'orchid-core';
 
 describe('transaction', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -234,6 +234,130 @@ describe('transaction', () => {
         await testDb.transaction(async () => {
           expect(testDb.isInTransaction()).toBe(true);
         });
+      });
+    });
+  });
+
+  describe('afterCommit', () => {
+    afterEach(() => {
+      const t = testDb.internal.transactionStorage.getStore();
+      if (t) {
+        delete t.afterCommit;
+        delete t.catchAfterCommitError;
+      }
+    });
+
+    // Async hook is a jets mock which only records the call only after it has been awaited.
+    const createAsyncHook = () => {
+      const mock = jest.fn();
+      return new Proxy(mock, {
+        apply: async (...args) => {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return mock.apply(args);
+        },
+      });
+    };
+
+    it('should run immediately without transaction', async () => {
+      const hook = createAsyncHook();
+
+      await testDb.afterCommit(hook);
+      expect(hook).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs multiple hooks after transaction commits', async () => {
+      const hooks = [createAsyncHook(), createAsyncHook(), jest.fn()];
+
+      await testDb.transaction(async () => {
+        for (const hook of hooks) {
+          await testDb.afterCommit(hook);
+        }
+        for (const hook of hooks) {
+          expect(hook).toHaveBeenCalledTimes(0);
+        }
+      });
+      for (const hook of hooks) {
+        expect(hook).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('works inside nested transaction', async () => {
+      const hook = createAsyncHook();
+
+      await testDb.transaction(async () => {
+        await testDb.afterCommit(hook);
+        expect(hook).toHaveBeenCalledTimes(0);
+        await testDb.transaction(async () => {
+          await testDb.afterCommit(hook);
+          expect(hook).toHaveBeenCalledTimes(0);
+        });
+        expect(hook).toHaveBeenCalledTimes(0);
+      });
+      expect(hook).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores hooks if transaction rolls back', async () => {
+      const hook = jest.fn();
+
+      await testDb
+        .transaction(async () => {
+          await testDb.afterCommit(hook);
+          throw new Error('Rollback');
+        })
+        .catch((err) => err);
+      expect(hook).toHaveBeenCalledTimes(0);
+    });
+
+    it('should throw AfterCommitError with transaction result and hook results from Promise.allSettled', async () => {
+      const err = await testDb
+        .transaction(async () => {
+          await testDb.afterCommit(function one() {
+            return 'ok';
+          });
+          await testDb.afterCommit(function two() {
+            throw new Error('error');
+          });
+          return 'transaction result';
+        })
+        .catch((err) => err);
+
+      expect(err).toBeInstanceOf(AfterCommitError);
+      expect(err).toMatchObject({
+        result: 'transaction result',
+        hookResults: [
+          {
+            status: 'fulfilled',
+            value: 'ok',
+            name: 'one',
+          },
+          {
+            status: 'rejected',
+            reason: expect.objectContaining({
+              message: 'error',
+            }),
+          },
+        ],
+      });
+    });
+
+    describe('works in testTransaction', () => {
+      useTestDatabase();
+
+      it('should run immediately in test transaction', async () => {
+        const hook = createAsyncHook();
+
+        await testDb.afterCommit(hook);
+        expect(hook).toHaveBeenCalledTimes(1);
+      });
+
+      it('runs hooks after user transaction commits', async () => {
+        const hook = createAsyncHook();
+
+        await testDb.transaction(async () => {
+          await testDb.afterCommit(hook);
+          expect(hook).toHaveBeenCalledTimes(0);
+        });
+        expect(hook).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/packages/qb/pqb/src/queryMethods/transaction.test.ts
+++ b/packages/qb/pqb/src/queryMethods/transaction.test.ts
@@ -252,7 +252,7 @@ describe('transaction', () => {
       const mock = jest.fn();
       return new Proxy(mock, {
         apply: async (...args) => {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await new Promise(setImmediate);
           return mock.apply(args);
         },
       });

--- a/packages/qb/pqb/src/queryMethods/transaction.test.ts
+++ b/packages/qb/pqb/src/queryMethods/transaction.test.ts
@@ -247,7 +247,7 @@ describe('transaction', () => {
       }
     });
 
-    // Async hook is a jets mock which only records the call only after it has been awaited.
+    // Async hook is a jest mock which only records the call only after it has been awaited.
     const createAsyncHook = () => {
       const mock = jest.fn();
       return new Proxy(mock, {

--- a/packages/qb/pqb/src/queryMethods/transaction.ts
+++ b/packages/qb/pqb/src/queryMethods/transaction.ts
@@ -321,17 +321,14 @@ const runAfterCommit = async (trx: TransactionState, result: unknown) => {
       }
     }
 
-    const hookResults = await Promise.allSettled(promises);
+    const hookResults = await Promise.allSettled(promises) as AfterCommitErrorResult[];
     if (hookResults.some((result) => result.status === 'rejected')) {
-      const resultsWithNames: AfterCommitErrorResult[] = hookResults.map(
-        (result, i) => ({
-          ...result,
-          name: trx.afterCommit?.[i].name,
-        }),
-      );
+      for (let i = 0; i < hookResults.length; i++) {
+        hookResults[i].name = trx.afterCommit?.[i].name
+      }
       handleAfterCommitError(
         result,
-        resultsWithNames,
+        hookResults,
         trx.catchAfterCommitError,
       );
     }

--- a/packages/qb/pqb/src/sql/data.ts
+++ b/packages/qb/pqb/src/sql/data.ts
@@ -17,6 +17,7 @@ import {
 } from './types';
 import { SelectableOrExpression } from '../common/utils';
 import {
+  AfterCommitErrorHandler,
   BatchParsers,
   ColumnsParsers,
   ColumnsShapeBase,
@@ -38,7 +39,6 @@ import {
 import { RelationQueryBase } from '../relations';
 
 import { ComputedColumns } from '../modules/computed';
-import { AfterCommitError } from '../queryMethods';
 
 export interface RecordOfColumnsShapeBase {
   [K: string]: ColumnsShapeBase;
@@ -170,7 +170,7 @@ export interface CommonQueryData {
   // additional select for afterDelete hooks
   afterDeleteSelect?: Set<string>;
   // catch after commit hooks errors, letting query to return its result
-  catchAfterCommitError?(error: AfterCommitError): void;
+  catchAfterCommitError?: AfterCommitErrorHandler;
   // log settings
   log?: QueryLogObject;
   // logger with `log`, `warn`, `error`


### PR DESCRIPTION
Adds `db.$afterCommit`, fixes #354.

There are a few decisions I'm not sure in, please review these in particular:

---

The return type is `Promise<void>` regardless of whether the hook is sync or async.

It probably can be converted to overload which returns `T | void` for sync hooks and replace `await hook()` with `return hook()` when not inside transaction, but I decided it's cleaner the way I did it.

---

I gathered `TransactionState` stuff from `packages/core/src/adapter.ts` and `AfterCommit*` stuff from `packages/qb/pqb/src/queryMethods/transaction.ts` under the new module `packages/core/src/transaction.ts`.

I also extracted `(!trx.testTransactionCount || trx.transactionId + 1 > trx.testTransactionCount)` as a utility there.

I figured this is not related to pqb (postgres query builder) but may be I got it wrong. Please advise if you want to organize things differently.

---

I moved `OrchidOrmError` to the new module `packages/core/src/errors.ts` (as `AfterCommitError` extended it and I didn't want to have core/pqb dependency loop).

