### PR TITLE
Export QuerySchema from pqb and orchid-orm

### DIFF
--- a/.changeset/re-export-query-schema.md
+++ b/.changeset/re-export-query-schema.md
@@ -1,0 +1,6 @@
+---
+'pqb': patch
+'orchid-orm': patch
+---
+
+Re-export `QuerySchema` type from `pqb` and `orchid-orm`

--- a/packages/pqb/src/public.ts
+++ b/packages/pqb/src/public.ts
@@ -12,4 +12,5 @@ export {
   Db,
   type Query,
   type QueryHelperResult,
+  type QuerySchema,
 } from './index';


### PR DESCRIPTION
Export `QuerySchema` from pqb and orchid-orm (previously done in #682, broken after switching to rolldown).