### PR TITLE
Update legacy User.method() examples in docs

### DIFF
--- a/docs/src/guide/advanced-queries.md
+++ b/docs/src/guide/advanced-queries.md
@@ -116,12 +116,12 @@ db.$qb
   .withRecursive(
     'subordinates',
     // the base, anchor query: find the manager to begin recursion with
-    Employee.select('id', 'name', 'managerId').find(1),
+    db.employee.select('id', 'name', 'managerId').find(1),
     // recursive query:
     // find employees whos managerId is id from the surrounding subordinates CTE
     (q) =>
       q
-        .from(Employee)
+        .from(db.employee)
         .select('id', 'name', 'managerId')
         .join('subordinates', 'subordinates.id', 'profile.managerId'),
   )

--- a/docs/src/guide/create-update-delete.md
+++ b/docs/src/guide/create-update-delete.md
@@ -374,7 +374,7 @@ Runtime defaults cannot work with it.
 
 ```ts
 const manyRecords = await db.table.createForEachFrom(
-  RelatedTable.select({ relatedId: 'id' }).where({ key: 'value' }),
+  db.relatedTable.select({ relatedId: 'id' }).where({ key: 'value' }),
 );
 ```
 
@@ -406,7 +406,8 @@ const user = await db.user
 The data can be returned from a function, it won't be called if the record was found:
 
 ```ts
-const user = await User.selectAll()
+const user = await db.user
+  .selectAll()
   .findBy({ email: 'some@email.com' })
   .orCreate(() => ({
     email: 'some@email.com',
@@ -912,7 +913,8 @@ Or, it can take `data` and `create` objects, `data` will be used for update and 
 No values are returned by default, place `select` or `selectAll` before `upsert` to specify returning columns.
 
 ```ts
-await User.selectAll()
+await db.user
+  .selectAll()
   .findBy({ email: 'some@email.com' })
   .upsert({
     data: {
@@ -930,7 +932,8 @@ await User.selectAll()
   });
 
 // the same as above but using `update` and `create`
-await User.selectAll()
+await db.user
+  .selectAll()
   .findBy({ email: 'some@email.com' })
   .upsert({
     update: {
@@ -947,7 +950,8 @@ await User.selectAll()
 The data for `create` may be returned from a function, it won't be called if a record was updated:
 
 ```ts
-await User.selectAll()
+await db.user
+  .selectAll()
   .findBy({ email: 'some@email.com' })
   .upsert({
     update: {
@@ -960,7 +964,8 @@ await User.selectAll()
   });
 
 // the same as above using `data`
-await User.selectAll()
+await db.user
+  .selectAll()
   .findBy({ email: 'some@email.com' })
   .upsert({
     data: {
@@ -977,7 +982,8 @@ await User.selectAll()
 Data from `data` or `update` is passed to the `create` function and can be used:
 
 ```ts
-const user = await User.selectAll()
+const user = await db.user
+  .selectAll()
   .findBy({ email: 'some@email.com' })
   .upsert({
     data: {
@@ -1117,7 +1123,7 @@ const deletedUsersFull = await db.table
 
 ```ts
 // delete all users who have corresponding profile records:
-db.table.join(Profile, 'profile.userId', 'user.id').all().delete();
+db.table.join(db.profile, 'profile.userId', 'user.id').all().delete();
 ```
 
 `delete` can be used in [with](/guide/advanced-queries#with) expressions:

--- a/docs/src/guide/join.md
+++ b/docs/src/guide/join.md
@@ -436,10 +436,11 @@ Second argument is a callback where you can reference other tables using `on` an
 Note that the regular `join` will also generate `JOIN LATERAL` SQL expression when the query returned from callback is complex enough (see [implicit join lateral](/guide/join#implicit-join-lateral)).
 
 ```ts
-// joinLateral a Message table, alias it as `m`
+// joinLateral messages relation, alias it as `m`
 // without aliasing you can refer to the message by a table name
-User.joinLateral(Message.as('m'), (q) =>
+db.user.joinLateral('messages', (q) =>
   q
+    .as('m') // alias to 'm'
     // select message columns
     .select('text')
     // join the message to the user, column names can be prefixed with table names
@@ -458,10 +459,9 @@ As well as simple `join`, `joinLateral` can select an object of full joined reco
 
 ```ts
 // join by relation name
-const result = await User.joinLateral(
-  'messages',
-  (q) => q.as('message'), // alias to 'message'
-).select('name', { message: 'message.*' });
+const result = await db.user
+  .joinLateral('messages', (q) => q.as('message')) // alias to 'message'
+  .select('name', { message: 'message.*' });
 
 // result has the following type:
 const ok: {
@@ -475,10 +475,9 @@ const ok: {
 
 ```ts
 // join by relation name
-const result = await User.joinLateral(
-  'messages',
-  (q) => q.as('message'), // alias to 'message'
-).select('name', { msg: 'message.*' });
+const result = await db.user
+  .joinLateral('messages', (q) => q.as('message')) // alias to 'message'
+  .select('name', { msg: 'message.*' });
 
 // result has the following type:
 const ok: {

--- a/docs/src/guide/query-methods.md
+++ b/docs/src/guide/query-methods.md
@@ -315,7 +315,7 @@ db.table.select('user.id', 'user.name', { nameAlias: 'user.name' });
 
 // table name may refer to the current table or a joined table:
 db.table
-  .join(Message, 'authorId', 'user.id')
+  .join(db.message, 'authorId', 'user.id')
   .select('user.name', 'message.text', { textAlias: 'message.text' });
 
 // select value from the sub-query,
@@ -422,7 +422,7 @@ Sets table alias:
 db.table.as('u').select('u.name');
 
 // Can be used in the join:
-db.table.join(Profile.as('p'), 'p.userId', 'user.id');
+db.table.join(db.profile.as('p'), 'p.userId', 'user.id');
 ```
 
 ## from

--- a/docs/src/guide/sql-expressions.md
+++ b/docs/src/guide/sql-expressions.md
@@ -214,7 +214,7 @@ await db.table.join('otherTable').select({
 For example, calling `sqrt` function to get a square root from some numeric column:
 
 ```ts
-const q = await User.select({
+const q = await db.user.select({
   sqrt: (q) => q.fn<number>('sqrt', ['numericColumn']),
 }).take();
 
@@ -226,7 +226,7 @@ If this is an aggregate function, you can specify aggregation options (see [Aggr
 Use `type` method to specify a column type so that its operators such as `lt` and `gt` become available:
 
 ```ts
-const q = await User.select({
+const q = await db.user.select({
   // Produces `sqrt("numericColumn") > 5`
   sqrtIsGreaterThan5: (q) =>
     q

--- a/docs/src/guide/where.md
+++ b/docs/src/guide/where.md
@@ -93,7 +93,7 @@ db.table.where((q) =>
     .where({ name: 'Name' })
     .orWhere({ id: 1 }, { id: 2 })
     .whereIn('letter', ['a', 'b', 'c'])
-    .whereExists(Message, 'authorId', 'id'),
+    .whereExists(db.message, 'authorId', 'id'),
 );
 ```
 
@@ -340,7 +340,7 @@ db.table.whereIn(
 It supports sub query which should return records with columns of the same type:
 
 ```ts
-db.table.whereIn(['id', 'name'], OtherTable.select('id', 'name'));
+db.table.whereIn(['id', 'name'], db.otherTable.select('id', 'name'));
 ```
 
 It supports raw SQL expression:
@@ -466,7 +466,7 @@ db.table.where({
     lt: 5,
 
     // lower than the value returned by sub-query
-    lt: OtherTable.select('someNumber').take(),
+    lt: db.otherTable.select('someNumber').take(),
 
     // raw SQL expression produces WHERE "numericColumn" < "otherColumn" + 10
     lt: sql`"otherColumn" + 10`,
@@ -500,7 +500,7 @@ db.table.where({
     in: ['a', 'b', 'c'],
 
     // WHERE "column" IN (SELECT "column" FROM "otherTable")
-    in: OtherTable.select('column'),
+    in: db.otherTable.select('column'),
 
     in: sql`('a', 'b')`,
   },
@@ -540,7 +540,7 @@ db.table.where({
     between: [1, 10],
 
     // sub-query and raw SQL expression
-    between: [OtherTable.select('column').take(), sql`2 + 2`],
+    between: [db.otherTable.select('column').take(), sql`2 + 2`],
   },
 });
 ```

--- a/packages/pqb/src/queryMethods/as.ts
+++ b/packages/pqb/src/queryMethods/as.ts
@@ -9,7 +9,7 @@ export abstract class QueryAsMethods {
    * db.table.as('u').select('u.name');
    *
    * // Can be used in the join:
-   * db.table.join(Profile.as('p'), 'p.userId', 'user.id');
+   * db.table.join(db.profile.as('p'), 'p.userId', 'user.id');
    * ```
    *
    * @param as - alias for the table of this query

--- a/packages/pqb/src/queryMethods/expressions.ts
+++ b/packages/pqb/src/queryMethods/expressions.ts
@@ -228,7 +228,7 @@ export class ExpressionMethods {
    * For example, calling `sqrt` function to get a square root from some numeric column:
    *
    * ```ts
-   * const q = await User.select({
+   * const q = await db.table.select({
    *   sqrt: (q) => q.fn<number>('sqrt', ['numericColumn']),
    * }).take();
    *
@@ -240,7 +240,7 @@ export class ExpressionMethods {
    * Use `type` method to specify a column type so that its operators such as `lt` and `gt` become available:
    *
    * ```ts
-   * const q = await User.select({
+   * const q = await db.table.select({
    *   // Produces `sqrt("numericColumn") > 5`
    *   sqrtIsGreaterThan5: (q) =>
    *     q

--- a/packages/pqb/src/queryMethods/join/join.ts
+++ b/packages/pqb/src/queryMethods/join/join.ts
@@ -975,10 +975,11 @@ export class Join {
    * Note that the regular `join` will also generate `JOIN LATERAL` SQL expression when the query returned from callback is complex enough (see the bottom of {@link join} description).
    *
    * ```ts
-   * // joinLateral a Message table, alias it as `m`
+   * // joinLateral messages relation, alias it as `m`
    * // without aliasing you can refer to the message by a table name
-   * User.joinLateral(Message.as('m'), (q) =>
+   * db.user.joinLateral('messages', (q) =>
    *   q
+   *     .as('m') // alias to 'm'
    *     // select message columns
    *     .select('text')
    *     // join the message to the user, column names can be prefixed with table names
@@ -997,10 +998,9 @@ export class Join {
    *
    * ```ts
    * // join by relation name
-   * const result = await User.joinLateral(
-   *   'messages',
-   *   (q) => q.as('message'), // alias to 'message'
-   * ).select('name', { message: 'message.*' });
+   * const result = await db.user
+   *   .joinLateral('messages', (q) => q.as('message')) // alias to 'message'
+   *   .select('name', { message: 'message.*' });
    *
    * // result has the following type:
    * const ok: {
@@ -1014,10 +1014,9 @@ export class Join {
    *
    * ```ts
    * // join by relation name
-   * const result = await User.joinLateral(
-   *   'messages',
-   *   (q) => q.as('message'), // alias to 'message'
-   * ).select('name', { msg: 'message.*' });
+   * const result = await db.user
+   *   .joinLateral('messages', (q) => q.as('message')) // alias to 'message'
+   *   .select('name', { msg: 'message.*' });
    *
    * // result has the following type:
    * const ok: {

--- a/packages/pqb/src/queryMethods/mutate/createFrom.ts
+++ b/packages/pqb/src/queryMethods/mutate/createFrom.ts
@@ -416,7 +416,7 @@ export class QueryCreateFrom {
    *
    * ```ts
    * const manyRecords = await db.table.createForEachFrom(
-   *   RelatedTable.select({ relatedId: 'id' }).where({ key: 'value' }),
+   *   db.relatedTable.select({ relatedId: 'id' }).where({ key: 'value' }),
    * );
    * ```
    *

--- a/packages/pqb/src/queryMethods/mutate/delete.ts
+++ b/packages/pqb/src/queryMethods/mutate/delete.ts
@@ -91,7 +91,7 @@ export class Delete {
    *
    * ```ts
    * // delete all users who have corresponding profile records:
-   * db.table.join(Profile, 'profile.userId', 'user.id').all().delete();
+   * db.table.join(db.profile, 'profile.userId', 'user.id').all().delete();
    * ```
    *
    * `delete` can be used in {@link WithMethods.with} expressions:

--- a/packages/pqb/src/queryMethods/mutate/orCreate.ts
+++ b/packages/pqb/src/queryMethods/mutate/orCreate.ts
@@ -167,7 +167,8 @@ export interface QueryOrCreate {
    * The data can be returned from a function, it won't be called if the record was found:
    *
    * ```ts
-   * const user = await User.selectAll()
+   * const user = await db.user
+   *   .selectAll()
    *   .findBy({ email: 'some@email.com' })
    *   .orCreate(() => ({
    *     email: 'some@email.com',

--- a/packages/pqb/src/queryMethods/mutate/upsert.ts
+++ b/packages/pqb/src/queryMethods/mutate/upsert.ts
@@ -55,7 +55,8 @@ export interface QueryUpsert {
    * No values are returned by default, place `select` or `selectAll` before `upsert` to specify returning columns.
    *
    * ```ts
-   * await User.selectAll()
+   * await db.user
+   *   .selectAll()
    *   .findBy({ email: 'some@email.com' })
    *   .upsert({
    *     data: {
@@ -77,7 +78,8 @@ export interface QueryUpsert {
    *   });
    *
    * // the same as above but using `update` and `create`
-   * await User.selectAll()
+   * await db.user
+   *   .selectAll()
    *   .findBy({ email: 'some@email.com' })
    *   .upsert({
    *     update: {
@@ -94,7 +96,8 @@ export interface QueryUpsert {
    * The data for `create` may be returned from a function, it won't be called if a record was updated:
    *
    * ```ts
-   * await User.selectAll()
+   * await db.user
+   *   .selectAll()
    *   .findBy({ email: 'some@email.com' })
    *   .upsert({
    *     update: {
@@ -107,7 +110,8 @@ export interface QueryUpsert {
    *   });
    *
    * // the same as above using `data`
-   * await User.selectAll()
+   * await db.user
+   *   .selectAll()
    *   .findBy({ email: 'some@email.com' })
    *   .upsert({
    *     data: {
@@ -124,7 +128,8 @@ export interface QueryUpsert {
    * Data from `data` or `update` is passed to the `create` function and can be used:
    *
    * ```ts
-   * const user = await User.selectAll()
+   * const user = await db.user
+   *   .selectAll()
    *   .findBy({ email: 'some@email.com' })
    *   .upsert({
    *     data: {

--- a/packages/pqb/src/queryMethods/select/select.ts
+++ b/packages/pqb/src/queryMethods/select/select.ts
@@ -1075,7 +1075,7 @@ export class Select {
    *
    * // table name may refer to the current table or a joined table:
    * db.table
-   *   .join(Message, 'authorId', 'user.id')
+   *   .join(db.message, 'authorId', 'user.id')
    *   .select('user.name', 'message.text', { textAlias: 'message.text' });
    *
    * // select value from the sub-query,

--- a/packages/pqb/src/queryMethods/where/where.ts
+++ b/packages/pqb/src/queryMethods/where/where.ts
@@ -555,7 +555,7 @@ export class Where {
    *     .where({ name: 'Name' })
    *     .orWhere({ id: 1 }, { id: 2 })
    *     .whereIn('letter', ['a', 'b', 'c'])
-   *     .whereExists(Message, 'authorId', 'id'),
+   *     .whereExists(db.message, 'authorId', 'id'),
    * );
    * ```
    *
@@ -684,7 +684,7 @@ export class Where {
    *     lt: 5,
    *
    *     // lower than the value returned by sub-query
-   *     lt: OtherTable.select('someNumber').take(),
+   *     lt: db.otherTable.select('someNumber').take(),
    *
    *     // raw SQL expression produces WHERE "numericColumn" < "otherColumn" + 10
    *     lt: sql`"otherColumn" + 10`,
@@ -724,7 +724,7 @@ export class Where {
    *     in: ['a', 'b', 'c'],
    *
    *     // WHERE "column" IN (SELECT "column" FROM "otherTable")
-   *     in: OtherTable.select('column'),
+   *     in: db.otherTable.select('column'),
    *
    *     in: sql`('a', 'b')`,
    *   },
@@ -773,7 +773,7 @@ export class Where {
    *     between: [1, 10],
    *
    *     // sub-query and raw SQL expression
-   *     between: [OtherTable.select('column').take(), sql`2 + 2`],
+   *     between: [db.otherTable.select('column').take(), sql`2 + 2`],
    *   },
    * });
    * ```
@@ -1024,7 +1024,7 @@ export class Where {
    * It supports sub query which should return records with columns of the same type:
    *
    * ```ts
-   * db.table.whereIn(['id', 'name'], OtherTable.select('id', 'name'));
+   * db.table.whereIn(['id', 'name'], db.otherTable.select('id', 'name'));
    * ```
    *
    * It supports raw SQL expression:

--- a/packages/pqb/src/queryMethods/with.ts
+++ b/packages/pqb/src/queryMethods/with.ts
@@ -346,12 +346,12 @@ export class WithMethods {
    *   .withRecursive(
    *     'subordinates',
    *     // the base, anchor query: find the manager to begin recursion with
-   *     Employee.select('id', 'name', 'managerId').find(1),
+   *     db.employee.select('id', 'name', 'managerId').find(1),
    *     // recursive query:
    *     // find employees whos managerId is id from the surrounding subordinates CTE
    *     (q) =>
    *       q
-   *         .from(Employee)
+   *         .from(db.employee)
    *         .select('id', 'name', 'managerId')
    *         .join('subordinates', 'subordinates.id', 'profile.managerId'),
    *   )


### PR DESCRIPTION
This PR replaces legacy `User.selectAll()` and similar examples throughout the documentation with their modern API equivalents. I have fixed all the instances I could find.

I realise that in `pqb`, `User.selectAll()` is a valid method, but the majority of JSDoc uses `db.table` syntax, so it doesn't make sense when it differs (such as with `joinLateral` and `leftJoinLateral`). I kept the old syntax in `createDb` docs where it actually made sense.