### PR TITLE
Allow postgres-js connections to be reopened after close

### DIFF
--- a/.changeset/five-experts-behave.md
+++ b/.changeset/five-experts-behave.md
@@ -1,0 +1,5 @@
+---
+'pqb': patch
+---
+
+Allow postgres-js connections to be reopened after close (#656)

--- a/packages/pqb/src/adapters/postgres-js.test.ts
+++ b/packages/pqb/src/adapters/postgres-js.test.ts
@@ -135,6 +135,21 @@ describe('postgres-js', () => {
     expect(ssl.sql.options.ssl).toBe(true);
   });
 
+  it('should recreate client on close so it can be reused', async () => {
+    const adapter = new PostgresJsAdapter({
+      databaseURL: 'postgres://user:@host:123/db',
+    });
+    const { sql } = adapter;
+    const endSpy = jest.spyOn(sql, 'end').mockResolvedValue();
+
+    await adapter.close();
+
+    expect(endSpy).toHaveBeenCalled();
+    expect(adapter.sql).not.toBe(sql);
+
+    await adapter.sql.end();
+  });
+
   describe('search path', () => {
     it('should support setting a default schema via url parameters', async () => {
       const url = new URL(testDbOptions.databaseURL as string);

--- a/packages/pqb/src/query/db.test.ts
+++ b/packages/pqb/src/query/db.test.ts
@@ -10,7 +10,6 @@ import {
   testAdapter,
   testDb,
   testDbOptions,
-  testingWithPostgresJS,
   useTestDatabase,
 } from 'test-utils';
 import { raw } from './expressions/raw-sql';
@@ -25,18 +24,15 @@ import { QueryLogger } from 'pqb';
 import { orchidORMWithAdapter } from 'orchid-orm';
 
 describe('db connection', () => {
-  // not supported by postgres.js
-  if (!testingWithPostgresJS) {
-    it('should be able to open connection after closing it', async () => {
-      const db = createTestDb(testDbOptions);
+  it('should be able to open connection after closing it', async () => {
+    const db = createTestDb(testDbOptions);
 
-      await db.close();
+    await db.close();
 
-      await expect(db.adapter.query('SELECT 1')).resolves.not.toThrow();
+    await expect(db.adapter.query('SELECT 1')).resolves.not.toThrow();
 
-      await db.close();
-    });
-  }
+    await db.close();
+  });
 
   it('should support setting a searchPath via url parameters', async () => {
     const url = new URL(testDbOptions.databaseURL as string);

--- a/packages/pqb/src/testTransaction.test.ts
+++ b/packages/pqb/src/testTransaction.test.ts
@@ -1,4 +1,4 @@
-import { testDb, testingWithPostgresJS, useTestDatabase } from 'test-utils';
+import { testDb, useTestDatabase } from 'test-utils';
 import { User, userData } from './test-utils/pqb.test-utils';
 import { testTransaction } from './testTransaction';
 
@@ -43,13 +43,10 @@ describe('testTransaction', () => {
     });
   });
 
-  // Reopening a connection does not work with postgres-js
-  if (!testingWithPostgresJS) {
-    it('should support starting and closing multiple times', async () => {
-      await testTransaction.start(testDb);
-      await testTransaction.close(testDb);
-      await testTransaction.start(testDb);
-      await testTransaction.close(testDb);
-    });
-  }
+  it('should support starting and closing multiple times', async () => {
+    await testTransaction.start(testDb);
+    await testTransaction.close(testDb);
+    await testTransaction.start(testDb);
+    await testTransaction.close(testDb);
+  });
 });


### PR DESCRIPTION
Allow postgres-js connections to be reopened after close (fixes #656).