### PR TITLE
Expose $ref on ORM instance

### DIFF
--- a/.changeset/rich-cows-peel.md
+++ b/.changeset/rich-cows-peel.md
@@ -1,0 +1,5 @@
+---
+'orchid-orm': patch
+---
+
+Expose `$ref` on ORM instance

--- a/docs/src/guide/orm-and-query-builder.md
+++ b/docs/src/guide/orm-and-query-builder.md
@@ -1241,6 +1241,14 @@ const row = result.rows[0];
 row[0]; // our value
 ```
 
+## $ref
+
+Use `$ref` when you need a column or other quoted identifier reference outside of a table query:
+
+```ts
+await db.$query`SET SEARCH_PATH TO ${db.$ref(schema)}`
+```
+
 ## $from
 
 Use `$from` to build a queries around sub queries similar to the following:

--- a/packages/orm/src/orm.test.ts
+++ b/packages/orm/src/orm.test.ts
@@ -10,7 +10,7 @@ import {
   UserData,
 } from 'test-utils';
 import { Selectable } from './baseTable';
-import { Db, raw } from 'pqb';
+import { Db, Expression, raw } from 'pqb';
 
 describe('orm', () => {
   useTestORM();
@@ -144,6 +144,14 @@ describe('orm', () => {
       await db.$queryArrays`SELECT 1`;
 
       expect(spy).toBeCalledWith`SELECT 1`;
+    });
+
+    it('should expose $ref from the query builder', () => {
+      const column = (db.$ref('table.column') as Expression).toSQL({
+        values: [],
+      });
+
+      expect(column).toBe(`"table"."column"`);
     });
   });
 

--- a/packages/orm/src/orm.ts
+++ b/packages/orm/src/orm.ts
@@ -130,6 +130,11 @@ interface OrchidORMMethods {
     arg: Arg,
   ): FromResult<FromQuery, Arg>;
 
+  /**
+   * See {@link QueryExpressions.ref}
+   */
+  $ref: OmitThisParameter<Db['ref']>;
+
   $close(): Promise<void>;
 }
 
@@ -187,6 +192,7 @@ export const orchidORMWithAdapter = <T extends TableClasses>(
     $afterCommit: afterCommit,
     $adapter: adapter,
     $qb: qb,
+    $ref: qb.ref.bind(qb),
     get $query() {
       return qb.query;
     },


### PR DESCRIPTION
The PR adds `db.$ref` as a shorthand for `db.$qb.ref`, along with updated documentation and a test.