### PR TITLE
Fix onConflictDoNothing with soft-delete

### DIFF
--- a/.changeset/sharp-needles-applaud.md
+++ b/.changeset/sharp-needles-applaud.md
@@ -1,0 +1,5 @@
+---
+'pqb': patch
+---
+
+Fix `onConflictDoNothing` with soft-delete (#649)


### PR DESCRIPTION
Fix `onConflictDoNothing` with soft-delete by preventing invalid trailing `WHERE` (#649).

Includes a fix for one the old tests that asserted broken SQL.