### PR TITLE
Relax overly specified Postgres error expectations

### DIFF
--- a/packages/pqb/src/adapters/node-postgres.test.ts
+++ b/packages/pqb/src/adapters/node-postgres.test.ts
@@ -133,9 +133,6 @@ describe('adapter', () => {
         schema: 'public',
         table: 'user',
         constraint: 'user_pkey',
-        file: 'nbtinsert.c',
-        line: '666',
-        routine: '_bt_check_unique',
       });
     });
   });

--- a/packages/pqb/src/adapters/postgres-js.test.ts
+++ b/packages/pqb/src/adapters/postgres-js.test.ts
@@ -117,9 +117,6 @@ describe('postgres-js', () => {
         schema: 'public',
         table: 'user',
         constraint: 'user_pkey',
-        file: 'nbtinsert.c',
-        line: '666',
-        routine: '_bt_check_unique',
       });
     });
   });


### PR DESCRIPTION
The PR relaxes the test expectations, otherwise tests fail on different Postgres versions (e.g. I have 18.1 from homebrew).