### PR TITLE
Use pnpm exec in lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,9 +3,9 @@ pre-commit:
   commands:
     lint:
       glob: "*.{js,mjs,ts,json}"
-      run: oxlint --fix --deny-warnings {staged_files}
+      run: pnpm exec oxlint --fix --deny-warnings {staged_files}
       stage_fixed: true
     fmt:
       glob: "*.{js,mjs,ts,json,md}"
-      run: oxfmt --no-error-on-unmatched-pattern {staged_files}
+      run: pnpm exec oxfmt --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true


### PR DESCRIPTION
Currently, lefthook runs global `oxlint` and `oxfmt`. This is incorrect, it should run project-local binaries.

Without the fix:

```
% git ci -am "Export QuerySchema from pqb and orchid-orm"
╭───────────────────────────────────────╮
│ 🥊 lefthook v1.7.18  hook: pre-commit │
╰───────────────────────────────────────╯
┃  fmt ❯

sh: oxfmt: command not found

┃  lint ❯

sh: oxlint: command not found
```

with the fix:

```
sync hooks: ✔️ (pre-commit)
┃  fmt ❯

Finished in 95ms on 2 files using 12 threads.

┃  lint ❯

Found 0 warnings and 0 errors.
Finished in 8ms on 1 file with 65 rules using 12 threads.
```
