### PR TITLE
Fix before hooks typing

### DIFF
--- a/.changeset/tender-comics-add.md
+++ b/.changeset/tender-comics-add.md
@@ -1,0 +1,5 @@
+---
+'orchid-orm': patch
+---
+
+Fix before hooks typing (#615)

--- a/packages/orm/src/baseTable.ts
+++ b/packages/orm/src/baseTable.ts
@@ -14,6 +14,7 @@ import {
   parseTableData,
   Query,
   QueryAfterHook,
+  QueryBeforeHook,
   QueryBeforeHookInternal,
   QueryData,
   QueryHooks,
@@ -232,6 +233,7 @@ export type Updatable<T extends ORMTableInput> = ShallowSimplify<
 
 // type of before hook function for the table
 type BeforeHookMethod = (cb: QueryBeforeHookInternal) => void;
+type BeforeActionHookMethod = (cb: QueryBeforeHook) => void;
 
 // type of after hook function for the table
 type AfterHookMethod = (cb: QueryAfterHook) => void;
@@ -447,13 +449,13 @@ export interface BaseTableInstance<ColumnTypes> {
 
   beforeQuery: BeforeHookMethod;
   afterQuery: AfterHookMethod;
-  beforeCreate: BeforeHookMethod;
+  beforeCreate: BeforeActionHookMethod;
   afterCreate: AfterSelectableHookMethod;
   afterCreateCommit: AfterSelectableHookMethod;
-  beforeUpdate: BeforeHookMethod;
+  beforeUpdate: BeforeActionHookMethod;
   afterUpdate: AfterSelectableHookMethod;
   afterUpdateCommit: AfterSelectableHookMethod;
-  beforeSave: BeforeHookMethod;
+  beforeSave: BeforeActionHookMethod;
   afterSave: AfterSelectableHookMethod;
   afterSaveCommit: AfterSelectableHookMethod;
   beforeDelete: BeforeHookMethod;


### PR DESCRIPTION
Fix before hooks typing (fixes #615).

To be honest I think pqb needs the same naming update to make it all consistent:

- QueryBeforeHookInternal → QueryBeforeHook
- QueryBeforeHook → QueryBeforeActionHook

but I decided to keep the PR to the bare minimum.
