### PR TITLE
Add updateMany, updateManyBy methods (#668)

### DIFF
--- a/.changeset/new-scissors-retire.md
+++ b/.changeset/new-scissors-retire.md
@@ -1,0 +1,5 @@
+---
+'pqb': patch
+---
+
+Add `updateMany`, `updateManyOptional`, `updateManyBy`, `updateManyByOptional` (#668)

--- a/docs/src/guide/create-update-delete.md
+++ b/docs/src/guide/create-update-delete.md
@@ -963,11 +963,6 @@ await db.table
     { id: 2, name: 'Bob' },
   ])
   .set({ updatedBy: currentUser.id });
-
-// keys-only data + shared .set() — all records get the same values
-await db.table
-  .updateMany([{ id: 1 }, { id: 2 }, { id: 3 }])
-  .set({ active: false });
 ```
 
 ### updateManyOptional

--- a/docs/src/guide/create-update-delete.md
+++ b/docs/src/guide/create-update-delete.md
@@ -983,20 +983,17 @@ const count = await db.table.updateManyOptional([
 
 [//]: # 'has JSDoc'
 
-Like `updateMany`, but accepts key columns matching primary keys, unique columns, or compound unique constraints defined on the table.
+Like `updateMany`, but matches rows by a unique column or a compound unique constraint instead of the primary key.
 
 Throws [NotFoundError](/guide/error-handling) if any record is not found.
 Use `updateManyByOptional` to skip records with no matching key without throwing.
 
 ```ts
 // single unique column
-await db.table.updateManyBy(
-  ['email'],
-  [
-    { email: 'alice@test.com', name: 'Alice' },
-    { email: 'bob@test.com', name: 'Bob' },
-  ],
-);
+await db.table.updateManyBy('email', [
+  { email: 'alice@test.com', name: 'Alice' },
+  { email: 'bob@test.com', name: 'Bob' },
+]);
 
 // compound unique constraint
 await db.table.updateManyBy(
@@ -1012,13 +1009,10 @@ await db.table.updateManyBy(
 Same as `updateManyBy`, but skips records with no matching key rather than throwing.
 
 ```ts
-await db.table.updateManyByOptional(
-  ['email'],
-  [
-    { email: 'alice@test.com', name: 'Alice' },
-    { email: 'unknown@test.com', name: 'Ghost' },
-  ],
-);
+await db.table.updateManyByOptional('email', [
+  { email: 'alice@test.com', name: 'Alice' },
+  { email: 'unknown@test.com', name: 'Ghost' },
+]);
 ```
 
 ## upsert

--- a/docs/src/guide/create-update-delete.md
+++ b/docs/src/guide/create-update-delete.md
@@ -924,6 +924,107 @@ db.books
   .set({ authorName: (q) => q.ref('author.name') });
 ```
 
+### updateMany
+
+[//]: # 'has JSDoc'
+
+Updates multiple records with different per-row data in a single query.
+
+Each row must include the primary key and the columns to update.
+All rows must have the same set of non-key columns.
+
+Returns a count of updated records by default.
+Place `select` or `selectAll` before `updateMany` to return updated records.
+
+Throws [NotFoundError](/guide/error-handling) if any record is not found.
+Use `updateManyOptional` to update existing records without throwing.
+
+```ts
+// returns count of updated records
+const count = await db.table.updateMany([
+  { id: 1, name: 'Alice', age: 30 },
+  { id: 2, name: 'Bob', age: 25 },
+]);
+
+// returns array of updated records
+const records = await db.table.select('id', 'name').updateMany([
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+]);
+```
+
+`.set()` applies shared values to all rows.
+Per-row values take precedence over `.set()` values for the same column.
+
+```ts
+await db.table
+  .updateMany([
+    { id: 1, name: 'Alice' },
+    { id: 2, name: 'Bob' },
+  ])
+  .set({ updatedBy: currentUser.id });
+
+// keys-only data + shared .set() — all records get the same values
+await db.table
+  .updateMany([{ id: 1 }, { id: 2 }, { id: 3 }])
+  .set({ active: false });
+```
+
+### updateManyOptional
+
+[//]: # 'has JSDoc'
+
+Same as `updateMany`, but does **not** throw when some records are not found.
+
+```ts
+// updates what it can, doesn't throw for missing id: 999
+const count = await db.table.updateManyOptional([
+  { id: 1, name: 'Alice' },
+  { id: 999, name: 'Ghost' },
+]);
+```
+
+### updateManyBy
+
+[//]: # 'has JSDoc'
+
+Like `updateMany`, but accepts key columns matching primary keys, unique columns, or compound unique constraints defined on the table.
+
+Throws [NotFoundError](/guide/error-handling) if any record is not found.
+
+```ts
+// single unique column
+await db.table.updateManyBy(
+  ['email'],
+  [
+    { email: 'alice@test.com', name: 'Alice' },
+    { email: 'bob@test.com', name: 'Bob' },
+  ],
+);
+
+// compound unique constraint
+await db.table.updateManyBy(
+  ['firstName', 'lastName'],
+  [{ firstName: 'John', lastName: 'Doe', bio: 'updated' }],
+);
+```
+
+### updateManyByOptional
+
+[//]: # 'has JSDoc'
+
+Same as `updateManyBy`, but does **not** throw when some records are not found.
+
+```ts
+await db.table.updateManyByOptional(
+  ['email'],
+  [
+    { email: 'alice@test.com', name: 'Alice' },
+    { email: 'unknown@test.com', name: 'Ghost' },
+  ],
+);
+```
+
 ## upsert
 
 [//]: # 'has JSDoc'

--- a/docs/src/guide/create-update-delete.md
+++ b/docs/src/guide/create-update-delete.md
@@ -137,7 +137,7 @@ To perform custom actions before or after creating records, see `beforeCreate`, 
 
 `create*` and `insert*` methods require columns that are not nullable and don't have a default.
 
-Place `select`, or `get` before or after `create` or `insert` to specify returning columns:
+Use `select`, `selectAll`, `get`, or `pluck` alongside `create` or `insert` to specify returning columns:
 
 ```ts
 // to return only `id`, use get('id')
@@ -743,7 +743,7 @@ db.table
 
 By default, `update` will return a count of updated records.
 
-Place `select`, `selectAll`, or `get` before `update` to specify returning columns.
+Use `select`, `selectAll`, `get`, or `pluck` alongside `update` to specify returning columns.
 
 You need to provide `where`, `findBy`, or `find` conditions before calling `update`.
 To ensure that the whole table won't be updated by accident, updating without where conditions will result in TypeScript and runtime errors.
@@ -934,7 +934,7 @@ Each row must include the primary key and the columns to update.
 All rows must have the same set of non-key columns.
 
 Returns a count of updated records by default.
-Place `select` or `selectAll` before `updateMany` to return updated records.
+Use `select`, `selectAll`, `get`, or `pluck` alongside `updateMany` to return updated records.
 
 Throws [NotFoundError](/guide/error-handling) if any record is not found.
 Use `updateManyOptional` to update existing records without throwing.

--- a/docs/src/guide/create-update-delete.md
+++ b/docs/src/guide/create-update-delete.md
@@ -937,7 +937,7 @@ Returns a count of updated records by default.
 Use `select`, `selectAll`, `get`, or `pluck` alongside `updateMany` to return updated records.
 
 Throws [NotFoundError](/guide/error-handling) if any record is not found.
-Use `updateManyOptional` to update existing records without throwing.
+Use `updateManyOptional` to skip missing records without throwing.
 
 ```ts
 // returns count of updated records
@@ -969,7 +969,7 @@ await db.table
 
 [//]: # 'has JSDoc'
 
-Same as `updateMany`, but does **not** throw when some records are not found.
+Same as `updateMany`, but skips missing records rather than throwing.
 
 ```ts
 // updates what it can, doesn't throw for missing id: 999
@@ -986,6 +986,7 @@ const count = await db.table.updateManyOptional([
 Like `updateMany`, but accepts key columns matching primary keys, unique columns, or compound unique constraints defined on the table.
 
 Throws [NotFoundError](/guide/error-handling) if any record is not found.
+Use `updateManyByOptional` to skip records with no matching key without throwing.
 
 ```ts
 // single unique column
@@ -1008,7 +1009,7 @@ await db.table.updateManyBy(
 
 [//]: # 'has JSDoc'
 
-Same as `updateManyBy`, but does **not** throw when some records are not found.
+Same as `updateManyBy`, but skips records with no matching key rather than throwing.
 
 ```ts
 await db.table.updateManyByOptional(

--- a/docs/src/guide/create-update-delete.md
+++ b/docs/src/guide/create-update-delete.md
@@ -954,7 +954,7 @@ const records = await db.table.select('id', 'name').updateMany([
 ```
 
 `.set()` applies shared values to all rows.
-Per-row values take precedence over `.set()` values for the same column.
+`.set()` values take precedence over per-row values for the same column.
 
 ```ts
 await db.table

--- a/docs/src/guide/hooks.md
+++ b/docs/src/guide/hooks.md
@@ -68,6 +68,7 @@ they can be only set in the hooks.
 This works for all update and create methods, including
 [createOneFrom](/guide/create-update-delete.html#orcreate),
 [createMany](/guide/create-update-delete.html#createmany-insertmany),
+[updateMany](/guide/create-update-delete.html#updatemany),
 [orCreate](/guide/create-update-delete.html#orcreate),
 [upsert](/guide/create-update-delete.html#upsert).
 

--- a/docs/src/guide/query-methods.md
+++ b/docs/src/guide/query-methods.md
@@ -105,7 +105,7 @@ const result: TableType | undefined = await db.table.find(123);
 [//]: # 'has JSDoc'
 
 Finds a single unique record, throws [NotFoundError](/guide/error-handling) if not found.
-It accepts values of primary keys or unique indexes defined on the table.
+It accepts values of primary keys, unique columns, or compound unique constraints defined on the table.
 `findBy`'s argument type is a union of all possible sets of unique conditions.
 
 You can use `where(...).take()` for non-unique conditions.
@@ -119,7 +119,7 @@ await db.table.findBy({ key: 'value' });
 [//]: # 'has JSDoc'
 
 Finds a single unique record, returns `undefined` if not found.
-It accepts values of primary keys or unique indexes defined on the table.
+It accepts values of primary keys, unique columns, or compound unique constraints defined on the table.
 `findBy`'s argument type is a union of all possible sets of unique conditions.
 
 You can use `where(...).takeOptional()` for non-unique conditions.

--- a/packages/pqb/src/query/basic-features/mutate/create-from.ts
+++ b/packages/pqb/src/query/basic-features/mutate/create-from.ts
@@ -20,7 +20,7 @@ import {
   SetQueryReturnsColumn,
   SetValueQueryReturnsPluckColumn,
 } from '../../query';
-import { InsertQueryDataObjectValues, QueryData } from '../../query-data';
+import { QueryData } from '../../query-data';
 import { SubQueryForSql } from '../../sub-query/sub-query-for-sql';
 import { MaybeArray, RecordUnknown } from '../../../utils';
 import { _clone } from '../clone/clone';
@@ -132,7 +132,7 @@ export const getFromSelectColumns = (
 ): {
   columns: string[];
   queryColumnsCount: number;
-  values: InsertQueryDataObjectValues;
+  values: unknown[][];
 } => {
   if (!many && !queryTypeWithLimitOne[from.q.returnType as string]) {
     throw new Error(
@@ -156,7 +156,7 @@ export const getFromSelectColumns = (
   const queryColumnsCount = queryColumns.size;
   const allValues: unknown[][] = [];
   if (obj?.columns) {
-    for (const objectValues of obj.values as InsertQueryDataObjectValues) {
+    for (const objectValues of obj.values) {
       const values: unknown[] = [];
       allValues.push(values);
 

--- a/packages/pqb/src/query/basic-features/mutate/create.ts
+++ b/packages/pqb/src/query/basic-features/mutate/create.ts
@@ -658,6 +658,9 @@ export class QueryCreate {
   /**
    * `create` and `insert` create a single record.
    *
+   * Use `select`, `selectAll`, `get`, or `pluck` alongside `create` or `insert` to
+   * specify returning columns.
+   *
    * Each column may accept a specific value, a raw SQL, or a query that returns a single value.
    *
    * ```ts

--- a/packages/pqb/src/query/basic-features/mutate/insert.sql.ts
+++ b/packages/pqb/src/query/basic-features/mutate/insert.sql.ts
@@ -1,11 +1,7 @@
 import { pushWhereStatementSql } from '../where/where.sql';
 import { SelectAsValue, SelectItem, selectToSql } from '../select/select.sql';
 import { ToSQLCtx, ToSQLQuery } from '../../sql/to-sql';
-import {
-  InsertQueryDataObjectValues,
-  pushQueryValueImmutable,
-  QueryData,
-} from '../../query-data';
+import { pushQueryValueImmutable, QueryData } from '../../query-data';
 import { Db } from '../../db';
 import { RawSql } from '../../expressions/raw-sql';
 import { MAX_BINDING_PARAMS } from '../../sql/sql-constants';
@@ -233,7 +229,7 @@ export const makeInsertSql = (
     let batch: SingleSqlItem[] | undefined;
     const { skipBatchCheck } = ctx;
 
-    for (let i = 0; i < (values as InsertQueryDataObjectValues).length; i++) {
+    for (let i = 0; i < values.length; i++) {
       const topCteSize = getTopCteSize(ctx);
 
       ctx.skipBatchCheck = true;
@@ -242,7 +238,7 @@ export const makeInsertSql = (
         ctx,
         ctxValues,
         QueryClass,
-        (values as InsertQueryDataObjectValues)[i],
+        values[i],
         runtimeDefaults,
         quotedAs,
         hookSetSql,
@@ -447,7 +443,7 @@ const applySqlState = (
 const processHookSet = (
   ctx: ToSQLCtx,
   q: ToSQLQuery,
-  values: InsertQueryDataObjectValues,
+  values: unknown[][],
   hookCreateSet: RecordUnknown[],
   columns: string[],
   QueryClass: Db,
@@ -457,7 +453,7 @@ const processHookSet = (
   columns: string[];
   insertFrom?: SubQueryForSql;
   queryColumnsCount?: number;
-  values: InsertQueryDataObjectValues;
+  values: unknown[][];
 } => {
   const hookSet: RecordUnknown = {};
   for (const item of hookCreateSet) {
@@ -577,7 +573,7 @@ const processHookSet = (
           quotedAs,
         ),
       };
-      for (const row of values as InsertQueryDataObjectValues) {
+      for (const row of values) {
         row[i] = fromHook;
       }
     }

--- a/packages/pqb/src/query/basic-features/mutate/update.sql.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.sql.ts
@@ -274,6 +274,7 @@ const pushUpdateManySql = (
   isSubSql?: boolean,
 ): Sql => {
   const { shape } = q;
+  const quotedTable = `"${query.table || (q.from as string)}"`;
   const from = quoteTableWithSchema(query);
 
   // Collect .set() keys so they take precedence over per-row data.
@@ -290,42 +291,48 @@ const pushUpdateManySql = (
     }
   }
 
-  // 1. Build per-row SET, skipping columns overridden by .set()
+  // Build per-row SET + hookSet + perRowSkip
   const set: string[] = [];
+  const hookSet: RecordUnknown = {};
+  const hookUpdateSet = q.hookUpdateSet;
+  const mergedHookSet: RecordUnknown = hookUpdateSet ? {} : emptyObject;
+  const perRowSkip: RecordUnknown = hookUpdateSet ? {} : emptyObject;
+
   for (const col of updateMany.setColumns) {
+    // perRowSkip needs ALL setColumns unconditionally
+    if (hookUpdateSet) perRowSkip[col] = true;
+
     if (col in sharedKeys) continue;
+
     const column = shape[col];
     const dbName = column.data.name || col;
     set.push(`"${dbName}" = "v"."${dbName}"::${column.dataType}`);
+    hookSet[col] = true;
   }
 
-  // 2. Build hookSet for dedup; per-row columns only if not overridden
-  const hookSet: RecordUnknown = {};
-  for (const col of updateMany.setColumns) {
-    if (!(col in sharedKeys)) hookSet[col] = true;
-  }
-  if (q.hookUpdateSet) {
-    for (const item of q.hookUpdateSet) Object.assign(hookSet, item);
+  if (hookUpdateSet) {
+    for (const item of hookUpdateSet) {
+      Object.assign(hookSet, item);
+      Object.assign(mergedHookSet, item);
+    }
   }
 
-  // 3. Build shared SET from updateData (.set() values override per-row)
+  // Build shared SET from updateData (.set() values override per-row)
   if (q.updateData) {
     processData(ctx, query, set, q.updateData, hookSet, quotedAs);
   }
 
-  // 4. Build SET from hookUpdateSet, skipping per-row columns
-  if (q.hookUpdateSet) {
-    const perRowSkip: RecordUnknown = {};
-    for (const col of updateMany.setColumns) perRowSkip[col] = true;
-    const merged: RecordUnknown = {};
-    for (const item of q.hookUpdateSet) Object.assign(merged, item);
-    applySet(ctx, query, set, merged, perRowSkip, quotedAs);
+  // Build SET from hookUpdateSet, skipping per-row columns
+  if (hookUpdateSet) {
+    applySet(ctx, query, set, mergedHookSet, perRowSkip, quotedAs);
   }
 
-  // 5. Build FROM (VALUES ...) "v"("col1", "col2")
+  // Build FROM (VALUES ...) "v"("col1", "col2")
   const valueRows: string[] = [];
+  const quotedColumnNames: string[] = [];
   for (const row of updateMany.values) {
     const cells: string[] = [];
+    const isFirstRow = valueRows.length === 0;
     for (let i = 0; i < updateMany.columns.length; i++) {
       const col = updateMany.columns[i];
       const column = shape[col];
@@ -335,24 +342,21 @@ const pushUpdateManySql = (
       } else {
         cells.push(addValue(ctx.values, value));
       }
-      // Cast the first row's values so Postgres knows the types
-      if (valueRows.length === 0 && column) {
-        cells[cells.length - 1] += `::${column.dataType}`;
+      // Cast the first VALUES row so Postgres can infer column types,
+      // and collect the alias column names once.
+      if (isFirstRow) {
+        if (column) cells[cells.length - 1] += `::${column.dataType}`;
+        quotedColumnNames.push(`"${column?.data.name || col}"`);
       }
     }
     valueRows.push(`(${cells.join(', ')})`);
   }
 
-  const quotedColumnNames = updateMany.columns.map((col) => {
-    const column = shape[col];
-    return `"${column?.data.name || col}"`;
-  });
-
   const valuesSql = `(VALUES ${valueRows.join(
     ', ',
   )}) "v"(${quotedColumnNames.join(', ')})`;
 
-  // 6. Build WHERE: "table"."key" = "v"."key"::dataType + user conditions
+  // Build WHERE: "table"."key" = "v"."key"::dataType + user conditions
   let whereSql = updateMany.keys
     .map((key) => {
       const column = shape[key];
@@ -402,7 +406,7 @@ const pushUpdateManySql = (
 
     // Build the UPDATE statement
     ctx.sql.push(`UPDATE ${from}`);
-    if (`"${query.table || (q.from as string)}"` !== quotedAs) {
+    if (quotedTable !== quotedAs) {
       ctx.sql.push(quotedAs);
     }
     ctx.sql.push('SET', set.join(', '));

--- a/packages/pqb/src/query/basic-features/mutate/update.sql.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.sql.ts
@@ -276,28 +276,44 @@ const pushUpdateManySql = (
   const { shape } = q;
   const from = quoteTableWithSchema(query);
 
-  // 1. Build per-row SET: "col" = "v"."col"::dataType
+  // Collect .set() keys so they take precedence over per-row data.
+  // Function items are delayed injectors (e.g. updatedAt timestamps),
+  // not explicit .set() overrides — skip them here.
+  const sharedKeys: Record<string, true> = {};
+  if (q.updateData) {
+    for (const item of q.updateData) {
+      if (typeof item !== 'function') {
+        for (const key in item) {
+          if (item[key] !== undefined) sharedKeys[key] = true;
+        }
+      }
+    }
+  }
+
+  // 1. Build per-row SET, skipping columns overridden by .set()
   const set: string[] = [];
   for (const col of updateMany.setColumns) {
+    if (col in sharedKeys) continue;
     const column = shape[col];
     const dbName = column.data.name || col;
     set.push(`"${dbName}" = "v"."${dbName}"::${column.dataType}`);
   }
 
-  // 2. Build hookSet that includes per-row setColumns + hookUpdateSet
-  //    This handles per-row-wins-over-shared AND updatedAt dedup
+  // 2. Build hookSet for dedup; per-row columns only if not overridden
   const hookSet: RecordUnknown = {};
-  for (const col of updateMany.setColumns) hookSet[col] = true;
+  for (const col of updateMany.setColumns) {
+    if (!(col in sharedKeys)) hookSet[col] = true;
+  }
   if (q.hookUpdateSet) {
     for (const item of q.hookUpdateSet) Object.assign(hookSet, item);
   }
 
-  // 3. Build shared SET from updateData (.set() + updatedAt injector)
+  // 3. Build shared SET from updateData (.set() values override per-row)
   if (q.updateData) {
     processData(ctx, query, set, q.updateData, hookSet, quotedAs);
   }
 
-  // 4. Build shared SET from hookUpdateSet, skipping per-row columns
+  // 4. Build SET from hookUpdateSet, skipping per-row columns
   if (q.hookUpdateSet) {
     const perRowSkip: RecordUnknown = {};
     for (const col of updateMany.setColumns) perRowSkip[col] = true;

--- a/packages/pqb/src/query/basic-features/mutate/update.sql.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.sql.ts
@@ -27,7 +27,6 @@ import {
   newDelayedRelationSelect,
 } from '../select/delayed-relational-select';
 import { isExpression } from '../../expressions/expression';
-import { Column } from '../../../columns/column';
 
 export const pushUpdateSql = (
   ctx: ToSQLCtx,
@@ -280,7 +279,7 @@ const pushUpdateManySql = (
   // 1. Build per-row SET: "col" = "v"."col"::dataType
   const set: string[] = [];
   for (const col of updateMany.setColumns) {
-    const column = shape[col] as unknown as Column;
+    const column = shape[col];
     const dbName = column.data.name || col;
     set.push(`"${dbName}" = "v"."${dbName}"::${column.dataType}`);
   }
@@ -313,7 +312,7 @@ const pushUpdateManySql = (
     const cells: string[] = [];
     for (let i = 0; i < updateMany.columns.length; i++) {
       const col = updateMany.columns[i];
-      const column = shape[col] as unknown as Column;
+      const column = shape[col];
       const value = row[i];
       if (isExpression(value)) {
         cells.push(value.toSQL(ctx, quotedAs));
@@ -329,7 +328,7 @@ const pushUpdateManySql = (
   }
 
   const quotedColumnNames = updateMany.columns.map((col) => {
-    const column = shape[col] as unknown as Column;
+    const column = shape[col];
     return `"${column?.data.name || col}"`;
   });
 
@@ -337,14 +336,18 @@ const pushUpdateManySql = (
     ', ',
   )}) "v"(${quotedColumnNames.join(', ')})`;
 
-  // 6. Build WHERE: "table"."key" = "v"."key"::dataType
-  const whereParts: string[] = [];
-  for (const key of updateMany.keys) {
-    const column = shape[key] as unknown as Column;
-    const dbName = column.data.name || key;
-    whereParts.push(
-      `${quotedAs}."${dbName}" = "v"."${dbName}"::${column.dataType}`,
-    );
+  // 6. Build WHERE: "table"."key" = "v"."key"::dataType + user conditions
+  let whereSql = updateMany.keys
+    .map((key) => {
+      const column = shape[key];
+      const dbName = column.data.name || key;
+      return `${quotedAs}."${dbName}" = "v"."${dbName}"::${column.dataType}`;
+    })
+    .join(' AND ');
+
+  const userWhere = whereToSql(ctx, query, q, quotedAs);
+  if (userWhere) {
+    whereSql += ' AND ' + userWhere;
   }
 
   const delayedRelationSelect: DelayedRelationSelect | undefined =
@@ -367,7 +370,7 @@ const pushUpdateManySql = (
     );
 
     ctx.sql.push(`FROM ${from}, ${valuesSql}`);
-    ctx.sql.push('WHERE', whereParts.join(' AND '));
+    ctx.sql.push('WHERE', whereSql);
   } else {
     // For strict variants, set up CTE infrastructure
     if (updateMany.strict) {
@@ -388,7 +391,7 @@ const pushUpdateManySql = (
     }
     ctx.sql.push('SET', set.join(', '));
     ctx.sql.push('FROM', valuesSql);
-    ctx.sql.push('WHERE', whereParts.join(' AND '));
+    ctx.sql.push('WHERE', whereSql);
 
     const returning = makeReturningSql(
       ctx,

--- a/packages/pqb/src/query/basic-features/mutate/update.sql.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.sql.ts
@@ -278,20 +278,6 @@ const pushUpdateManySql = (
   const { shape } = q;
   const from = quoteTableWithSchema(query);
 
-  // Post-updateMany conflict guard (catches updateFrom/join chained AFTER updateMany)
-  if (q.updateFrom) {
-    throw new OrchidOrmInternalError(
-      query as unknown as Query,
-      'updateMany cannot be combined with updateFrom',
-    );
-  }
-  if (q.join) {
-    throw new OrchidOrmInternalError(
-      query as unknown as Query,
-      'updateMany cannot be combined with join',
-    );
-  }
-
   // For strict variants, set up CTE infrastructure BEFORE generating SQL
   if (updateMany.strict) {
     const wrapAs = setFreeTopCteAs(ctx);

--- a/packages/pqb/src/query/basic-features/mutate/update.sql.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.sql.ts
@@ -3,6 +3,7 @@ import { pushWhereStatementSql, whereToSql } from '../where/where.sql';
 import { ToSQLCtx, ToSQLQuery } from '../../sql/to-sql';
 import {
   QueryData,
+  UpdateManyQueryData,
   UpdateQueryDataItem,
   UpdateQueryDataObject,
 } from '../../query-data';
@@ -37,7 +38,7 @@ export const pushUpdateSql = (
   isSubSql?: boolean,
 ): Sql => {
   if (q.updateMany) {
-    return pushUpdateManySql(ctx, query, q, quotedAs, isSubSql);
+    return pushUpdateManySql(ctx, query, q, q.updateMany, quotedAs, isSubSql);
   }
 
   const quotedTable = `"${query.table || (q.from as string)}"`;
@@ -270,11 +271,10 @@ const pushUpdateManySql = (
   ctx: ToSQLCtx,
   query: ToSQLQuery,
   q: QueryData,
+  updateMany: UpdateManyQueryData,
   quotedAs: string,
   isSubSql?: boolean,
 ): Sql => {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const updateMany = q.updateMany!;
   const { shape } = q;
   const from = quoteTableWithSchema(query);
 

--- a/packages/pqb/src/query/basic-features/mutate/update.sql.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.sql.ts
@@ -27,7 +27,6 @@ import {
   newDelayedRelationSelect,
 } from '../select/delayed-relational-select';
 import { isExpression } from '../../expressions/expression';
-import { OrchidOrmInternalError } from '../../errors';
 import { Column } from '../../../columns/column';
 
 export const pushUpdateSql = (
@@ -278,18 +277,6 @@ const pushUpdateManySql = (
   const { shape } = q;
   const from = quoteTableWithSchema(query);
 
-  // For strict variants, set up CTE infrastructure BEFORE generating SQL
-  if (updateMany.strict) {
-    const wrapAs = setFreeTopCteAs(ctx);
-    ctx.wrapAs = wrapAs;
-    const cteHooks = (ctx.topCtx.cteHooks ??= {
-      hasSelect: true,
-      tableHooks: {},
-    });
-    cteHooks.hasSelect = true;
-    (cteHooks.ensureCount ??= {})[wrapAs] = updateMany.count;
-  }
-
   // 1. Build per-row SET: "col" = "v"."col"::dataType
   const set: string[] = [];
   for (const col of updateMany.setColumns) {
@@ -320,15 +307,7 @@ const pushUpdateManySql = (
     applySet(ctx, query, set, merged, perRowSkip, quotedAs);
   }
 
-  // 5. Empty SET check
-  if (!set.length) {
-    throw new OrchidOrmInternalError(
-      query as unknown as Query,
-      'updateMany: no columns to set. Provide non-key columns in data or use .set()',
-    );
-  }
-
-  // 6. Build FROM (VALUES ...) "v"("col1", "col2")
+  // 5. Build FROM (VALUES ...) "v"("col1", "col2")
   const valueRows: string[] = [];
   for (const row of updateMany.values) {
     const cells: string[] = [];
@@ -358,7 +337,7 @@ const pushUpdateManySql = (
     ', ',
   )}) "v"(${quotedColumnNames.join(', ')})`;
 
-  // 7. Build WHERE: "table"."key" = "v"."key"::dataType
+  // 6. Build WHERE: "table"."key" = "v"."key"::dataType
   const whereParts: string[] = [];
   for (const key of updateMany.keys) {
     const column = shape[key] as unknown as Column;
@@ -368,36 +347,65 @@ const pushUpdateManySql = (
     );
   }
 
-  // Build the UPDATE statement
-  ctx.sql.push(`UPDATE ${from}`);
-  if (`"${query.table || (q.from as string)}"` !== quotedAs) {
-    ctx.sql.push(quotedAs);
-  }
-  ctx.sql.push('SET', set.join(', '));
-  ctx.sql.push('FROM', valuesSql);
-  ctx.sql.push('WHERE', whereParts.join(' AND '));
-
-  // 8. Handle delayedRelationSelect
   const delayedRelationSelect: DelayedRelationSelect | undefined =
     q.selectRelation ? newDelayedRelationSelect(query) : undefined;
 
-  // 9. RETURNING via makeReturningSql with hookPurpose: 'Update'
-  const returning = makeReturningSql(
-    ctx,
-    query,
-    q,
-    quotedAs,
-    delayedRelationSelect,
-    'Update',
-    undefined,
-    isSubSql || !!ctx.topCtx.cteHooks,
-  );
-  if (returning) ctx.sql.push('RETURNING', returning);
+  // If nothing to set, make a SELECT query (like regular update does)
+  if (!set.length) {
+    if (!q.select) {
+      q.select = countSelect;
+    }
+
+    pushUpdateReturning(
+      ctx,
+      query,
+      q,
+      quotedAs,
+      'SELECT',
+      delayedRelationSelect,
+      isSubSql,
+    );
+
+    ctx.sql.push(`FROM ${from}, ${valuesSql}`);
+    ctx.sql.push('WHERE', whereParts.join(' AND '));
+  } else {
+    // For strict variants, set up CTE infrastructure
+    if (updateMany.strict) {
+      const wrapAs = setFreeTopCteAs(ctx);
+      ctx.wrapAs = wrapAs;
+      const cteHooks = (ctx.topCtx.cteHooks ??= {
+        hasSelect: true,
+        tableHooks: {},
+      });
+      cteHooks.hasSelect = true;
+      (cteHooks.ensureCount ??= {})[wrapAs] = updateMany.count;
+    }
+
+    // Build the UPDATE statement
+    ctx.sql.push(`UPDATE ${from}`);
+    if (`"${query.table || (q.from as string)}"` !== quotedAs) {
+      ctx.sql.push(quotedAs);
+    }
+    ctx.sql.push('SET', set.join(', '));
+    ctx.sql.push('FROM', valuesSql);
+    ctx.sql.push('WHERE', whereParts.join(' AND '));
+
+    const returning = makeReturningSql(
+      ctx,
+      query,
+      q,
+      quotedAs,
+      delayedRelationSelect,
+      'Update',
+      undefined,
+      isSubSql || !!ctx.topCtx.cteHooks,
+    );
+    if (returning) ctx.sql.push('RETURNING', returning);
+  }
 
   if (delayedRelationSelect) {
     ctx.topCtx.delayedRelationSelect = delayedRelationSelect;
   }
 
-  // makeSql handles CTE wrapping automatically for type='update' when cteHooks is set
   return makeSql(ctx, 'update', isSubSql);
 };

--- a/packages/pqb/src/query/basic-features/mutate/update.sql.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.sql.ts
@@ -11,7 +11,7 @@ import { selectToSql } from '../select/select.sql';
 import { countSelect } from '../../expressions/raw-sql';
 import { Query } from '../../query';
 import { processJoinItem } from '../join/join.sql';
-import { moveMutativeQueryToCte } from '../cte/cte.sql';
+import { moveMutativeQueryToCte, setFreeTopCteAs } from '../cte/cte.sql';
 import { SubQueryForSql } from '../../sub-query/sub-query-for-sql';
 import { pushLimitSQL } from '../limit-offset/limit-offset.sql';
 import { makeSql, quoteTableWithSchema, Sql } from '../../sql/sql';
@@ -26,6 +26,8 @@ import {
   newDelayedRelationSelect,
 } from '../select/delayed-relational-select';
 import { isExpression } from '../../expressions/expression';
+import { OrchidOrmInternalError } from '../../errors';
+import { Column } from '../../../columns/column';
 
 export const pushUpdateSql = (
   ctx: ToSQLCtx,
@@ -34,6 +36,10 @@ export const pushUpdateSql = (
   quotedAs: string,
   isSubSql?: boolean,
 ): Sql => {
+  if (q.updateMany) {
+    return pushUpdateManySql(ctx, query, q, quotedAs, isSubSql);
+  }
+
   const quotedTable = `"${query.table || (q.from as string)}"`;
   const from = quoteTableWithSchema(query);
 
@@ -258,4 +264,154 @@ const processValue = (
   }
 
   return addValue(ctx.values, value);
+};
+
+const pushUpdateManySql = (
+  ctx: ToSQLCtx,
+  query: ToSQLQuery,
+  q: QueryData,
+  quotedAs: string,
+  isSubSql?: boolean,
+): Sql => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const updateMany = q.updateMany!;
+  const { shape } = q;
+  const from = quoteTableWithSchema(query);
+
+  // Post-updateMany conflict guard (catches updateFrom/join chained AFTER updateMany)
+  if (q.updateFrom) {
+    throw new OrchidOrmInternalError(
+      query as unknown as Query,
+      'updateMany cannot be combined with updateFrom',
+    );
+  }
+  if (q.join) {
+    throw new OrchidOrmInternalError(
+      query as unknown as Query,
+      'updateMany cannot be combined with join',
+    );
+  }
+
+  // For strict variants, set up CTE infrastructure BEFORE generating SQL
+  if (updateMany.strict) {
+    const wrapAs = setFreeTopCteAs(ctx);
+    ctx.wrapAs = wrapAs;
+    const cteHooks = (ctx.topCtx.cteHooks ??= {
+      hasSelect: true,
+      tableHooks: {},
+    });
+    cteHooks.hasSelect = true;
+    (cteHooks.ensureCount ??= {})[wrapAs] = updateMany.count;
+  }
+
+  // 1. Build per-row SET: "col" = "v"."col"::dataType
+  const set: string[] = [];
+  for (const col of updateMany.setColumns) {
+    const column = shape[col] as unknown as Column;
+    const dbName = column.data.name || col;
+    set.push(`"${dbName}" = "v"."${dbName}"::${column.dataType}`);
+  }
+
+  // 2. Build hookSet that includes per-row setColumns + hookUpdateSet
+  //    This handles per-row-wins-over-shared AND updatedAt dedup
+  const hookSet: RecordUnknown = {};
+  for (const col of updateMany.setColumns) hookSet[col] = true;
+  if (q.hookUpdateSet) {
+    for (const item of q.hookUpdateSet) Object.assign(hookSet, item);
+  }
+
+  // 3. Build shared SET from updateData (.set() + updatedAt injector)
+  if (q.updateData) {
+    processData(ctx, query, set, q.updateData, hookSet, quotedAs);
+  }
+
+  // 4. Build shared SET from hookUpdateSet, skipping per-row columns
+  if (q.hookUpdateSet) {
+    const perRowSkip: RecordUnknown = {};
+    for (const col of updateMany.setColumns) perRowSkip[col] = true;
+    const merged: RecordUnknown = {};
+    for (const item of q.hookUpdateSet) Object.assign(merged, item);
+    applySet(ctx, query, set, merged, perRowSkip, quotedAs);
+  }
+
+  // 5. Empty SET check
+  if (!set.length) {
+    throw new OrchidOrmInternalError(
+      query as unknown as Query,
+      'updateMany: no columns to set. Provide non-key columns in data or use .set()',
+    );
+  }
+
+  // 6. Build FROM (VALUES ...) "v"("col1", "col2")
+  const valueRows: string[] = [];
+  for (const row of updateMany.values) {
+    const cells: string[] = [];
+    for (let i = 0; i < updateMany.columns.length; i++) {
+      const col = updateMany.columns[i];
+      const column = shape[col] as unknown as Column;
+      const value = row[i];
+      if (isExpression(value)) {
+        cells.push(value.toSQL(ctx, quotedAs));
+      } else {
+        cells.push(addValue(ctx.values, value));
+      }
+      // Cast the first row's values so Postgres knows the types
+      if (valueRows.length === 0 && column) {
+        cells[cells.length - 1] += `::${column.dataType}`;
+      }
+    }
+    valueRows.push(`(${cells.join(', ')})`);
+  }
+
+  const quotedColumnNames = updateMany.columns.map((col) => {
+    const column = shape[col] as unknown as Column;
+    return `"${column?.data.name || col}"`;
+  });
+
+  const valuesSql = `(VALUES ${valueRows.join(
+    ', ',
+  )}) "v"(${quotedColumnNames.join(', ')})`;
+
+  // 7. Build WHERE: "table"."key" = "v"."key"::dataType
+  const whereParts: string[] = [];
+  for (const key of updateMany.keys) {
+    const column = shape[key] as unknown as Column;
+    const dbName = column.data.name || key;
+    whereParts.push(
+      `${quotedAs}."${dbName}" = "v"."${dbName}"::${column.dataType}`,
+    );
+  }
+
+  // Build the UPDATE statement
+  ctx.sql.push(`UPDATE ${from}`);
+  if (`"${query.table || (q.from as string)}"` !== quotedAs) {
+    ctx.sql.push(quotedAs);
+  }
+  ctx.sql.push('SET', set.join(', '));
+  ctx.sql.push('FROM', valuesSql);
+  ctx.sql.push('WHERE', whereParts.join(' AND '));
+
+  // 8. Handle delayedRelationSelect
+  const delayedRelationSelect: DelayedRelationSelect | undefined =
+    q.selectRelation ? newDelayedRelationSelect(query) : undefined;
+
+  // 9. RETURNING via makeReturningSql with hookPurpose: 'Update'
+  const returning = makeReturningSql(
+    ctx,
+    query,
+    q,
+    quotedAs,
+    delayedRelationSelect,
+    'Update',
+    undefined,
+    isSubSql || !!ctx.topCtx.cteHooks,
+  );
+  if (returning) ctx.sql.push('RETURNING', returning);
+
+  if (delayedRelationSelect) {
+    ctx.topCtx.delayedRelationSelect = delayedRelationSelect;
+  }
+
+  // makeSql handles CTE wrapping automatically for type='update' when cteHooks is set
+  return makeSql(ctx, 'update', isSubSql);
 };

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -5,6 +5,7 @@ import {
   SnakeRecord,
   snakeSelectAll,
   User,
+  UserSoftDelete,
   Message,
   Profile,
   userData,
@@ -1363,6 +1364,34 @@ describe('updateMany', () => {
           WHERE "user"."id" = "v"."id"::int4
         `,
         ['shared-pass', 1, 'Alice'],
+      );
+    });
+
+    it('should support .where() conditions', () => {
+      expectSql(
+        User.where({ age: 18 })
+          .updateManyOptional([{ id: 1, name: 'Alice' }])
+          .toSQL(),
+        `
+          UPDATE "schema"."user"
+          SET "name" = "v"."name"::text, "updated_at" = now()
+          FROM (VALUES ($1::int4, $2::text)) "v"("id", "name")
+          WHERE "user"."id" = "v"."id"::int4 AND "user"."age" = $3
+        `,
+        [1, 'Alice', 18],
+      );
+    });
+
+    it('should apply softDelete filter', () => {
+      expectSql(
+        UserSoftDelete.updateManyOptional([{ id: 1, name: 'Alice' }]).toSQL(),
+        `
+          UPDATE "schema"."user"
+          SET "name" = "v"."name"::varchar
+          FROM (VALUES ($1::int4, $2::varchar)) "v"("id", "name")
+          WHERE "user"."id" = "v"."id"::int4 AND ("user"."deleted_at" IS NULL)
+        `,
+        [1, 'Alice'],
       );
     });
 

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -5,11 +5,13 @@ import {
   SnakeRecord,
   snakeSelectAll,
   User,
+  Message,
   Profile,
   userData,
   UserInsert,
   Product,
   userColumnsSql,
+  userTableColumnsSql,
 } from '../../../test-utils/pqb.test-utils';
 import {
   assertType,
@@ -1280,6 +1282,383 @@ describe('update', () => {
         `,
         ['name'],
       );
+    });
+  });
+});
+
+describe('updateMany', () => {
+  useTestDatabase();
+
+  describe('SQL shape', () => {
+    it('should generate UPDATE ... FROM (VALUES ...) for updateManyOptional', () => {
+      expectSql(
+        User.updateManyOptional([
+          { id: 1, name: 'Alice' },
+          { id: 2, name: 'Bob' },
+        ]).toSQL(),
+        `
+          UPDATE "schema"."user"
+          SET "name" = "v"."name"::text, "updated_at" = now()
+          FROM (VALUES ($1::int4, $2::text), ($3, $4)) "v"("id", "name")
+          WHERE "user"."id" = "v"."id"::int4
+        `,
+        [1, 'Alice', 2, 'Bob'],
+      );
+    });
+
+    it('should generate CTE for strict updateMany with select', () => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const columns = User.q.selectAllColumns!;
+      expectSql(
+        User.selectAll()
+          .updateMany([{ id: 1, name: 'Alice' }])
+          .toSQL(),
+        `
+          WITH q AS (
+            UPDATE "schema"."user"
+            SET "name" = "v"."name"::text, "updated_at" = now()
+            FROM (VALUES ($1::int4, $2::text)) "v"("id", "name")
+            WHERE "user"."id" = "v"."id"::int4
+            RETURNING ${userTableColumnsSql}
+          )
+          SELECT *, NULL FROM q
+          UNION ALL
+          SELECT ${columns.map(() => 'NULL').join(', ')},
+          json_build_object('#q',
+            CASE WHEN (SELECT count(*) FROM "q") < 1
+            THEN (SELECT 'not-found')::int END)
+        `,
+        [1, 'Alice'],
+      );
+    });
+
+    it('should NOT generate CTE for updateManyOptional', () => {
+      expectSql(
+        User.updateManyOptional([{ id: 1, name: 'Alice' }]).toSQL(),
+        `
+          UPDATE "schema"."user"
+          SET "name" = "v"."name"::text, "updated_at" = now()
+          FROM (VALUES ($1::int4, $2::text)) "v"("id", "name")
+          WHERE "user"."id" = "v"."id"::int4
+        `,
+        [1, 'Alice'],
+      );
+    });
+
+    it('should generate updateManyBy with explicit key', () => {
+      expectSql(
+        User.updateManyByOptional(
+          ['name'],
+          [{ name: 'Alice', password: 'new-pass' }],
+        ).toSQL(),
+        `
+          UPDATE "schema"."user"
+          SET "password" = "v"."password"::text, "updated_at" = now()
+          FROM (VALUES ($1::text, $2::text)) "v"("name", "password")
+          WHERE "user"."name" = "v"."name"::text
+        `,
+        ['Alice', 'new-pass'],
+      );
+    });
+
+    it('should support .set() chaining with per-row wins', () => {
+      expectSql(
+        User.updateManyOptional([{ id: 1, name: 'Alice' }])
+          .set({
+            name: 'Ignored',
+            password: 'shared-pass',
+          })
+          .toSQL(),
+        `
+          UPDATE "schema"."user"
+          SET "name" = "v"."name"::text, "password" = $1, "updated_at" = now()
+          FROM (VALUES ($2::int4, $3::text)) "v"("id", "name")
+          WHERE "user"."id" = "v"."id"::int4
+        `,
+        ['shared-pass', 1, 'Alice'],
+      );
+    });
+
+    it('should support keys-only data with .set()', () => {
+      expectSql(
+        User.updateManyOptional([{ id: 1 }, { id: 2 }])
+          .set({
+            name: 'shared-name',
+          })
+          .toSQL(),
+        `
+          UPDATE "schema"."user"
+          SET "name" = $1, "updated_at" = now()
+          FROM (VALUES ($2::int4), ($3)) "v"("id")
+          WHERE "user"."id" = "v"."id"::int4
+        `,
+        ['shared-name', 1, 2],
+      );
+    });
+
+    it('should generate CTE with RETURNING NULL in strict rowCount mode', () => {
+      expectSql(
+        User.updateMany([{ id: 1, name: 'Alice' }]).toSQL(),
+        `
+          WITH q AS (
+            UPDATE "schema"."user"
+            SET "name" = "v"."name"::text, "updated_at" = now()
+            FROM (VALUES ($1::int4, $2::text)) "v"("id", "name")
+            WHERE "user"."id" = "v"."id"::int4
+            RETURNING NULL
+          )
+          SELECT *, NULL FROM q
+          UNION ALL
+          SELECT NULL,
+          json_build_object('#q',
+            CASE WHEN (SELECT count(*) FROM "q") < 1
+            THEN (SELECT 'not-found')::int END)
+        `,
+        [1, 'Alice'],
+      );
+    });
+  });
+
+  describe('execution', () => {
+    it('should batch update records and return count', async () => {
+      const users = await User.select('id').createMany([
+        { ...userData, name: 'exec1' },
+        { ...userData, name: 'exec2' },
+      ]);
+
+      const count = await User.updateMany([
+        { id: users[0].id, name: 'updated1' },
+        { id: users[1].id, name: 'updated2' },
+      ]);
+
+      expect(count).toBe(2);
+
+      const updated = await User.where({ id: { in: users.map((u) => u.id) } })
+        .order('id')
+        .pluck('name');
+      expect(updated).toEqual(['updated1', 'updated2']);
+    });
+
+    it('should return records when select is used', async () => {
+      const users = await User.select('id').createMany([
+        { ...userData, name: 'sel1' },
+        { ...userData, name: 'sel2' },
+      ]);
+
+      const result = await User.select('id', 'name').updateMany([
+        { id: users[0].id, name: 'sel-upd1' },
+        { id: users[1].id, name: 'sel-upd2' },
+      ]);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r.name).sort()).toEqual([
+        'sel-upd1',
+        'sel-upd2',
+      ]);
+    });
+
+    it('should throw NotFoundError for strict variant when row is missing', async () => {
+      const user = await User.select('id').create({
+        ...userData,
+        name: 'strict-test',
+      });
+
+      await expect(
+        User.updateMany([
+          { id: user.id, name: 'ok' },
+          { id: 999999, name: 'missing' },
+        ]),
+      ).rejects.toThrow('Record is not found');
+    });
+
+    it('should NOT throw for optional variant when row is missing', async () => {
+      const user = await User.select('id').create({
+        ...userData,
+        name: 'optional-test',
+      });
+
+      const count = await User.updateManyOptional([
+        { id: user.id, name: 'ok-updated' },
+        { id: 999999, name: 'missing' },
+      ]);
+
+      expect(count).toBe(1);
+    });
+  });
+
+  describe('validation', () => {
+    it('should throw on empty effective SET when no .set() is used', () => {
+      // Use a table without timestamps — User has updatedAt auto-set which fills SET
+      const NoTimestamps = testDb(
+        'no_ts',
+        (t) => ({
+          id: t.identity().primaryKey(),
+          name: t.string(),
+        }),
+        undefined,
+        { schema: () => 'schema' },
+      );
+      expect(() => NoTimestamps.updateMany([{ id: 1 }]).toSQL()).toThrow(
+        'no columns to set',
+      );
+    });
+
+    it('should throw on duplicate keys', () => {
+      expect(() =>
+        User.updateMany([
+          { id: 1, name: 'a' },
+          { id: 1, name: 'b' },
+        ]),
+      ).toThrow('Duplicate key');
+    });
+
+    it('should throw on undefined key value', () => {
+      expect(() =>
+        User.updateMany([{ id: undefined as unknown as number, name: 'a' }]),
+      ).toThrow('undefined or null');
+    });
+
+    it('should ignore undefined fields in all rows', () => {
+      expectSql(
+        User.updateMany([
+          { id: 1, name: 'Alice', password: undefined },
+          { id: 2, name: 'Bob', password: undefined },
+        ]).toSQL(),
+        `
+          WITH q AS (
+            UPDATE "schema"."user"
+            SET "name" = "v"."name"::text, "updated_at" = now()
+            FROM (VALUES ($1::int4, $2::text), ($3, $4)) "v"("id", "name")
+            WHERE "user"."id" = "v"."id"::int4
+            RETURNING NULL
+          )
+          SELECT *, NULL FROM q
+          UNION ALL
+          SELECT NULL,
+          json_build_object('#q',
+            CASE WHEN (SELECT count(*) FROM "q") < 2
+            THEN (SELECT 'not-found')::int END)
+        `,
+        [1, 'Alice', 2, 'Bob'],
+      );
+    });
+
+    it('should throw when undefined field is inconsistent across rows', () => {
+      expect(() =>
+        User.updateMany([
+          { id: 1, name: 'a', password: 'p' },
+          { id: 2, name: 'b', password: undefined },
+        ]),
+      ).toThrow('different columns');
+    });
+
+    it('should throw on rows with different columns', () => {
+      expect(() =>
+        User.updateMany([
+          { id: 1, name: 'a' },
+          { id: 2, name: 'b', password: 'p' },
+        ]),
+      ).toThrow('different columns');
+    });
+
+    it('should throw on inconsistent rows even with .set() covering the gap', () => {
+      expect(() =>
+        User.updateMany([
+          { id: 1, name: 'a', age: 18 },
+          { id: 2, name: 'b' },
+        ]).set({ age: 20 }),
+      ).toThrow('different columns');
+    });
+
+    it('should throw on readOnly column in updateMany data', () => {
+      expect(() =>
+        TableWithReadOnly.updateMany([
+          // @ts-expect-error value is readOnly
+          { id: 1, key: 'a', value: 42 },
+        ]),
+      ).toThrow('Trying to update a readonly column');
+    });
+
+    it('should return empty for empty data', async () => {
+      const count = await User.updateMany([]);
+      expect(count).toBe(0);
+
+      const result = await User.selectAll().updateMany([]);
+      expect(result).toEqual([]);
+    });
+
+    it('should throw when combined with updateFrom', () => {
+      expect(() =>
+        User.updateFrom(
+          () => Profile,
+          (q) => q.on('userId', 'user.id'),
+        ).updateMany([{ id: 1, name: 'a' }]),
+      ).toThrow('updateMany cannot be combined with updateFrom');
+    });
+
+    it('should throw when combined with join', () => {
+      expect(() =>
+        User.join(Profile, (q) => q.on('userId', 'user.id')).updateMany([
+          { id: 1, name: 'a' },
+        ]),
+      ).toThrow('updateMany cannot be combined with join');
+    });
+
+    it('should throw on null key value', () => {
+      expect(() =>
+        User.updateMany([{ id: null as unknown as number, name: 'a' }]),
+      ).toThrow('undefined or null');
+    });
+
+    it('should throw on expression as key value', () => {
+      expect(() =>
+        User.updateMany([{ id: sql`1` as never, name: 'a' }]),
+      ).toThrow('must be a concrete value, not an expression');
+    });
+
+    it('should support expression values inside VALUES', () => {
+      expectSql(
+        User.updateManyOptional([
+          { id: 1, name: sql`'expr'` as never },
+        ]).toSQL(),
+        `
+          UPDATE "schema"."user"
+          SET "name" = "v"."name"::text, "updated_at" = now()
+          FROM (VALUES ($1::int4, 'expr'::text)) "v"("id", "name")
+          WHERE "user"."id" = "v"."id"::int4
+        `,
+        [1],
+      );
+    });
+
+    it('should encode values with column.data.encode', () => {
+      expectSql(
+        Message.updateManyOptional([{ id: 1, meta: { foo: 1 } }]).toSQL(),
+        `
+          UPDATE "schema"."message"
+          SET "meta" = "v"."meta"::jsonb, "updated_at" = now()
+          FROM (VALUES ($1::int4, $2::jsonb)) "v"("id", "meta")
+          WHERE "message"."id" = "v"."id"::int4
+        `,
+        [1, '{"foo":1}'],
+      );
+    });
+  });
+
+  describe('types', () => {
+    it('should return number by default', () => {
+      const q = User.updateMany([{ id: 1, name: 'a' }]);
+      assertType<Awaited<typeof q>, number>();
+    });
+
+    it('should return array when select is used', () => {
+      const q = User.select('id', 'name').updateMany([{ id: 1, name: 'a' }]);
+      assertType<Awaited<typeof q>, { id: number; name: string }[]>();
+    });
+
+    it('should map one returnType to all', () => {
+      const q = User.selectAll().updateMany([{ id: 1, name: 'a' }]);
+      assertType<Awaited<typeof q>, (typeof User.outputType)[]>();
     });
   });
 });

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -1438,6 +1438,22 @@ describe('updateMany', () => {
       expect(updated).toEqual(['updated1', 'updated2']);
     });
 
+    it('should return void with exec', async () => {
+      const user = await User.select('id').create({
+        ...userData,
+        name: 'exec-void',
+      });
+
+      const result = await User.updateManyOptional([
+        { id: user.id, name: 'exec-void-updated' },
+      ]).exec();
+
+      expect(result).toBe(undefined);
+
+      const updated = await User.find(user.id).get('name');
+      expect(updated).toBe('exec-void-updated');
+    });
+
     it('should return records when select is used', async () => {
       const users = await User.select('id').createMany([
         { ...userData, name: 'sel1' },
@@ -1619,6 +1635,21 @@ describe('updateMany', () => {
           WHERE "user"."id" = "v"."id"::int4
         `,
         [1],
+      );
+    });
+
+    it('should not add RETURNING with exec', () => {
+      expectSql(
+        User.updateManyOptional([{ id: 1, name: 'a' }])
+          .exec()
+          .toSQL(),
+        `
+          UPDATE "schema"."user"
+          SET "name" = "v"."name"::text, "updated_at" = now()
+          FROM (VALUES ($1::int4, $2::text)) "v"("id", "name")
+          WHERE "user"."id" = "v"."id"::int4
+        `,
+        [1, 'a'],
       );
     });
 

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -1527,16 +1527,32 @@ describe('updateMany', () => {
         { ...userData, name: 'sel2' },
       ]);
 
-      const result = await User.select('id', 'name').updateMany([
-        { id: users[0].id, name: 'sel-upd1' },
-        { id: users[1].id, name: 'sel-upd2' },
+      const result = await User.select('id', 'name')
+        .updateMany([
+          { id: users[0].id, name: 'sel-upd1' },
+          { id: users[1].id, name: 'sel-upd2' },
+        ])
+        .order('name');
+
+      expect(result.map((r) => r.name)).toEqual(['sel-upd1', 'sel-upd2']);
+    });
+
+    // RETURNING must qualify columns with the table name,
+    // otherwise "id" is ambiguous between "user"."id" and "v"."id".
+    it('should selectAll without ambiguous column reference', async () => {
+      const users = await User.select('id').createMany([
+        { ...userData, name: 'amb1' },
+        { ...userData, name: 'amb2' },
       ]);
 
-      expect(result).toHaveLength(2);
-      expect(result.map((r) => r.name).sort()).toEqual([
-        'sel-upd1',
-        'sel-upd2',
-      ]);
+      const result = await User.selectAll()
+        .updateMany([
+          { id: users[0].id, name: 'amb-upd1' },
+          { id: users[1].id, name: 'amb-upd2' },
+        ])
+        .order('name');
+
+      expect(result.map((r) => r.name)).toEqual(['amb-upd1', 'amb-upd2']);
     });
 
     it('should throw NotFoundError for strict variant when row is missing', async () => {

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -1382,13 +1382,28 @@ describe('updateMany', () => {
       );
     });
 
-    it('should support .set() chaining with per-row wins', () => {
+    it('should let .set() override per-row columns', () => {
       expectSql(
         User.updateManyOptional([{ id: 1, name: 'Alice' }])
           .set({
-            name: 'Ignored',
+            name: 'Override',
             password: 'shared-pass',
           })
+          .toSQL(),
+        `
+          UPDATE "schema"."user"
+          SET "name" = $1, "password" = $2, "updated_at" = now()
+          FROM (VALUES ($3::int4, $4::text)) "v"("id", "name")
+          WHERE "user"."id" = "v"."id"::int4
+        `,
+        ['Override', 'shared-pass', 1, 'Alice'],
+      );
+    });
+
+    it('should not remove per-row column when .set() has undefined', () => {
+      expectSql(
+        User.updateManyOptional([{ id: 1, name: 'Alice' }])
+          .set({ name: undefined, password: 'shared-pass' })
           .toSQL(),
         `
           UPDATE "schema"."user"

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -1350,12 +1350,11 @@ describe('updateMany', () => {
       );
     });
 
-    it('should generate updateManyBy with explicit key', () => {
+    it('should generate updateManyBy with a string key', () => {
       expectSql(
-        User.updateManyByOptional(
-          ['name'],
-          [{ name: 'Alice', password: 'new-pass' }],
-        ).toSQL(),
+        User.updateManyByOptional('name', [
+          { name: 'Alice', password: 'new-pass' },
+        ]).toSQL(),
         `
           UPDATE "schema"."user"
           SET "password" = "v"."password"::text, "updated_at" = now()
@@ -1363,6 +1362,23 @@ describe('updateMany', () => {
           WHERE "user"."name" = "v"."name"::text
         `,
         ['Alice', 'new-pass'],
+      );
+    });
+
+    it('should generate updateManyBy with a tuple key', () => {
+      expectSql(
+        UniqueTable.updateManyByOptional(
+          ['thirdColumn', 'fourthColumn'],
+          [{ thirdColumn: 'a', fourthColumn: 1, one: 'updated' }],
+        ).toSQL(),
+        `
+          UPDATE "schema"."uniqueTable"
+          SET "one" = "v"."one"::text
+          FROM (VALUES ($1::text, $2::int4, $3::text)) "v"("third_column", "fourth_column", "one")
+          WHERE "uniqueTable"."third_column" = "v"."third_column"::text
+            AND "uniqueTable"."fourth_column" = "v"."fourth_column"::int4
+        `,
+        ['a', 1, 'updated'],
       );
     });
 

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -1430,6 +1430,25 @@ describe('updateMany', () => {
       );
     });
 
+    it('should support whereExists', () => {
+      expectSql(
+        User.whereExists(Message, 'authorId', 'id')
+          .updateManyOptional([{ id: 1, name: 'Alice' }])
+          .toSQL(),
+        `
+          UPDATE "schema"."user"
+          SET "name" = "v"."name"::text, "updated_at" = now()
+          FROM (VALUES ($1::int4, $2::text)) "v"("id", "name")
+          WHERE "user"."id" = "v"."id"::int4
+            AND EXISTS (
+              SELECT 1 FROM "schema"."message"
+              WHERE "message"."author_id" = "user"."id"
+            )
+        `,
+        [1, 'Alice'],
+      );
+    });
+
     it('should apply softDelete filter', () => {
       expectSql(
         UserSoftDelete.updateManyOptional([{ id: 1, name: 'Alice' }]).toSQL(),

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -1366,23 +1366,6 @@ describe('updateMany', () => {
       );
     });
 
-    it('should support keys-only data with .set()', () => {
-      expectSql(
-        User.updateManyOptional([{ id: 1 }, { id: 2 }])
-          .set({
-            name: 'shared-name',
-          })
-          .toSQL(),
-        `
-          UPDATE "schema"."user"
-          SET "name" = $1, "updated_at" = now()
-          FROM (VALUES ($2::int4), ($3)) "v"("id")
-          WHERE "user"."id" = "v"."id"::int4
-        `,
-        ['shared-name', 1, 2],
-      );
-    });
-
     it('should generate CTE with RETURNING NULL in strict rowCount mode', () => {
       expectSql(
         User.updateMany([{ id: 1, name: 'Alice' }]).toSQL(),
@@ -1473,23 +1456,46 @@ describe('updateMany', () => {
     });
   });
 
-  describe('validation', () => {
-    it('should throw on empty effective SET when no .set() is used', () => {
-      // Use a table without timestamps — User has updatedAt auto-set which fills SET
-      const NoTimestamps = testDb(
-        'no_ts',
-        (t) => ({
-          id: t.identity().primaryKey(),
-          name: t.string(),
-        }),
-        undefined,
-        { schema: () => 'schema' },
-      );
-      expect(() => NoTimestamps.updateMany([{ id: 1 }]).toSQL()).toThrow(
-        'no columns to set',
+  describe('fallback to select', () => {
+    const User = testDb(
+      'user',
+      (t) => ({
+        id: t.identity().primaryKey(),
+        name: t.string(),
+      }),
+      undefined,
+      { schema: () => 'schema' },
+    );
+
+    it('should select count when nothing to update', () => {
+      expectSql(
+        User.updateMany([{ id: 1 }, { id: 2 }]).toSQL(),
+        `
+          SELECT count(*) FROM "schema"."user",
+          (VALUES ($1::int4), ($2)) "v"("id")
+          WHERE "user"."id" = "v"."id"::int4
+        `,
+        [1, 2],
       );
     });
 
+    it('should select columns when nothing to update', () => {
+      expectSql(
+        User.select('id', 'name')
+          .updateMany([{ id: 1 }, { id: 2 }])
+          .toSQL(),
+        `
+          SELECT "user"."id", "user"."name"
+          FROM "schema"."user",
+          (VALUES ($1::int4), ($2)) "v"("id")
+          WHERE "user"."id" = "v"."id"::int4
+        `,
+        [1, 2],
+      );
+    });
+  });
+
+  describe('validation', () => {
     it('should throw on duplicate keys', () => {
       expect(() =>
         User.updateMany([

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -1499,12 +1499,6 @@ describe('updateMany', () => {
       ).toThrow('Duplicate key');
     });
 
-    it('should throw on undefined key value', () => {
-      expect(() =>
-        User.updateMany([{ id: undefined as unknown as number, name: 'a' }]),
-      ).toThrow('undefined or null');
-    });
-
     it('should ignore undefined fields in all rows', () => {
       expectSql(
         User.updateMany([
@@ -1572,29 +1566,6 @@ describe('updateMany', () => {
 
       const result = await User.selectAll().updateMany([]);
       expect(result).toEqual([]);
-    });
-
-    it('should throw when combined with updateFrom', () => {
-      expect(() =>
-        User.updateFrom(
-          () => Profile,
-          (q) => q.on('userId', 'user.id'),
-        ).updateMany([{ id: 1, name: 'a' }]),
-      ).toThrow('updateMany cannot be combined with updateFrom');
-    });
-
-    it('should throw when combined with join', () => {
-      expect(() =>
-        User.join(Profile, (q) => q.on('userId', 'user.id')).updateMany([
-          { id: 1, name: 'a' },
-        ]),
-      ).toThrow('updateMany cannot be combined with join');
-    });
-
-    it('should throw on null key value', () => {
-      expect(() =>
-        User.updateMany([{ id: null as unknown as number, name: 'a' }]),
-      ).toThrow('undefined or null');
     });
 
     it('should throw on expression as key value', () => {

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -1611,9 +1611,7 @@ describe('updateMany', () => {
 
     it('should support expression values inside VALUES', () => {
       expectSql(
-        User.updateManyOptional([
-          { id: 1, name: sql`'expr'` as never },
-        ]).toSQL(),
+        User.updateManyOptional([{ id: 1, name: sql`'expr'` }]).toSQL(),
         `
           UPDATE "schema"."user"
           SET "name" = "v"."name"::text, "updated_at" = now()

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -11,6 +11,7 @@ import {
   userData,
   UserInsert,
   Product,
+  UniqueTable,
   userColumnsSql,
   userTableColumnsSql,
 } from '../../../test-utils/pqb.test-utils';
@@ -1304,6 +1305,22 @@ describe('updateMany', () => {
           WHERE "user"."id" = "v"."id"::int4
         `,
         [1, 'Alice', 2, 'Bob'],
+      );
+    });
+
+    it('should support composite primary keys', () => {
+      expectSql(
+        UniqueTable.updateManyOptional([
+          { id: 1, one: 'a', thirdColumn: 'x' },
+          { id: 2, one: 'b', thirdColumn: 'y' },
+        ]).toSQL(),
+        `
+          UPDATE "schema"."uniqueTable"
+          SET "third_column" = "v"."third_column"::text
+          FROM (VALUES ($1::int4, $2::text, $3::text), ($4, $5, $6)) "v"("id", "one", "third_column")
+          WHERE "uniqueTable"."id" = "v"."id"::int4 AND "uniqueTable"."one" = "v"."one"::text
+        `,
+        [1, 'a', 'x', 2, 'b', 'y'],
       );
     });
 

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -1332,19 +1332,6 @@ describe('updateMany', () => {
       );
     });
 
-    it('should NOT generate CTE for updateManyOptional', () => {
-      expectSql(
-        User.updateManyOptional([{ id: 1, name: 'Alice' }]).toSQL(),
-        `
-          UPDATE "schema"."user"
-          SET "name" = "v"."name"::text, "updated_at" = now()
-          FROM (VALUES ($1::int4, $2::text)) "v"("id", "name")
-          WHERE "user"."id" = "v"."id"::int4
-        `,
-        [1, 'Alice'],
-      );
-    });
-
     it('should generate updateManyBy with explicit key', () => {
       expectSql(
         User.updateManyByOptional(

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -164,24 +164,32 @@ type UpdateManyBySelf = UpdateSelf &
   PickQueryResultReturnTypeUniqueColumns &
   PickQueryUniqueProperties;
 
-// Allow Expression as an alternative value for each column in updateMany data
-type InputTypeOrExpression<InputType> = {
-  [K in keyof InputType]: InputType[K] | Expression;
-};
-
 // Data type for updateMany / updateManyOptional (PK-based)
 type UpdateManyData<T extends UpdateSelf> = (ShapePrimaryKeyQueryTypes<
   T['shape']
-> &
-  Partial<InputTypeOrExpression<T['inputType']>>)[];
+> & {
+  [P in keyof T['inputType']]?: T['inputType'][P] | Expression;
+})[];
+
+// Valid key tuples for updateManyBy / updateManyByOptional
+type UpdateManyByKeys<T extends UpdateManyBySelf> =
+  | [T['internal']['uniqueColumnNames']]
+  | T['internal']['uniqueColumnTuples'];
+
+// Extract key column names from a Keys tuple
+type UpdateManyByKeyColumns<Keys> = Keys extends unknown[]
+  ? Keys[number] & string
+  : never;
 
 // Data type for updateManyBy / updateManyByOptional (custom keys)
-type UpdateManyByData<T extends UpdateSelf, K extends string> = (Required<
-  Pick<T['inputType'], K & keyof T['inputType']>
-> &
-  Partial<
-    Omit<InputTypeOrExpression<T['inputType']>, K & keyof T['inputType']>
-  >)[];
+// Inlined to minimize mapped type instantiations
+type UpdateManyByData<T extends UpdateSelf, K extends string> = ({
+  [P in K & keyof T['inputType']]-?: T['inputType'][P];
+} & {
+  [P in keyof T['inputType'] as P extends K ? never : P]?:
+    | T['inputType'][P]
+    | Expression;
+})[];
 
 // Return type for updateMany/updateManyBy — mirrors InsertManyResult
 type UpdateManyResult<T extends UpdateSelf> = T['__hasSelect'] extends true
@@ -977,10 +985,8 @@ export class QueryUpdate {
    */
   updateManyBy<
     T extends UpdateManyBySelf,
-    Keys extends
-      | readonly [T['internal']['uniqueColumnNames']]
-      | T['internal']['uniqueColumnTuples'],
-    K extends string = Keys extends readonly (infer E)[] ? E & string : never,
+    Keys extends UpdateManyByKeys<T>,
+    K extends string = UpdateManyByKeyColumns<Keys>,
   >(
     this: T,
     keys: Keys,
@@ -1006,10 +1012,8 @@ export class QueryUpdate {
    */
   updateManyByOptional<
     T extends UpdateManyBySelf,
-    Keys extends
-      | readonly [T['internal']['uniqueColumnNames']]
-      | T['internal']['uniqueColumnTuples'],
-    K extends string = Keys extends readonly (infer E)[] ? E & string : never,
+    Keys extends UpdateManyByKeys<T>,
+    K extends string = UpdateManyByKeyColumns<Keys>,
   >(
     this: T,
     keys: Keys,

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -198,7 +198,7 @@ const _queryUpdateMany = <T extends UpdateSelf>(
     }
   }
 
-  // Normalize return type (must happen before .none() for empty data)
+  // Normalize return type
   q.type = 'update';
   const returnCount = !q.select;
   if (returnCount) {

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -918,7 +918,7 @@ export class QueryUpdate {
    * ```
    *
    * `.set()` applies shared values to all rows.
-   * Per-row values take precedence over `.set()` values for the same column.
+   * `.set()` values take precedence over per-row values for the same column.
    *
    * ```ts
    * await db.table

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -886,9 +886,6 @@ export class QueryUpdate {
    * Throws {@link NotFoundError} if any record is not found.
    * Use {@link updateManyOptional} to update existing records without throwing.
    *
-   * `.set()` applies shared values to all rows.
-   * Per-row values take precedence over `.set()` values for the same column.
-   *
    * ```ts
    * // returns count of updated records
    * const count = await db.table.updateMany([
@@ -901,6 +898,18 @@ export class QueryUpdate {
    *   { id: 1, name: 'Alice' },
    *   { id: 2, name: 'Bob' },
    * ]);
+   * ```
+   *
+   * `.set()` applies shared values to all rows.
+   * Per-row values take precedence over `.set()` values for the same column.
+   *
+   * ```ts
+   * await db.table
+   *   .updateMany([
+   *     { id: 1, name: 'Alice' },
+   *     { id: 2, name: 'Bob' },
+   *   ])
+   *   .set({ updatedBy: currentUser.id });
    * ```
    */
   updateMany<

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -60,8 +60,6 @@ export interface UpdateSelf
     PickQueryHasSelect,
     PickQueryHasWhere {}
 
-interface UpdateManySelf extends UpdateSelf, PickQuerySinglePrimaryKey {}
-
 // Type of argument for `update` and `updateOrThrow`
 //
 // It maps the `inputType` of a table into object with column values.
@@ -159,10 +157,33 @@ type ShapePrimaryKeyQueryTypes<Shape extends Column.QueryColumns> = {
     : never]: Shape[K]['queryType'];
 };
 
+export interface UpdateManySelf extends UpdateSelf, PickQuerySinglePrimaryKey {}
+
+// `type` instead of `interface`: PickQueryResultReturnTypeUniqueColumns and
+// PickQueryUniqueProperties both declare `internal` with different shapes,
+// which `interface extends` cannot merge.
+type UpdateManyBySelf = UpdateSelf &
+  PickQueryResultReturnTypeUniqueColumns &
+  PickQueryUniqueProperties;
+
 // Allow Expression as an alternative value for each column in updateMany data
 type InputTypeOrExpression<InputType> = {
   [K in keyof InputType]: InputType[K] | Expression;
 };
+
+// Data type for updateMany / updateManyOptional (PK-based)
+type UpdateManyData<T extends UpdateManySelf> = (ShapePrimaryKeyQueryTypes<
+  T['shape']
+> &
+  Partial<InputTypeOrExpression<T['inputType']>>)[];
+
+// Data type for updateManyBy / updateManyByOptional (custom keys)
+type UpdateManyByData<T extends UpdateSelf, K extends string> = (Required<
+  Pick<T['inputType'], K & keyof T['inputType']>
+> &
+  Partial<
+    Omit<InputTypeOrExpression<T['inputType']>, K & keyof T['inputType']>
+  >)[];
 
 // Return type for updateMany/updateManyBy — mirrors InsertManyResult
 type UpdateManyResult<T extends UpdateSelf> = T['__hasSelect'] extends true
@@ -902,8 +923,7 @@ export class QueryUpdate {
    */
   updateMany<T extends UpdateManySelf>(
     this: T,
-    data: (ShapePrimaryKeyQueryTypes<T['shape']> &
-      Partial<InputTypeOrExpression<T['inputType']>>)[],
+    data: UpdateManyData<T>,
   ): UpdateManyResult<T> & QueryHasWhere {
     const q = _clone(this) as unknown as Query;
     const pk = q.internal.singlePrimaryKey as string;
@@ -928,8 +948,7 @@ export class QueryUpdate {
    */
   updateManyOptional<T extends UpdateManySelf>(
     this: T,
-    data: (ShapePrimaryKeyQueryTypes<T['shape']> &
-      Partial<InputTypeOrExpression<T['inputType']>>)[],
+    data: UpdateManyData<T>,
   ): UpdateManyResult<T> & QueryHasWhere {
     const q = _clone(this) as unknown as Query;
     const pk = q.internal.singlePrimaryKey as string;
@@ -961,9 +980,7 @@ export class QueryUpdate {
    * ```
    */
   updateManyBy<
-    T extends PickQueryResultReturnTypeUniqueColumns &
-      PickQueryUniqueProperties &
-      UpdateSelf,
+    T extends UpdateManyBySelf,
     Keys extends
       | readonly [T['internal']['uniqueColumnNames']]
       | T['internal']['uniqueColumnTuples'],
@@ -971,10 +988,7 @@ export class QueryUpdate {
   >(
     this: T,
     keys: Keys,
-    data: (Required<Pick<T['inputType'], K & keyof T['inputType']>> &
-      Partial<
-        Omit<InputTypeOrExpression<T['inputType']>, K & keyof T['inputType']>
-      >)[],
+    data: UpdateManyByData<T, K>,
   ): UpdateManyResult<T> & QueryHasWhere {
     return _queryUpdateMany(
       _clone(this) as never,
@@ -995,9 +1009,7 @@ export class QueryUpdate {
    * ```
    */
   updateManyByOptional<
-    T extends PickQueryResultReturnTypeUniqueColumns &
-      PickQueryUniqueProperties &
-      UpdateSelf,
+    T extends UpdateManyBySelf,
     Keys extends
       | readonly [T['internal']['uniqueColumnNames']]
       | T['internal']['uniqueColumnTuples'],
@@ -1005,10 +1017,7 @@ export class QueryUpdate {
   >(
     this: T,
     keys: Keys,
-    data: (Required<Pick<T['inputType'], K & keyof T['inputType']>> &
-      Partial<
-        Omit<InputTypeOrExpression<T['inputType']>, K & keyof T['inputType']>
-      >)[],
+    data: UpdateManyByData<T, K>,
   ): UpdateManyResult<T> & QueryHasWhere {
     return _queryUpdateMany(
       _clone(this) as never,

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -171,13 +171,15 @@ type UpdateManyData<T extends UpdateSelf> = (ShapePrimaryKeyQueryTypes<
   [P in keyof T['inputType']]?: T['inputType'][P] | Expression;
 })[];
 
-// Valid key tuples for updateManyBy / updateManyByOptional
+// Valid keys for updateManyBy: a single unique column name or a compound tuple
 type UpdateManyByKeys<T extends UpdateManyBySelf> =
-  | [T['internal']['uniqueColumnNames']]
+  | T['internal']['uniqueColumnNames']
   | T['internal']['uniqueColumnTuples'];
 
-// Extract key column names from a Keys tuple
-type UpdateManyByKeyColumns<Keys> = Keys extends unknown[]
+// Extract key column names from a string or tuple
+type UpdateManyByKeyColumns<Keys> = Keys extends string
+  ? Keys
+  : Keys extends unknown[]
   ? Keys[number] & string
   : never;
 
@@ -965,14 +967,14 @@ export class QueryUpdate {
   }
 
   /**
-   * Like {@link updateMany}, but accepts key columns matching primary keys, unique columns, or compound unique constraints defined on the table.
+   * Like {@link updateMany}, but matches rows by a unique column or a compound unique constraint instead of the primary key.
    *
    * Throws {@link NotFoundError} if any record is not found.
    * Use {@link updateManyByOptional} to skip records with no matching key without throwing.
    *
    * ```ts
    * // single unique column
-   * await db.table.updateManyBy(['email'], [
+   * await db.table.updateManyBy('email', [
    *   { email: 'alice@test.com', name: 'Alice' },
    *   { email: 'bob@test.com', name: 'Bob' },
    * ]);
@@ -994,7 +996,7 @@ export class QueryUpdate {
   ): UpdateManyResult<T> & QueryHasWhere {
     return _queryUpdateMany(
       _clone(this) as never,
-      keys as unknown as string[],
+      typeof keys === 'string' ? [keys] : (keys as unknown as string[]),
       data as RecordUnknown[],
       true,
     ) as never;
@@ -1004,7 +1006,7 @@ export class QueryUpdate {
    * Same as {@link updateManyBy}, but skips records with no matching key rather than throwing.
    *
    * ```ts
-   * await db.table.updateManyByOptional(['email'], [
+   * await db.table.updateManyByOptional('email', [
    *   { email: 'alice@test.com', name: 'Alice' },
    *   { email: 'unknown@test.com', name: 'Ghost' },
    * ]);
@@ -1021,7 +1023,7 @@ export class QueryUpdate {
   ): UpdateManyResult<T> & QueryHasWhere {
     return _queryUpdateMany(
       _clone(this) as never,
-      keys as unknown as string[],
+      typeof keys === 'string' ? [keys] : (keys as unknown as string[]),
       data as RecordUnknown[],
       false,
     ) as never;

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -884,7 +884,7 @@ export class QueryUpdate {
    * updated records.
    *
    * Throws {@link NotFoundError} if any record is not found.
-   * Use {@link updateManyOptional} to update existing records without throwing.
+   * Use {@link updateManyOptional} to skip missing records without throwing.
    *
    * ```ts
    * // returns count of updated records
@@ -929,7 +929,7 @@ export class QueryUpdate {
   }
 
   /**
-   * Same as {@link updateMany}, but does **not** throw when some records are not found.
+   * Same as {@link updateMany}, but skips missing records rather than throwing.
    *
    * ```ts
    * // updates what it can, doesn't throw for missing id: 999
@@ -959,6 +959,7 @@ export class QueryUpdate {
    * Like {@link updateMany}, but accepts key columns matching primary keys, unique columns, or compound unique constraints defined on the table.
    *
    * Throws {@link NotFoundError} if any record is not found.
+   * Use {@link updateManyByOptional} to skip records with no matching key without throwing.
    *
    * ```ts
    * // single unique column
@@ -996,7 +997,7 @@ export class QueryUpdate {
   }
 
   /**
-   * Same as {@link updateManyBy}, but does **not** throw when some records are not found.
+   * Same as {@link updateManyBy}, but skips records with no matching key rather than throwing.
    *
    * ```ts
    * await db.table.updateManyByOptional(['email'], [

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -254,10 +254,15 @@ const _queryUpdateMany = <T extends UpdateSelf>(
     return _queryNone(query) as never;
   }
 
-  // Validate key values + check for duplicate keys
+  // Validate keys, check for duplicates, determine setColumns, validate consistency
   const seenKeys = new Set<string>();
+  const keysSet = new Set(keys);
+  const setColumns: string[] = [];
+  let setColumnsSet = new Set<string>();
   for (let i = 0; i < data.length; i++) {
     const row = data[i];
+
+    // Key validation + dedup
     const keyParts: unknown[] = [];
     for (const key of keys) {
       const val = row[key];
@@ -278,14 +283,8 @@ const _queryUpdateMany = <T extends UpdateSelf>(
       );
     }
     seenKeys.add(keyStr);
-  }
 
-  // Determine setColumns from first row, validate subsequent rows match
-  const keysSet = new Set(keys);
-  const setColumns: string[] = [];
-  let setColumnsSet = new Set<string>();
-  for (let i = 0; i < data.length; i++) {
-    const row = data[i];
+    // Determine setColumns from first row, validate subsequent rows match
     const rowCols: string[] = [];
     for (const key in row) {
       if (keysSet.has(key)) continue;

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -176,20 +176,6 @@ const _queryUpdateMany = <T extends UpdateSelf>(
   const query = self as unknown as Query;
   const { q } = query;
 
-  // Conflict guard: incompatible with updateFrom/join
-  if (q.updateFrom) {
-    throw new OrchidOrmInternalError(
-      query,
-      'updateMany cannot be combined with updateFrom',
-    );
-  }
-  if (q.join) {
-    throw new OrchidOrmInternalError(
-      query,
-      'updateMany cannot be combined with join',
-    );
-  }
-
   // Keys validation
   if (!keys.length) {
     throw new OrchidOrmInternalError(
@@ -238,12 +224,6 @@ const _queryUpdateMany = <T extends UpdateSelf>(
     const keyParts: unknown[] = [];
     for (const key of keys) {
       const val = row[key];
-      if (val === undefined || val === null) {
-        throw new OrchidOrmInternalError(
-          query,
-          `Key column "${key}" is undefined or null in row ${i}`,
-        );
-      }
       if (isExpression(val)) {
         throw new OrchidOrmInternalError(
           query,

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -202,9 +202,11 @@ const _queryUpdateMany = <T extends UpdateSelf>(
   q.type = 'update';
   const returnCount = !q.select;
   if (returnCount) {
-    q.returningMany = true;
-    q.returnType = 'valueOrThrow';
-    q.returning = true;
+    if (q.returnType !== 'void') {
+      q.returningMany = true;
+      q.returnType = 'valueOrThrow';
+      q.returning = true;
+    }
   } else {
     // When select is present, ensure many-return semantics
     const rt = q.returnType;

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -41,7 +41,7 @@ import {
 } from '../../pick-query-types';
 import { EmptyObject, RecordUnknown } from '../../../utils';
 import { RelationConfigBase } from '../../relations';
-import { isExpression } from '../../expressions/expression';
+import { Expression, isExpression } from '../../expressions/expression';
 import { _clone } from '../clone/clone';
 import { OrchidOrmInternalError } from '../../errors';
 import { resolveSubQueryCallback } from '../../sub-query/sub-query';
@@ -157,6 +157,11 @@ type ShapePrimaryKeyQueryTypes<Shape extends Column.QueryColumns> = {
   [K in keyof Shape as Shape[K] extends { data: { primaryKey: string } }
     ? K
     : never]: Shape[K]['queryType'];
+};
+
+// Allow Expression as an alternative value for each column in updateMany data
+type InputTypeOrExpression<InputType> = {
+  [K in keyof InputType]: InputType[K] | Expression;
 };
 
 // Return type for updateMany/updateManyBy — mirrors InsertManyResult
@@ -895,7 +900,8 @@ export class QueryUpdate {
    */
   updateMany<T extends UpdateManySelf>(
     this: T,
-    data: (ShapePrimaryKeyQueryTypes<T['shape']> & Partial<T['inputType']>)[],
+    data: (ShapePrimaryKeyQueryTypes<T['shape']> &
+      Partial<InputTypeOrExpression<T['inputType']>>)[],
   ): UpdateManyResult<T> & QueryHasWhere {
     const q = _clone(this) as unknown as Query;
     const pk = q.internal.singlePrimaryKey as string;
@@ -920,7 +926,8 @@ export class QueryUpdate {
    */
   updateManyOptional<T extends UpdateManySelf>(
     this: T,
-    data: (ShapePrimaryKeyQueryTypes<T['shape']> & Partial<T['inputType']>)[],
+    data: (ShapePrimaryKeyQueryTypes<T['shape']> &
+      Partial<InputTypeOrExpression<T['inputType']>>)[],
   ): UpdateManyResult<T> & QueryHasWhere {
     const q = _clone(this) as unknown as Query;
     const pk = q.internal.singlePrimaryKey as string;
@@ -963,7 +970,9 @@ export class QueryUpdate {
     this: T,
     keys: Keys,
     data: (Required<Pick<T['inputType'], K & keyof T['inputType']>> &
-      Partial<Omit<T['inputType'], K & keyof T['inputType']>>)[],
+      Partial<
+        Omit<InputTypeOrExpression<T['inputType']>, K & keyof T['inputType']>
+      >)[],
   ): UpdateManyResult<T> & QueryHasWhere {
     return _queryUpdateMany(
       _clone(this) as never,
@@ -995,7 +1004,9 @@ export class QueryUpdate {
     this: T,
     keys: Keys,
     data: (Required<Pick<T['inputType'], K & keyof T['inputType']>> &
-      Partial<Omit<T['inputType'], K & keyof T['inputType']>>)[],
+      Partial<
+        Omit<InputTypeOrExpression<T['inputType']>, K & keyof T['inputType']>
+      >)[],
   ): UpdateManyResult<T> & QueryHasWhere {
     return _queryUpdateMany(
       _clone(this) as never,

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -469,7 +469,8 @@ export class QueryUpdate {
    *
    * By default, `update` will return a count of updated records.
    *
-   * Place `select`, `selectAll`, or `get` before `update` to specify returning columns.
+   * Use `select`, `selectAll`, `get`, or `pluck` alongside `update` to specify
+   * returning columns.
    *
    * You need to provide `where`, `findBy`, or `find` conditions before calling `update`.
    * To ensure that the whole table won't be updated by accident, updating without where conditions will result in TypeScript and runtime errors.
@@ -879,7 +880,8 @@ export class QueryUpdate {
    * All rows must have the same set of non-key columns.
    *
    * Returns a count of updated records by default.
-   * Place `select` or `selectAll` before `updateMany` to return updated records.
+   * Use `select`, `selectAll`, `get`, or `pluck` alongside `updateMany` to return
+   * updated records.
    *
    * Throws {@link NotFoundError} if any record is not found.
    * Use {@link updateManyOptional} to update existing records without throwing.

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -34,7 +34,7 @@ import {
   PickQueryReturnType,
   PickQuerySelectable,
   PickQueryShape,
-  PickQueryShapeResultReturnTypeSinglePrimaryKey,
+  PickQuerySinglePrimaryKey,
   PickQueryResultReturnTypeUniqueColumns,
   PickQueryUniqueProperties,
   PickQueryWithData,
@@ -56,10 +56,11 @@ export interface UpdateSelf
     PickQueryReturnType,
     PickQueryShape,
     PickQueryInputType,
-    PickQueryShape,
     PickQueryAs,
     PickQueryHasSelect,
     PickQueryHasWhere {}
+
+interface UpdateManySelf extends UpdateSelf, PickQuerySinglePrimaryKey {}
 
 // Type of argument for `update` and `updateOrThrow`
 //
@@ -151,11 +152,11 @@ const throwOnReadOnly = (q: unknown, column: Column.Pick.Data, key: string) => {
   }
 };
 
-// Helper: extract PK columns from shape (concrete values only, no expressions)
-type ShapePrimaryKeys<Shape> = {
+// Helper: require PK columns with their query types (for WHERE matching)
+type ShapePrimaryKeyQueryTypes<Shape extends Column.QueryColumns> = {
   [K in keyof Shape as Shape[K] extends { data: { primaryKey: string } }
     ? K
-    : never]: Shape[K] extends { queryType: infer QT } ? QT : never;
+    : never]: Shape[K]['queryType'];
 };
 
 // Return type for updateMany/updateManyBy — mirrors InsertManyResult
@@ -892,11 +893,9 @@ export class QueryUpdate {
    *   .set({ updatedBy: currentUser.id });
    * ```
    */
-  updateMany<
-    T extends PickQueryShapeResultReturnTypeSinglePrimaryKey & UpdateSelf,
-  >(
+  updateMany<T extends UpdateManySelf>(
     this: T,
-    data: (ShapePrimaryKeys<T['shape']> & Partial<T['inputType']>)[],
+    data: (ShapePrimaryKeyQueryTypes<T['shape']> & Partial<T['inputType']>)[],
   ): UpdateManyResult<T> & QueryHasWhere {
     const q = _clone(this) as unknown as Query;
     const pk = q.internal.singlePrimaryKey as string;
@@ -919,11 +918,9 @@ export class QueryUpdate {
    * ]);
    * ```
    */
-  updateManyOptional<
-    T extends PickQueryShapeResultReturnTypeSinglePrimaryKey & UpdateSelf,
-  >(
+  updateManyOptional<T extends UpdateManySelf>(
     this: T,
-    data: (ShapePrimaryKeys<T['shape']> & Partial<T['inputType']>)[],
+    data: (ShapePrimaryKeyQueryTypes<T['shape']> & Partial<T['inputType']>)[],
   ): UpdateManyResult<T> & QueryHasWhere {
     const q = _clone(this) as unknown as Query;
     const pk = q.internal.singlePrimaryKey as string;

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -2,8 +2,11 @@ import {
   isQuery,
   Query,
   QueryOrExpression,
+  SetQueryReturnsAllResult,
+  SetQueryReturnsPluckColumnResult,
   SetQueryReturnsRowCount,
   SetQueryReturnsRowCountMany,
+  SetQueryResult,
 } from '../../query';
 import { throwIfNoWhere } from '../../query.utils';
 import { QueryHasWhere } from '../where/where';
@@ -31,6 +34,9 @@ import {
   PickQueryReturnType,
   PickQuerySelectable,
   PickQueryShape,
+  PickQueryShapeResultReturnTypeSinglePrimaryKey,
+  PickQueryResultReturnTypeUniqueColumns,
+  PickQueryUniqueProperties,
   PickQueryWithData,
 } from '../../pick-query-types';
 import { EmptyObject, RecordUnknown } from '../../../utils';
@@ -143,6 +149,181 @@ const throwOnReadOnly = (q: unknown, column: Column.Pick.Data, key: string) => {
       { column: key },
     );
   }
+};
+
+// Helper: extract PK columns from shape (concrete values only, no expressions)
+type ShapePrimaryKeys<Shape> = {
+  [K in keyof Shape as Shape[K] extends { data: { primaryKey: string } }
+    ? K
+    : never]: Shape[K] extends { queryType: infer QT } ? QT : never;
+};
+
+// Return type for updateMany/updateManyBy — mirrors InsertManyResult
+type UpdateManyResult<T extends UpdateSelf> = T['__hasSelect'] extends true
+  ? T['returnType'] extends 'one' | 'oneOrThrow'
+    ? SetQueryReturnsAllResult<T, T['result']>
+    : T['returnType'] extends 'value' | 'valueOrThrow'
+    ? SetQueryReturnsPluckColumnResult<T, T['result']>
+    : SetQueryResult<T, T['result']>
+  : SetQueryReturnsRowCountMany<T>;
+
+const _queryUpdateMany = <T extends UpdateSelf>(
+  self: T,
+  keys: string[],
+  data: RecordUnknown[],
+  strict: boolean,
+): T => {
+  const query = self as unknown as Query;
+  const { q } = query;
+
+  // Conflict guard: incompatible with updateFrom/join
+  if (q.updateFrom) {
+    throw new OrchidOrmInternalError(
+      query,
+      'updateMany cannot be combined with updateFrom',
+    );
+  }
+  if (q.join) {
+    throw new OrchidOrmInternalError(
+      query,
+      'updateMany cannot be combined with join',
+    );
+  }
+
+  // Keys validation
+  if (!keys.length) {
+    throw new OrchidOrmInternalError(
+      query,
+      'updateMany requires at least one key column',
+    );
+  }
+  const { shape } = q;
+  for (const key of keys) {
+    if (!shape[key]) {
+      throw new OrchidOrmInternalError(query, `Unknown key column: ${key}`, {
+        column: key,
+      });
+    }
+  }
+
+  // Normalize return type (must happen before .none() for empty data)
+  q.type = 'update';
+  const returnCount = !q.select;
+  if (returnCount) {
+    q.returningMany = true;
+    q.returnType = 'valueOrThrow';
+    q.returning = true;
+  } else {
+    // When select is present, ensure many-return semantics
+    const rt = q.returnType;
+    if (rt === 'one' || rt === 'oneOrThrow') {
+      q.returningMany = true;
+      q.returnType = 'all';
+    } else if (rt === 'value' || rt === 'valueOrThrow') {
+      q.returningMany = true;
+      q.returnType = 'pluck';
+    } else {
+      q.returningMany = !rt || rt === 'all';
+    }
+  }
+
+  if (!data.length) {
+    return _queryNone(query) as never;
+  }
+
+  // Validate key values + check for duplicate keys
+  const seenKeys = new Set<string>();
+  for (let i = 0; i < data.length; i++) {
+    const row = data[i];
+    const keyParts: unknown[] = [];
+    for (const key of keys) {
+      const val = row[key];
+      if (val === undefined || val === null) {
+        throw new OrchidOrmInternalError(
+          query,
+          `Key column "${key}" is undefined or null in row ${i}`,
+        );
+      }
+      if (isExpression(val)) {
+        throw new OrchidOrmInternalError(
+          query,
+          `Key column "${key}" must be a concrete value, not an expression, in row ${i}`,
+        );
+      }
+      keyParts.push(val);
+    }
+    const keyStr =
+      keyParts.length === 1 ? String(keyParts[0]) : JSON.stringify(keyParts);
+    if (seenKeys.has(keyStr)) {
+      throw new OrchidOrmInternalError(
+        query,
+        `Duplicate key in updateMany data at row ${i}`,
+      );
+    }
+    seenKeys.add(keyStr);
+  }
+
+  // Determine setColumns from first row, validate subsequent rows match
+  const keysSet = new Set(keys);
+  const setColumns: string[] = [];
+  let setColumnsSet = new Set<string>();
+  for (let i = 0; i < data.length; i++) {
+    const row = data[i];
+    const rowCols: string[] = [];
+    for (const key in row) {
+      if (keysSet.has(key)) continue;
+      if (row[key] === undefined) continue;
+
+      const column = shape[key];
+      if (!column) continue;
+      if (column.data.virtual) continue;
+      throwOnReadOnly(query, column, key);
+
+      rowCols.push(key);
+    }
+
+    if (i === 0) {
+      setColumns.push(...rowCols);
+      setColumnsSet = new Set(setColumns);
+    } else if (
+      rowCols.length !== setColumns.length ||
+      rowCols.some((c) => !setColumnsSet.has(c))
+    ) {
+      throw new OrchidOrmInternalError(
+        query,
+        `Row ${i} has different columns than row 0. Expected: [${setColumns.join(
+          ', ',
+        )}], got: [${rowCols.join(', ')}]`,
+      );
+    }
+  }
+
+  const columns = [...keys, ...setColumns];
+
+  const values: unknown[][] = [];
+  for (const row of data) {
+    const encoded: unknown[] = [];
+    for (const col of columns) {
+      let value = row[col];
+      if (value !== null && value !== undefined && !isExpression(value)) {
+        const encode = shape[col]?.data.encode;
+        if (encode) value = encode(value);
+      }
+      encoded.push(value);
+    }
+    values.push(encoded);
+  }
+
+  q.updateMany = {
+    keys,
+    columns,
+    setColumns,
+    values,
+    count: data.length,
+    strict,
+  };
+
+  return query as never;
 };
 
 // apply `increment` or a `decrement`,
@@ -258,14 +439,16 @@ export const _queryUpdate = <T extends UpdateSelf>(
     }
   }
 
-  if (returnCount) {
+  // Skip returnType normalization when updateMany is set —
+  // _queryUpdateMany already configured these, and .set() must not override them.
+  if (returnCount && !q.updateMany) {
     q.returningMany = !q.returnType || q.returnType === 'all';
     q.returnType = 'valueOrThrow';
     q.returning = true;
   }
 
-  // assuming conditions are set by `updateFrom`
-  if (!q.updateFrom) {
+  // assuming conditions are set by `updateFrom` or `updateMany`
+  if (!q.updateFrom && !q.updateMany) {
     throwIfNoWhere(query, 'update');
   }
 
@@ -687,5 +870,149 @@ export class QueryUpdate {
     data: ChangeCountArg<T>,
   ): UpdateResult<T> {
     return _queryChangeCounter(_clone(this), '-', data as never);
+  }
+
+  /**
+   * Updates multiple records with different per-row data in a single query.
+   *
+   * Each row must include the primary key and the columns to update.
+   * All rows must have the same set of non-key columns.
+   *
+   * Returns a count of updated records by default.
+   * Place `select` or `selectAll` before `updateMany` to return updated records.
+   *
+   * Throws {@link NotFoundError} if any record is not found.
+   * Use {@link updateManyOptional} to update existing records without throwing.
+   *
+   * `.set()` applies shared values to all rows.
+   * Per-row values take precedence over `.set()` values for the same column.
+   *
+   * ```ts
+   * // returns count of updated records
+   * const count = await db.table.updateMany([
+   *   { id: 1, name: 'Alice', age: 30 },
+   *   { id: 2, name: 'Bob', age: 25 },
+   * ]);
+   *
+   * // returns array of updated records
+   * const records = await db.table.select('id', 'name').updateMany([
+   *   { id: 1, name: 'Alice' },
+   *   { id: 2, name: 'Bob' },
+   * ]);
+   * ```
+   */
+  updateMany<
+    T extends PickQueryShapeResultReturnTypeSinglePrimaryKey & UpdateSelf,
+  >(
+    this: T,
+    data: (ShapePrimaryKeys<T['shape']> & Partial<T['inputType']>)[],
+  ): UpdateManyResult<T> & QueryHasWhere {
+    const q = _clone(this) as unknown as Query;
+    const pk = q.internal.singlePrimaryKey as string;
+    return _queryUpdateMany(
+      q as never,
+      [pk],
+      data as RecordUnknown[],
+      true,
+    ) as never;
+  }
+
+  /**
+   * Same as {@link updateMany}, but does **not** throw when some records are not found.
+   *
+   * ```ts
+   * // updates what it can, doesn't throw for missing id: 999
+   * const count = await db.table.updateManyOptional([
+   *   { id: 1, name: 'Alice' },
+   *   { id: 999, name: 'Ghost' },
+   * ]);
+   * ```
+   */
+  updateManyOptional<
+    T extends PickQueryShapeResultReturnTypeSinglePrimaryKey & UpdateSelf,
+  >(
+    this: T,
+    data: (ShapePrimaryKeys<T['shape']> & Partial<T['inputType']>)[],
+  ): UpdateManyResult<T> & QueryHasWhere {
+    const q = _clone(this) as unknown as Query;
+    const pk = q.internal.singlePrimaryKey as string;
+    return _queryUpdateMany(
+      q as never,
+      [pk],
+      data as RecordUnknown[],
+      false,
+    ) as never;
+  }
+
+  /**
+   * Like {@link updateMany}, but accepts key columns matching primary keys, unique columns, or compound unique constraints defined on the table.
+   *
+   * Throws {@link NotFoundError} if any record is not found.
+   *
+   * ```ts
+   * // single unique column
+   * await db.table.updateManyBy(['email'], [
+   *   { email: 'alice@test.com', name: 'Alice' },
+   *   { email: 'bob@test.com', name: 'Bob' },
+   * ]);
+   *
+   * // compound unique constraint
+   * await db.table.updateManyBy(['firstName', 'lastName'], [
+   *   { firstName: 'John', lastName: 'Doe', bio: 'updated' },
+   * ]);
+   * ```
+   */
+  updateManyBy<
+    T extends PickQueryResultReturnTypeUniqueColumns &
+      PickQueryUniqueProperties &
+      UpdateSelf,
+    Keys extends
+      | readonly [T['internal']['uniqueColumnNames']]
+      | T['internal']['uniqueColumnTuples'],
+    K extends string = Keys extends readonly (infer E)[] ? E & string : never,
+  >(
+    this: T,
+    keys: Keys,
+    data: (Required<Pick<T['inputType'], K & keyof T['inputType']>> &
+      Partial<Omit<T['inputType'], K & keyof T['inputType']>>)[],
+  ): UpdateManyResult<T> & QueryHasWhere {
+    return _queryUpdateMany(
+      _clone(this) as never,
+      keys as unknown as string[],
+      data as RecordUnknown[],
+      true,
+    ) as never;
+  }
+
+  /**
+   * Same as {@link updateManyBy}, but does **not** throw when some records are not found.
+   *
+   * ```ts
+   * await db.table.updateManyByOptional(['email'], [
+   *   { email: 'alice@test.com', name: 'Alice' },
+   *   { email: 'unknown@test.com', name: 'Ghost' },
+   * ]);
+   * ```
+   */
+  updateManyByOptional<
+    T extends PickQueryResultReturnTypeUniqueColumns &
+      PickQueryUniqueProperties &
+      UpdateSelf,
+    Keys extends
+      | readonly [T['internal']['uniqueColumnNames']]
+      | T['internal']['uniqueColumnTuples'],
+    K extends string = Keys extends readonly (infer E)[] ? E & string : never,
+  >(
+    this: T,
+    keys: Keys,
+    data: (Required<Pick<T['inputType'], K & keyof T['inputType']>> &
+      Partial<Omit<T['inputType'], K & keyof T['inputType']>>)[],
+  ): UpdateManyResult<T> & QueryHasWhere {
+    return _queryUpdateMany(
+      _clone(this) as never,
+      keys as unknown as string[],
+      data as RecordUnknown[],
+      false,
+    ) as never;
   }
 }

--- a/packages/pqb/src/query/basic-features/mutate/update.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.ts
@@ -34,7 +34,6 @@ import {
   PickQueryReturnType,
   PickQuerySelectable,
   PickQueryShape,
-  PickQuerySinglePrimaryKey,
   PickQueryResultReturnTypeUniqueColumns,
   PickQueryUniqueProperties,
   PickQueryWithData,
@@ -44,6 +43,7 @@ import { RelationConfigBase } from '../../relations';
 import { Expression, isExpression } from '../../expressions/expression';
 import { _clone } from '../clone/clone';
 import { OrchidOrmInternalError } from '../../errors';
+import { requirePrimaryKeys } from '../../query-columns/primary-keys';
 import { resolveSubQueryCallback } from '../../sub-query/sub-query';
 import { pushQueryValueImmutable } from '../../query-data';
 import { ToSQLQuery } from '../../sql/to-sql';
@@ -157,8 +157,6 @@ type ShapePrimaryKeyQueryTypes<Shape extends Column.QueryColumns> = {
     : never]: Shape[K]['queryType'];
 };
 
-export interface UpdateManySelf extends UpdateSelf, PickQuerySinglePrimaryKey {}
-
 // `type` instead of `interface`: PickQueryResultReturnTypeUniqueColumns and
 // PickQueryUniqueProperties both declare `internal` with different shapes,
 // which `interface extends` cannot merge.
@@ -172,7 +170,7 @@ type InputTypeOrExpression<InputType> = {
 };
 
 // Data type for updateMany / updateManyOptional (PK-based)
-type UpdateManyData<T extends UpdateManySelf> = (ShapePrimaryKeyQueryTypes<
+type UpdateManyData<T extends UpdateSelf> = (ShapePrimaryKeyQueryTypes<
   T['shape']
 > &
   Partial<InputTypeOrExpression<T['inputType']>>)[];
@@ -921,15 +919,14 @@ export class QueryUpdate {
    *   .set({ updatedBy: currentUser.id });
    * ```
    */
-  updateMany<T extends UpdateManySelf>(
+  updateMany<T extends UpdateSelf>(
     this: T,
     data: UpdateManyData<T>,
   ): UpdateManyResult<T> & QueryHasWhere {
     const q = _clone(this) as unknown as Query;
-    const pk = q.internal.singlePrimaryKey as string;
     return _queryUpdateMany(
       q as never,
-      [pk],
+      requirePrimaryKeys(q, 'updateMany requires a primary key'),
       data as RecordUnknown[],
       true,
     ) as never;
@@ -946,15 +943,14 @@ export class QueryUpdate {
    * ]);
    * ```
    */
-  updateManyOptional<T extends UpdateManySelf>(
+  updateManyOptional<T extends UpdateSelf>(
     this: T,
     data: UpdateManyData<T>,
   ): UpdateManyResult<T> & QueryHasWhere {
     const q = _clone(this) as unknown as Query;
-    const pk = q.internal.singlePrimaryKey as string;
     return _queryUpdateMany(
       q as never,
-      [pk],
+      requirePrimaryKeys(q, 'updateMany requires a primary key'),
       data as RecordUnknown[],
       false,
     ) as never;

--- a/packages/pqb/src/query/basic-features/select/select.sql.ts
+++ b/packages/pqb/src/query/basic-features/select/select.sql.ts
@@ -376,6 +376,7 @@ const internalSelectAllSql = (
   ctx: ToSQLCtx,
   query: {
     updateFrom?: unknown;
+    updateMany?: unknown;
     join?: QueryData['join'];
     selectAllColumns?: string[];
     selectAllShape?: RecordUnknown;
@@ -405,6 +406,7 @@ const internalSelectAllSql = (
 export const selectAllSql = (
   q: {
     updateFrom?: unknown;
+    updateMany?: unknown;
     join?: QueryData['join'];
     selectAllColumns?: string[];
     selectAllShape?: RecordUnknown;
@@ -413,7 +415,7 @@ export const selectAllSql = (
   quotedAs?: string,
   columnsCount?: number,
 ): string[] => {
-  return q.join?.length || q.updateFrom
+  return q.join?.length || q.updateFrom || q.updateMany
     ? q.selectAllColumns?.map((item) => `${quotedAs}.${item}`) ||
         (isEmptySelect(q.shape, columnsCount) ? [] : [`${quotedAs}.*`])
     : q.selectAllColumns

--- a/packages/pqb/src/query/extra-features/hooks/hooks.test.ts
+++ b/packages/pqb/src/query/extra-features/hooks/hooks.test.ts
@@ -1216,7 +1216,7 @@ describe('hooks', () => {
         expect(cols).toEqual(['name']);
 
         assert.updateHooksBeingCalled({
-          data: [{ name: 'dedup-updated' }],
+          data: [{ name: 'ignored-shared' }],
         });
       });
     });

--- a/packages/pqb/src/query/extra-features/hooks/hooks.test.ts
+++ b/packages/pqb/src/query/extra-features/hooks/hooks.test.ts
@@ -1103,6 +1103,127 @@ describe('hooks', () => {
       });
     });
 
+    describe('updateMany', () => {
+      it.each(['updateMany', 'updateManyOptional'] as const)(
+        'should fire update hooks for %s',
+        async (method) => {
+          tested[method] = true;
+
+          const ids = await Promise.all([
+            User.get('id').create({ ...userData, name: 'um1' }),
+            User.get('id').create({ ...userData, name: 'um2' }),
+          ]);
+          jest.clearAllMocks();
+
+          await User[method]([
+            { id: ids[0], name: 'new1' },
+            { id: ids[1], name: 'new2' },
+          ]);
+
+          assert.updateHooksBeingCalled({
+            data: [{ name: 'new1' }, { name: 'new2' }],
+          });
+        },
+      );
+
+      it.each(['updateManyBy', 'updateManyByOptional'] as const)(
+        'should fire update hooks for %s',
+        async (method) => {
+          tested[method] = true;
+
+          await Promise.all([
+            User.get('id').create({ ...userData, name: 'umby1' }),
+            User.get('id').create({ ...userData, name: 'umby2' }),
+          ]);
+          jest.clearAllMocks();
+
+          await User[method](
+            ['name'],
+            [
+              { name: 'umby1', password: 'pw1' },
+              { name: 'umby2', password: 'pw2' },
+            ],
+          );
+
+          assert.updateHooksBeingCalled({
+            data: [{ name: 'umby1' }, { name: 'umby2' }],
+          });
+        },
+      );
+
+      it('should apply hookSet values from beforeUpdate', async () => {
+        const id = await User.get('id').create({
+          ...userData,
+          name: 'hook-test',
+        });
+        jest.clearAllMocks();
+
+        const result = await User.selectAll().updateMany([
+          { id, name: 'hook-updated' },
+        ]);
+
+        // hookSet.beforeUpdate sets active: false
+        // hookSet.beforeSave sets picture: 'picture from beforeSave'
+        expect(result[0]).toMatchObject(hookSetUpdateValues);
+      });
+
+      it('should expose per-row setColumns in beforeUpdate columns', async () => {
+        const id = await User.get('id').create({
+          ...userData,
+          name: 'cols-test',
+        });
+
+        let cols: string[] | undefined;
+
+        await User.beforeUpdate(({ columns }) => {
+          cols = columns;
+        }).updateMany([{ id, name: 'cols-updated' }]);
+
+        expect(cols).toEqual(['name']);
+      });
+
+      it('should merge per-row and .set() columns in beforeUpdate', async () => {
+        const id = await User.get('id').create({
+          ...userData,
+          name: 'merge-test',
+        });
+
+        let cols: string[] | undefined;
+
+        await User.beforeUpdate(({ columns }) => {
+          cols = columns;
+        })
+          .updateMany([{ id, name: 'merge-updated' }])
+          .set({ password: 'shared' });
+
+        // 'password' from .set(), 'name' from per-row setColumns
+        expect(cols).toEqual(['password', 'name']);
+      });
+
+      it('should not duplicate columns when .set() overlaps per-row', async () => {
+        const id = await User.get('id').create({
+          ...userData,
+          name: 'dedup-test',
+        });
+        jest.clearAllMocks();
+
+        let cols: string[] | undefined;
+
+        await User.beforeUpdate(({ columns }) => {
+          cols = columns;
+        })
+          .updateMany([{ id, name: 'dedup-updated' }])
+          .set({ name: 'ignored-shared' });
+
+        // 'name' appears in both .set() and per-row — must appear only once
+        expect(cols).toEqual(['name']);
+
+        assert.updateHooksBeingCalled({
+          data: [{ name: 'dedup-updated' }],
+        });
+      });
+    });
+
     describe('cte', () => {
       describe('update methods in cte', () => {
         it('update', async () => {

--- a/packages/pqb/src/query/extra-features/hooks/hooks.test.ts
+++ b/packages/pqb/src/query/extra-features/hooks/hooks.test.ts
@@ -1137,13 +1137,10 @@ describe('hooks', () => {
           ]);
           jest.clearAllMocks();
 
-          await User[method](
-            ['name'],
-            [
-              { name: 'umby1', password: 'pw1' },
-              { name: 'umby2', password: 'pw2' },
-            ],
-          );
+          await User[method]('name', [
+            { name: 'umby1', password: 'pw1' },
+            { name: 'umby2', password: 'pw2' },
+          ]);
 
           assert.updateHooksBeingCalled({
             data: [{ name: 'umby1' }, { name: 'umby2' }],

--- a/packages/pqb/src/query/extra-features/hooks/hooks.ts
+++ b/packages/pqb/src/query/extra-features/hooks/hooks.ts
@@ -234,6 +234,15 @@ export const _queryHookBeforeUpdate = <T extends PickQueryShape>(
         columns.push(...Object.keys(item));
       }
     }
+    if (q.q.updateMany) {
+      const columnsSet = new Set(columns);
+      for (const col of q.q.updateMany.setColumns) {
+        if (!columnsSet.has(col)) {
+          columns.push(col);
+          columnsSet.add(col);
+        }
+      }
+    }
 
     return cb(new QueryHookUtils(q, columns, 'hookUpdateSet'));
   });

--- a/packages/pqb/src/query/query-data.ts
+++ b/packages/pqb/src/query/query-data.ts
@@ -318,14 +318,16 @@ export interface QueryData
   /** update **/
 
   updateData: UpdateQueryDataItem[];
-  updateMany?: {
-    keys: string[];
-    columns: string[];
-    setColumns: string[];
-    values: unknown[][];
-    count: number;
-    strict?: boolean;
-  };
+  updateMany?: UpdateManyQueryData;
+}
+
+export interface UpdateManyQueryData {
+  keys: string[];
+  columns: string[];
+  setColumns: string[];
+  values: unknown[][];
+  count: number;
+  strict?: boolean;
 }
 
 export interface UpdateQueryDataObject {

--- a/packages/pqb/src/query/query-data.ts
+++ b/packages/pqb/src/query/query-data.ts
@@ -308,7 +308,7 @@ export interface QueryData
   insertFrom?: SubQueryForSql;
   insertValuesAs?: string;
   queryColumnsCount?: number;
-  values: InsertQueryDataObjectValues;
+  values: unknown[][];
   onConflict?: {
     target?: OnConflictTarget;
     set?: OnConflictSet;
@@ -318,9 +318,15 @@ export interface QueryData
   /** update **/
 
   updateData: UpdateQueryDataItem[];
+  updateMany?: {
+    keys: string[];
+    columns: string[];
+    setColumns: string[];
+    values: unknown[][];
+    count: number;
+    strict?: boolean;
+  };
 }
-
-export type InsertQueryDataObjectValues = unknown[][];
 
 export interface UpdateQueryDataObject {
   [K: string]: Expression | { op: string; arg: unknown } | unknown;

--- a/packages/pqb/src/query/query-methods.ts
+++ b/packages/pqb/src/query/query-methods.ts
@@ -567,7 +567,7 @@ export class QueryMethods<ColumnTypes> {
 
   /**
    * Finds a single unique record, throws [NotFoundError](/guide/error-handling.html) if not found.
-   * It accepts values of primary keys or unique indexes defined on the table.
+   * It accepts values of primary keys, unique columns, or compound unique constraints defined on the table.
    * `findBy`'s argument type is a union of all possible sets of unique conditions.
    *
    * You can use `where(...).take()` for non-unique conditions.
@@ -576,7 +576,7 @@ export class QueryMethods<ColumnTypes> {
    * await db.table.findBy({ key: 'value' });
    * ```
    *
-   * @param uniqueColumnValues - is derived from primary keys and unique indexes in the table
+   * @param uniqueColumnValues - is derived from primary keys, unique columns, and compound unique constraints in the table
    */
   findBy<T extends PickQueryResultReturnTypeUniqueColumns>(
     this: T,
@@ -587,7 +587,7 @@ export class QueryMethods<ColumnTypes> {
 
   /**
    * Finds a single unique record, returns `undefined` if not found.
-   * It accepts values of primary keys or unique indexes defined on the table.
+   * It accepts values of primary keys, unique columns, or compound unique constraints defined on the table.
    * `findBy`'s argument type is a union of all possible sets of unique conditions.
    *
    * You can use `where(...).takeOptional()` for non-unique conditions.
@@ -596,7 +596,7 @@ export class QueryMethods<ColumnTypes> {
    * await db.table.findByOptional({ key: 'value' });
    * ```
    *
-   * @param uniqueColumnValues - is derived from primary keys and unique indexes in the table
+   * @param uniqueColumnValues - is derived from primary keys, unique columns, and compound unique constraints in the table
    */
   findByOptional<T extends PickQueryResultReturnTypeUniqueColumns>(
     this: T,


### PR DESCRIPTION
Add `updateMany`, `updateManyOptional`, `updateManyBy`, `updateManyByOptional` methods (resolves #668).

Following some observations and questions — please review and approve:

## MOST IMPORTANT: Duplicate keys check

- `updateMany` validates input before generating SQL: key columns must be present, key values must be concrete values (not null/undefined, and **not expressions**). User input having duplicate keys is rejected early. Perhaps, for `updateMany*Optional` we could allow expressions and disable duplicate check?
- Duplicate composite keys are compared via `JSON.stringify()`. This is simple and adequate for normal scalar DB keys, but it is still a heuristic rather than a database-level equality model.

## API semantic

- Row shape is determined **from the first row**, and every following row must match exactly.
- `.set()` values cannot “fill in” missing per-row columns.
- Per-row values always win over shared `.set()` values and over hook-generated values for the same column.
- Empty effective set of updated fields is an error. Unlike regular `update`, batch update does not fall back to `SELECT`.
- `updateMany` is intentionally incompatible with `join` and `updateFrom`; both chaining orders are rejected at runtime.

## Implementation decisions

- `InsertQueryDataObjectValues` was removed because it was barely used and similar code already worked with `unknown[][]` directly.

## Technical debt

- The local `ShapePrimaryKeys` type is a simplified version of `ShapeColumnPrimaryKeys`. Should this be unfiied somehow (especially if we allow expression for `updateMany*Optional`)?
- `UpdateManyResult` is a literal copy/paste of `InsertManyResult`. Should they be unified somehow?
- `updateManyBy` does **not** runtime-verify that `keys` match a declared unique constraint. That remains type-level only, consistent with `findBy`. Perhaps both should be improved?
- `QueryData.updateMany` is stored as a single compound object, while insert batch data is still represented by flat `QueryData` fields. The two batch-mutation paths are conceptually similar but structurally inconsistent.
