### PR TITLE
Export Expression, isExpression as public API

### DIFF
--- a/.changeset/heavy-meals-prove.md
+++ b/.changeset/heavy-meals-prove.md
@@ -1,0 +1,5 @@
+---
+'pqb': patch
+---
+
+Export `Expression`, `isExpression` as public API

--- a/packages/pqb/src/public.ts
+++ b/packages/pqb/src/public.ts
@@ -13,4 +13,6 @@ export {
   type Query,
   type QueryHelperResult,
   type QuerySchema,
+  Expression,
+  isExpression,
 } from './index';


### PR DESCRIPTION
I need `Expression` as a reusable type for my decomposed raw SQL builders.

Real-life example:

```ts
export function buildEffectiveAccessRoleSql<Role extends string>({
  userId,
  roleWeight,
  weightedRoles,
}: {
  userId: string
  roleWeight: Expression // <------- Here
  weightedRoles: WeightedRoles<Role>
}) {
  const { schema } = getActiveTenant()
  const roleWhens = makeRoleWeightEntries(weightedRoles)
    .map(({ role, weight }) => `WHEN ${weight} THEN '${role}'`)
    .join(" ")
  const roleCaseWhens = sql({ raw: roleWhens })

  return sql<Role | null>`
    CASE
      WHEN EXISTS (
        SELECT 1
        FROM ${sql.ref(`${schema}.user`)} active_user
        WHERE active_user.id = ${userId}
          AND active_user.deleted_at IS NULL
      )
      THEN CASE ${roleWeight} ${roleCaseWhens} ELSE NULL END
      ELSE NULL
    END
  `
}
```

and usage:

```ts
buildEffectiveAccessRoleSql<SectionAccessRole>({
    userId,
    roleWeight: sql<number>`
      GREATEST(
        ${buildGlobalCompanyRoleWeightSql({
          userId,
          weightedRoles: SECTION_WEIGHTED_ROLES,
        })},
        ${allowEveryoneWeight},
        ${ownAccessWeight}
      )
    `,
    weightedRoles: SECTION_WEIGHTED_ROLES,
  })
```

currently, I have to infer the type with weird hacks:

```ts
import { sql } from "../base"

const _makeRawSql = () => sql``
const _makeSqlRefExpression = () => sql.ref("")

// Quick replacement for import type { Expression } from "pqb/internal"
export type Expression = ReturnType<typeof _makeRawSql> | ReturnType<typeof _makeSqlRefExpression>
```