### PR TITLE
Lint all files, fix linting errors

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -105,7 +105,9 @@ jest.mock('./packages/pqb/src/query/sub-query/sub-query-for-sql', () => {
 });
 
 jest.mock('./packages/pqb/src/query/basic-features/wrap/wrap', () => {
-  const actual = jest.requireActual('./packages/pqb/src/query/basic-features/wrap/wrap');
+  const actual = jest.requireActual(
+    './packages/pqb/src/query/basic-features/wrap/wrap',
+  );
 
   return process.env.RUNNING_BENCHMARKS
     ? actual
@@ -204,7 +206,9 @@ jest.mock(
 );
 
 jest.mock('./packages/pqb/src/query/basic-features/cte/cte.query', () => {
-  const actual = jest.requireActual('./packages/pqb/src/query/basic-features/cte/cte.query');
+  const actual = jest.requireActual(
+    './packages/pqb/src/query/basic-features/cte/cte.query',
+  );
   return process.env.RUNNING_BENCHMARKS
     ? actual
     : {

--- a/packages/pqb/src/query/extra-features/clear/clear.test.ts
+++ b/packages/pqb/src/query/extra-features/clear/clear.test.ts
@@ -1,4 +1,8 @@
-import { Message, User, userColumnsSql } from '../../../test-utils/pqb.test-utils';
+import {
+  Message,
+  User,
+  userColumnsSql,
+} from '../../../test-utils/pqb.test-utils';
 import { expectSql, line } from 'test-utils';
 
 describe('clear', () => {

--- a/packages/pqb/src/query/extra-features/copy-table-data/copy-table-data.sql.ts
+++ b/packages/pqb/src/query/extra-features/copy-table-data/copy-table-data.sql.ts
@@ -43,15 +43,10 @@ export const pushCopySql = (
 
   const target = 'from' in copy ? copy.from : copy.to;
 
-  const quotedTable = quoteSchemaAndTable(
-    query.schema,
-    table.table as string,
-  );
+  const quotedTable = quoteSchemaAndTable(query.schema, table.table as string);
 
   sql.push(
-    `COPY ${quotedTable}${columns} ${
-      'from' in copy ? 'FROM' : 'TO'
-    } ${
+    `COPY ${quotedTable}${columns} ${'from' in copy ? 'FROM' : 'TO'} ${
       typeof target === 'string'
         ? escapeString(target)
         : `PROGRAM ${escapeString(target.program)}`

--- a/packages/pqb/src/query/extra-features/data-transform/map.ts
+++ b/packages/pqb/src/query/extra-features/data-transform/map.ts
@@ -1,4 +1,8 @@
-import { Query, QueryReturnTypeAll, QueryReturnTypeOptional } from '../../query';
+import {
+  Query,
+  QueryReturnTypeAll,
+  QueryReturnTypeOptional,
+} from '../../query';
 import { Column } from '../../../columns/column';
 import { PickQueryReturnType } from '../../pick-query-types';
 import { RecordUnknown } from '../../../utils';

--- a/packages/pqb/src/query/extra-features/truncate/truncate.test.ts
+++ b/packages/pqb/src/query/extra-features/truncate/truncate.test.ts
@@ -1,4 +1,7 @@
-import { expectQueryNotMutated, User } from '../../../test-utils/pqb.test-utils';
+import {
+  expectQueryNotMutated,
+  User,
+} from '../../../test-utils/pqb.test-utils';
 import { expectSql } from 'test-utils';
 
 describe('truncate', () => {

--- a/packages/rake-db/src/generate/dbStructure.ts
+++ b/packages/rake-db/src/generate/dbStructure.ts
@@ -296,7 +296,7 @@ const viewsSql = `SELECT
       WHERE rew.ev_class = c.oid AND obj.oid <> c.oid
     ) t
   ) "deps",
-  right(substring(r.ev_action from ':hasRecursive \w'), 1)::bool AS "isRecursive",
+  right(substring(r.ev_action from ':hasRecursive \\w'), 1)::bool AS "isRecursive",
   array_to_json(c.reloptions) AS "with",
   (SELECT coalesce(json_agg(t), '[]') FROM (${columnsSql({
     schema: 'nc',

--- a/packages/rake-db/src/prompt.ts
+++ b/packages/rake-db/src/prompt.ts
@@ -9,7 +9,7 @@ const { stdin, stdout } = process;
 const visibleChars = (s: string) =>
   s.replace(
     // eslint-disable-next-line no-control-regex
-    /[\u001B\u009B][[\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\d\/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d\/#&.:=?%@~_]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PRZcf-ntqry=><~]))/g,
+    /[\u001B\u009B][[\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PRZcf-ntqry=><~]))/g,
     '',
   ).length;
 


### PR DESCRIPTION
I ran `pnpm eslint --fix .` to format everything, and fixed 3 outstanding errors.

One of them (the misquoted `\w`) was apparently a genuine bug.