### PR TITLE
Add missing exports of createDatabase, createSchema, etc.

### DIFF
--- a/.changeset/grumpy-sloths-raise.md
+++ b/.changeset/grumpy-sloths-raise.md
@@ -1,0 +1,5 @@
+---
+'rake-db': patch
+---
+
+Add missing exports of `createDatabase`, `createSchema`, etc.

--- a/packages/rake-db/src/index.ts
+++ b/packages/rake-db/src/index.ts
@@ -42,6 +42,14 @@ export type {
 } from './generate/structure-to-ast';
 export { makeFileVersion, writeMigrationFile } from './commands/new-migration';
 export {
+  createDatabase,
+  dropDatabase,
+  createSchema,
+  dropSchema,
+  createTable,
+  dropTable,
+} from './commands/create-or-drop';
+export {
   migrationConfigDefaults,
   makeRakeDbConfig,
   incrementIntermediateCaller,


### PR DESCRIPTION
The recently added `createDatabase`, `createSchema` and [other exports](https://orchid-orm.netlify.app/guide/migration-programmatic-use.html#creating-and-dropping) are not actually exported:

```
% node -e "import('orchid-orm/migrations').then(m => console.log(m.createSchema))"

undefined

% grep version node_modules/orchid-orm/package.json 
  "version": "1.62.3",
```

The PR adds the missing exports.