### PR TITLE
Bun SQL support (#601)

### DIFF
--- a/.changeset/pretty-days-breathe.md
+++ b/.changeset/pretty-days-breathe.md
@@ -1,0 +1,10 @@
+---
+'orchid-orm-valibot': minor
+'orchid-orm-schema-to-zod': minor
+'orchid-orm-test-factory': minor
+'rake-db': minor
+'orchid-orm': minor
+'pqb': minor
+---
+
+Bun SQL support (#601)

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -60,6 +60,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          # timezone-related bug is fixed in canary, not released at the time of writing: https://github.com/oven-sh/bun/pull/31212
+          bun-version: canary
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10.32.1
@@ -82,10 +88,17 @@ jobs:
         working-directory: packages/rake-db
         run: pnpm db migrate
 
-      - name: Run tests
+      - name: (postgres-js) Run tests
         run: |
           ADAPTER=postgres-js pnpm check:coverage
+
+      - name: (node-postgres) Run tests
+        run: |
           ADAPTER=node-postgres pnpm check
+
+      - name: (bun) Run tests
+        run: |
+          ADAPTER=bun pnpm bun:check
 
       - name: Lint & Format
         run: ./node_modules/.bin/turbo run lint:check fmt:check

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -6,8 +6,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 on:
   push:
     branches:
-      - main
-      - dev
+      - '**'
   pull_request:
     types: [opened, synchronize]
 
@@ -17,12 +16,8 @@ env:
   PNPM_CACHE_FOLDER: .pnpm-store
 
 jobs:
-  test-and-release:
+  test:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      id-token: write
 
     strategy:
       matrix:
@@ -103,15 +98,60 @@ jobs:
       - name: Lint & Format
         run: ./node_modules/.bin/turbo run lint:check fmt:check
 
-      - name: Build
-        run: pnpm build
-
       - name: Type-check
         run: ./node_modules/.bin/turbo run types
 
+      - name: Test build
+        run: |
+          pnpm build
+          pnpm test-builds types
+
+      - name: Get total coverage
+        id: coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: echo "COVERAGE=$(./node_modules/.bin/ts-node scripts/get-test-coverage-total.ts)" >> $GITHUB_OUTPUT
+
+  release:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    strategy:
+      matrix:
+        node-version: [24]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          # fetch all history to get the tags needed for `changeset tag` command when publishing
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
+      - name: Setup pnpm config
+        run: pnpm config set store-dir $PNPM_CACHE_FOLDER
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
       # This step will run changeset version, setting the step output to if there were changesets found
       - name: Version command
-        if: github.ref == 'refs/heads/main'
         id: version
         run: |
           echo ::set-output name=changes::$(pnpm changeset version 2>&1 | grep -q 'No unreleased changesets found' && echo 'false' || echo 'true')
@@ -119,7 +159,7 @@ jobs:
       # Push the updated package.json, and CHANGESET.md files
       # the || echo 'No changes' is to ignore errors from git when trying to commit and there are no changes
       - name: Push changes
-        if: ${{ github.ref == 'refs/heads/main' && steps.version.outputs.changes == 'true' }}
+        if: steps.version.outputs.changes == 'true'
         run: |
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
@@ -128,22 +168,18 @@ jobs:
           git push
 
       - name: Release
-        if: github.ref == 'refs/heads/main'
         uses: changesets/action@v1
         with:
           publish: pnpm publish:ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get total coverage
-        id: coverage
-        if: github.ref == 'refs/heads/main'
-        run: echo "COVERAGE=$(./node_modules/.bin/ts-node scripts/get-test-coverage-total.ts)" >> $GITHUB_OUTPUT
-
   badge:
     name: Generate badge image with test coverage value
-    needs: test-and-release
-    if: github.ref == 'refs/heads/main'
+    needs:
+      - test
+      - release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -155,7 +191,7 @@ jobs:
         id: badge
         with:
           label: 'test coverage'
-          status: ${{ needs.test-and-release.outputs.COVERAGE }}
+          status: ${{ needs.test.outputs.COVERAGE }}
           color: 'green'
           path: coverage-badge.svg
 

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -99,7 +99,7 @@ jobs:
         run: ./node_modules/.bin/turbo run lint:check fmt:check
 
       - name: Type-check
-        run: ./node_modules/.bin/turbo run types
+        run: pnpm types
 
       - name: Test build
         run: |

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,38 @@
 # Breaking changes
 
+## orchid-orm 1.72
+
+When using the `node-postgres` adapter, pass `nodePostgresSchemaConfig` to `schemaConfig` in `createBaseTable`.
+This aligns OrchidORM column encoding and parsing behavior with node-postgres column type parsing.
+
+```ts
+import { createBaseTable } from 'orchid-orm';
+import { nodePostgresSchemaConfig } from 'pqb/node-postgres';
+
+export const BaseTable = createBaseTable({
+  schemaConfig: nodePostgresSchemaConfig,
+});
+```
+
+When also using Zod or Valibot schemas, wrap the adapter config:
+
+```ts
+import { createBaseTable } from 'orchid-orm';
+import { nodePostgresSchemaConfig } from 'pqb/node-postgres';
+import { zodSchemaConfig } from 'orchid-orm-schema-to-zod';
+
+export const BaseTable = createBaseTable({
+  schemaConfig: () => zodSchemaConfig(nodePostgresSchemaConfig),
+});
+```
+
+## rake-db 2.36.1
+
+`rake-db` no longer upgrades legacy migration tracking tables that are missing the `name` column.
+
+The `name` column was added in 2024, and previous versions automatically added and populated it so existing projects could migrate without manual steps.
+That compatibility path has been removed now that supported projects are expected to already have the column.
+
 ## orchid-orm 1.71, rake-db 2.35
 
 In rake-db migrations, `createView` now creates views with `securityInvoker: true` by default.

--- a/docs/src/guide/advanced-queries.md
+++ b/docs/src/guide/advanced-queries.md
@@ -199,7 +199,7 @@ db.table
       two: t.string(),
     }),
     // define SQL expression:
-    (q) => sql`(VALUES (1, 'two')) t(one, two)`,
+    (q) => sql`VALUES (1, 'two')`,
   )
   // is not prefixed in the middle of a query chain
   .withSql(
@@ -207,7 +207,7 @@ db.table
     (t) => ({
       x: t.integer(),
     }),
-    (q) => sql`(VALUES (1)) t(x)`,
+    (q) => sql`VALUES (1)`,
   )
   .from('alias');
 ```
@@ -230,7 +230,7 @@ db.table
       one: t.integer(),
       two: t.string(),
     }),
-    (q) => sql`(VALUES (1, 'two')) t(one, two)`,
+    (q) => sql`VALUES (1, 'two')`,
   )
   .from('alias');
 ```

--- a/docs/src/guide/base-table.md
+++ b/docs/src/guide/base-table.md
@@ -49,6 +49,25 @@ export const { sql } = BaseTable;
 
 See [override column types](/guide/columns-overview#override-column-types) for details of customizing columns.
 
+When using the `node-postgres` or `bun` adapters, set the `schemaConfig` imported from the corresponding adapter.
+Nothing is needed when using `postgres-js`.
+
+Different Postgres drivers have different column type parsing behavior and restrictions,
+and this adjusts how OrchidORM column types encode and parse certain column types.
+
+```ts
+import { createBaseTable } from 'orchid-orm';
+import { nodePostgresSchemaConfig } from 'pqb/node-postgres';
+import { bunSchemaConfig } from 'orchid-orm/bun';
+
+export const BaseTable = createBaseTable({
+  // for node-postgres
+  schemaConfig: nodePostgresSchemaConfig,
+  // for bun
+  schemaConfig: bunSchemaConfig,
+});
+```
+
 Tables are defined as classes `table` and `columns` required properties:
 
 `table` is a table name and `columns` is for defining table column types (see [Columns schema](/guide/columns-overview) document for details).

--- a/docs/src/guide/columns-types.md
+++ b/docs/src/guide/columns-types.md
@@ -343,7 +343,10 @@ export class Table extends BaseTable {
 }
 ```
 
-When using ORM without a [validation library](/guide/columns-validation-methods), you can set an arbitrary type to `json`.
+`t.jsonText()` is a Postgres `json` column.
+It accepts any user-provided data and automatically parses JSON values loaded from the database, so both input and output TypeScript types are `unknown`.
+
+When using ORM without a [validation library](/guide/columns-validation-methods), you can set an arbitrary type to `jsonb` with `t.json`.
 Make sure to only save properly validated data.
 
 ```ts

--- a/docs/src/guide/columns-validation-methods.md
+++ b/docs/src/guide/columns-validation-methods.md
@@ -46,6 +46,30 @@ export const BaseTable = createBaseTable({
 });
 ```
 
+When using `node-postgres` or `bun` Postgres drivers, wrap the adapter's `schemaConfig` with the validation config.
+Nothing is needed when using `postgres-js`.
+
+```ts
+import { createBaseTable } from 'orchid-orm';
+import { nodePostgresSchemaConfig } from 'pqb/node-postgres';
+import { bunSchemaConfig } from 'orchid-orm/bun';
+
+import { zodSchemaConfig } from 'orchid-orm-schema-to-zod';
+import { valibotSchemaConfig } from 'orchid-orm-valibot';
+
+export const BaseTable = createBaseTable({
+  // for node-postgres with zod
+  schemaConfig: () => zodSchemaConfig(nodePostgresSchemaConfig),
+  // for bun with zod
+  schemaConfig: () => zodSchemaConfig(bunSchemaConfig),
+
+  // for node-postgres with valibot
+  schemaConfig: () => valibotSchemaConfig(nodePostgresSchemaConfig),
+  // for bun with valibot
+  schemaConfig: () => valibotSchemaConfig(bunSchemaConfig),
+});
+```
+
 All table classes will now expose schemas for different purposes.
 
 - `Table.inputSchema()` - validating input data for inserting records, primary keys are not omitted.

--- a/docs/src/guide/current-status-and-limitations.md
+++ b/docs/src/guide/current-status-and-limitations.md
@@ -9,7 +9,7 @@ Despite thousands tests written, may have bugs, please drop an issue if you enco
 Supporting other than Postgres databases isn't planned: simply too much effort to support additional dbs,
 focusing on ORM features and Postgres-specific features and optimizations instead.
 
-It is limited to node-postgres only, supporting other Postgres adapters is in the plans.
+It supports `node-postgres`, `postgres-js`, and `Bun SQL` Postgres adapters.
 
 You can use OrchidORM for the app connected to multiple databases, but it cannot manage table relations spread across databases.
 

--- a/docs/src/guide/customize-db-adapter.md
+++ b/docs/src/guide/customize-db-adapter.md
@@ -14,6 +14,8 @@ import { AdapterClass, orchidORMWithAdapter } from 'orchid-orm';
 import { Adapter as PostgresJsAdapter } from 'orchid-orm/postgres-js';
 // for node-postgres driver:
 // import { Adapter as NodePostgresAdapter } from 'orchid-orm/node-postgres';
+// for Bun SQL driver:
+// import { Adapter as BunAdapter } from 'orchid-orm/bun';
 
 const adapter = new AdapterClass({
   driverAdapter: PostgresJsAdapter,
@@ -37,6 +39,10 @@ If you need to bundle tables before database config exists, use `bundleOrchidORM
 ```ts
 import { bundleOrchidORMTables } from 'orchid-orm';
 import { makeOrchidOrmDb } from 'orchid-orm/postgres-js';
+// for node-postgres driver:
+// import { makeOrchidOrmDb } from 'orchid-orm/node-postgres';
+// for Bun SQL driver:
+// import { makeOrchidOrmDb } from 'orchid-orm/bun';
 
 import { UserTable } from './tables/user';
 import { MessageTable } from './tables/message';

--- a/docs/src/guide/error-handling.md
+++ b/docs/src/guide/error-handling.md
@@ -164,7 +164,7 @@ If the query fails, it does `ROLLBACK TO SAVEPOINT` to recover the transaction f
 
 `postgres-js` sends the save-point and the query SQLs simultaneously, without introducing additional round-trips.
 
-But the same is not possible with `node-postgres` and in case of using it the `catch` adds additional round-trips.
+The same is not possible with `node-postgres` or Bun SQL, so with these adapters `catch` adds additional round-trips.
 
 ## catchUniqueError
 

--- a/docs/src/guide/migration-commands.md
+++ b/docs/src/guide/migration-commands.md
@@ -406,6 +406,9 @@ import { rakeDb } from 'rake-db/postgres-js'; // when using rake-db as a standal
 // for node-postgres driver:
 import { rakeDb } from 'orchid-orm/migrations/node-postgres'; // when using ORM
 import { rakeDb } from 'rake-db/node-postgres'; // when using rake-db as a standalone tool
+// for Bun SQL driver:
+import { rakeDb } from 'orchid-orm/migrations/bun'; // when using ORM
+import { rakeDb } from 'rake-db/bun'; // when using rake-db as a standalone tool
 
 import { createDb } from 'pqb';
 import { config } from './config';

--- a/docs/src/guide/migration-programmatic-use.md
+++ b/docs/src/guide/migration-programmatic-use.md
@@ -14,7 +14,7 @@ but you can use `rake-db` as a standalone tool and import the same functions fro
 Most of the functions accept a `db` argument, which can be one of:
 
 - instance returned by [orchidORM](/guide/orm-setup.html#instantiate-orchidorm).
-- adapter: a wrapper of node-postgres or postgres-js, which you can import from `orchid-orm/postgres-js` as `Adapter` class.
+- adapter: a wrapper of node-postgres, postgres-js, or Bun SQL, which you can import from `orchid-orm/postgres-js`, `orchid-orm/node-postgres`, or `orchid-orm/bun` as `Adapter` class.
 
 All the exposed functions are designed to respect the currently opened transaction.
 
@@ -24,6 +24,10 @@ The exposed functions aren't closing connection automatically, remember to call 
 
 ```ts
 import { rakeDb } from 'orchid-orm/migrations/postgres-js';
+// or for node-postgres:
+import { rakeDb } from 'orchid-orm/migrations/node-postgres';
+// or for Bun SQL:
+import { rakeDb } from 'orchid-orm/migrations/bun';
 
 const migrator = rakeDb(rakeDbConfig);
 

--- a/docs/src/guide/migration-setup-and-overview.md
+++ b/docs/src/guide/migration-setup-and-overview.md
@@ -114,6 +114,9 @@ import { rakeDb } from 'rake-db/postgres-js'; // when using a standalone rake-db
 // for node-postgres driver
 import { rakeDb } from 'orchid-orm/migrations/node-postgres'; // when using Orchid ORM
 import { rakeDb } from 'rake-db/node-postgres'; // when using a standalone rake-db
+// for Bun SQL driver
+import { rakeDb } from 'orchid-orm/migrations/bun'; // when using Orchid ORM
+import { rakeDb } from 'rake-db/bun'; // when using a standalone rake-db
 
 import { config } from './config';
 import { BaseTable } from './base-table';

--- a/docs/src/guide/orm-methods.md
+++ b/docs/src/guide/orm-methods.md
@@ -258,7 +258,7 @@ Direct `SET ROLE`, `RESET ROLE`, or `set_config(...)` calls inside the callback 
 
 [//]: # 'has JSDoc'
 
-Adapter is a wrapper on top of `postgres-js`, `node-postgres`, or other db driver.
+Adapter is a wrapper on top of `postgres-js`, `node-postgres`, Bun SQL, or other db driver.
 
 When in transaction, returns a db adapter object for the transaction,
 returns a default adapter object otherwise.

--- a/docs/src/guide/orm-setup.md
+++ b/docs/src/guide/orm-setup.md
@@ -35,6 +35,8 @@ Returns an instance with tables and some specific functions prefixed with a `$` 
 import { orchidORM } from 'orchid-orm/postgres-js';
 // for node-postgres driver:
 import { orchidORM } from 'orchid-orm/node-postgres';
+// for Bun SQL driver:
+import { orchidORM } from 'orchid-orm/bun';
 
 // import all tables
 import { UserTable } from './tables/user';
@@ -70,6 +72,21 @@ export const db = orchidORM(
 );
 ```
 
+### Bun SQL
+
+Bun SQL is supported via the `orchid-orm/bun` adapter and works only under the Bun runtime.
+
+The most important caveat is that Bun parses timestamps and dates into its own custom Date-like object.
+Such objects look like and act like normal JavaScript `Date` objects, but `returnedRow.createdAt instanceof Date` is `false`.
+
+There is also a Bun bug for parsing `timestamp without time zone`.
+It was fixed in [oven-sh/bun#31212](https://github.com/oven-sh/bun/pull/31212), but the fix is not released yet.
+Use a Bun canary version until the fix is available in a stable release.
+
+Bun does not parse Postgres result fields.
+This should not be a problem when using ORM abstractions, but it can bite when making raw SQL queries.
+`fields` are empty when no rows are returned.
+
 ## split ORM initialization
 
 `orchidORM` shown above is the default and recommended way to set up the ORM.
@@ -79,6 +96,10 @@ you can split setup into a table bundle and a later DB binding step.
 ```ts
 import { bundleOrchidORMTables } from 'orchid-orm';
 import { makeOrchidOrmDb } from 'orchid-orm/postgres-js';
+// for node-postgres driver:
+// import { makeOrchidOrmDb } from 'orchid-orm/node-postgres';
+// for Bun SQL driver:
+// import { makeOrchidOrmDb } from 'orchid-orm/bun';
 
 import { UserTable } from './tables/user';
 import { MessageTable } from './tables/message';
@@ -98,7 +119,7 @@ export const db = makeOrchidOrmDb(orm, {
 });
 ```
 
-`makeOrchidOrmDb` is exported from both `orchid-orm/postgres-js` and `orchid-orm/node-postgres`,
+`makeOrchidOrmDb` is exported from `orchid-orm/postgres-js`, `orchid-orm/node-postgres`, and `orchid-orm/bun`,
 and accepts the same driver-specific options as `orchidORM` from the same path.
 
 The bundled `orm` has only your table keys, and each bundled table object exposes only `makeHelper`.

--- a/docs/src/guide/query-builder-standalone.md
+++ b/docs/src/guide/query-builder-standalone.md
@@ -16,6 +16,8 @@ It is accepting the same options as `orchidORM` + options of `createBaseTable`:
 import { createDb } from 'pqb/postgres-js';
 // for node-postgres driver:
 import { createDb } from 'pqb/node-postgres';
+// for Bun SQL driver:
+import { createDb } from 'pqb/bun';
 
 import { zodSchemaConfig } from 'orchid-orm-schema-to-zod';
 // or

--- a/docs/src/guide/transactions.md
+++ b/docs/src/guide/transactions.md
@@ -194,7 +194,7 @@ await db.$withOptions(
 );
 ```
 
-This works consistently across both supported adapters (`node-postgres` and `postgres-js`) even though their internal connection handling differs.
+This works consistently across supported adapters (`node-postgres`, `postgres-js`, and Bun SQL) even though their internal connection handling differs.
 
 For query-scoped SQL session options, see [$withOptions](/guide/orm-methods.html#withoptions).
 

--- a/jest-load-env.cjs
+++ b/jest-load-env.cjs
@@ -1,6 +1,45 @@
 const path = require('path');
 const dotenv = require('dotenv');
+const { TextDecoder, TextEncoder } = require('node:util');
+const { webcrypto } = require('node:crypto');
+const { URL, URLSearchParams } = require('node:url');
 
 dotenv.config({
   path: path.resolve(__dirname, '.env'),
 });
+
+// Bun exposes these APIs in the process global scope, but they are missing from
+// Jest's VM when running tests with `bun --bun jest`. Keep this in `setupFiles`
+// so dependencies that read globals during top-level imports, such as `pg`, see
+// the same runtime APIs they have in Node.js.
+if (!globalThis.TextEncoder) {
+  globalThis.TextEncoder = TextEncoder;
+}
+
+if (!globalThis.TextDecoder) {
+  globalThis.TextDecoder = TextDecoder;
+}
+
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto;
+}
+
+if (!globalThis.URL) {
+  globalThis.URL = URL;
+}
+
+if (!globalThis.URLSearchParams) {
+  globalThis.URLSearchParams = URLSearchParams;
+}
+
+if (!globalThis.queueMicrotask) {
+  globalThis.queueMicrotask = (callback) => {
+    Promise.resolve()
+      .then(callback)
+      .catch((error) => {
+        setTimeout(() => {
+          throw error;
+        }, 0);
+      });
+  };
+}

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,9 +1,47 @@
 import dotenv from 'dotenv';
+import * as timers from 'node:timers';
 import path from 'path';
 import { QueryData, RecordUnknown } from './packages/pqb/src/internal';
 import { skipQueryKeysForSubQuery } from './packages/pqb/src/query/sql/get-is-join-sub-query';
 import { setPrepareSubQueryForSql } from './packages/pqb/src/columns/operators';
 import { setRawSqlPrepareSubQueryForSql } from './packages/pqb/src/query/expressions/raw-sql';
+
+/**
+ * Workaround for Bun SQL:
+ * Bun SQL returns timestamps as Date-like objects, they are not `instanceof Date`.
+ */
+const isBun = process.env.ADAPTER === 'bun';
+const originalExpectAny = expect.any;
+expect.any = (cls: unknown) => {
+  if (isBun && cls === Date) {
+    return {
+      ...originalExpectAny(cls),
+      asymmetricMatch(value: unknown) {
+        return Object.prototype.toString.call(value) === '[object Date]';
+      },
+    };
+  }
+  return originalExpectAny(cls);
+};
+
+const ensureTimerGlobal = (
+  key: 'setTimeout' | 'clearTimeout' | 'setImmediate' | 'clearImmediate',
+) => {
+  if (typeof globalThis[key] === 'function') {
+    return;
+  }
+
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    value: timers[key],
+  });
+};
+
+ensureTimerGlobal('setTimeout');
+ensureTimerGlobal('clearTimeout');
+ensureTimerGlobal('setImmediate');
+ensureTimerGlobal('clearImmediate');
 
 dotenv.config({ path: path.resolve(__dirname, '.env') });
 
@@ -26,6 +64,10 @@ jest.mock(
     virtual: true,
   },
 );
+
+jest.mock('orchid-orm/bun', () => require('./packages/orm/src/adapters/bun'), {
+  virtual: true,
+});
 
 jest.mock(
   'orchid-orm/node-postgres',
@@ -59,7 +101,15 @@ jest.mock(
   },
 );
 
+jest.mock('pqb/bun', () => require('./packages/pqb/src/adapters/bun'), {
+  virtual: true,
+});
+
 jest.mock('rake-db', () => require('./packages/rake-db/src'), {
+  virtual: true,
+});
+
+jest.mock('rake-db/bun', () => require('./packages/rake-db/src/adapters/bun'), {
   virtual: true,
 });
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ai-sync": "tsx scripts/ai-sync.ts",
     "prepare": "lefthook install",
     "check": "turbo run check --filter=!./packages/repro",
+    "bun:check": "turbo run bun:check --filter=!./packages/repro",
     "check:coverage": "turbo run check:coverage --cache-dir=.turbo",
     "types": "turbo run types",
     "build": "turbo run build",
@@ -52,5 +53,13 @@
     "turbo": "1.8.8",
     "typescript": "6.0.2"
   },
-  "packageManager": "pnpm@10.32.1"
+  "packageManager": "pnpm@10.32.1",
+  "pnpm": {
+    "patchedDependencies": {
+      "jest-runtime@30.4.2": "patches/jest-runtime@30.4.2.patch",
+      "jest-message-util@30.4.1": "patches/jest-message-util@30.4.1.patch",
+      "jest-util@30.4.1": "patches/jest-util@30.4.1.patch",
+      "jest-circus@30.4.2": "patches/jest-circus@30.4.2.patch"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check": "turbo run check --filter=!./packages/repro",
     "bun:check": "turbo run bun:check --filter=!./packages/repro",
     "check:coverage": "turbo run check:coverage --cache-dir=.turbo",
-    "types": "turbo run types",
+    "types": "turbo run types --filter=!./packages/test-builds",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "lint:check": "turbo run lint:check",
@@ -25,6 +25,7 @@
     "valibot": "pnpm --filter orchid-orm-valibot",
     "test-factory": "pnpm --filter orchid-orm-test-factory",
     "test-utils": "pnpm --filter test-utils",
+    "test-builds": "pnpm --filter test-builds",
     "repro": "pnpm --filter repro",
     "doc": "cd docs && npm start",
     "doc:build": "cd docs && pnpm build"

--- a/packages/create-orm/tsconfig.json
+++ b/packages/create-orm/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "paths": {
-      "create-orchid-orm/lib": ["./src/lib.ts"]
+      "create-orchid-orm": ["./src/lib.ts"]
     }
   }
 }

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -65,6 +65,16 @@
         "types": "./dist/postgres-js.d.ts"
       }
     },
+    "./bun": {
+      "require": {
+        "default": "./dist/bun.js",
+        "types": "./dist/bun.d.ts"
+      },
+      "import": {
+        "default": "./dist/bun.mjs",
+        "types": "./dist/bun.d.ts"
+      }
+    },
     "./migrations": {
       "require": {
         "default": "./dist/migrations/index.js",
@@ -94,11 +104,23 @@
         "default": "./dist/migrations/postgres-js.mjs",
         "types": "./dist/migrations/postgres-js.d.ts"
       }
+    },
+    "./migrations/bun": {
+      "require": {
+        "default": "./dist/migrations/bun.js",
+        "types": "./dist/migrations/bun.d.ts"
+      },
+      "import": {
+        "default": "./dist/migrations/bun.mjs",
+        "types": "./dist/migrations/bun.d.ts"
+      }
     }
   },
   "scripts": {
-    "test": "jest --watch --verbose false",
+    "test": "jest --watch --reporters default --verbose false",
+    "bun:test": "bun --bun jest --watch --reporters default --verbose false --runInBand",
     "check": "jest",
+    "bun:check": "bun --bun jest --runInBand",
     "check:coverage": "jest --coverage --coverageReporters json-summary",
     "types": "tsc",
     "build": "rimraf ./dist/ ./codegen/ && rolldown -c ./rolldown.config.mjs",

--- a/packages/orm/rolldown.config.mjs
+++ b/packages/orm/rolldown.config.mjs
@@ -19,6 +19,9 @@ export default [
   ...rolldownExportFile('src/adapters/postgres-js', 'dist/postgres-js', {
     forbidImportFrom: src,
   }),
+  ...rolldownExportFile('src/adapters/bun', 'dist/bun', {
+    forbidImportFrom: src,
+  }),
   ...rolldownExportFile('src/migrations/index', 'dist/migrations/index'),
   ...rolldownExportFile(
     'src/migrations/adapters/node-postgres',
@@ -28,4 +31,5 @@ export default [
     'src/migrations/adapters/postgres-js',
     'dist/migrations/postgres-js',
   ),
+  ...rolldownExportFile('src/migrations/adapters/bun', 'dist/migrations/bun'),
 ];

--- a/packages/orm/src/adapters/bun.test.ts
+++ b/packages/orm/src/adapters/bun.test.ts
@@ -1,0 +1,43 @@
+import { bundleOrchidORMTables } from 'orchid-orm';
+import { makeOrchidOrmDb, orchidORM } from './bun';
+import { RecordUnknown } from 'pqb/index';
+
+describe('bun', () => {
+  beforeAll(() => {
+    class SQL {
+      static PostgresError = Error;
+    }
+
+    if (!process.versions.bun) {
+      (globalThis as unknown as { Bun: { SQL: typeof SQL } }).Bun = { SQL };
+    }
+  });
+
+  it('should not pass `log` param to the driver in makeOrchidOrmDb', () => {
+    const orm = bundleOrchidORMTables({});
+    const db = makeOrchidOrmDb(orm, {
+      databaseURL: 'postgres://user:@host:123/db?ssl=false',
+      log: true,
+    });
+
+    const adapter = db.$qb.adapterNotInTransaction as unknown as {
+      config: RecordUnknown;
+    };
+    expect('log' in adapter.config).toBe(false);
+  });
+
+  it('should not pass `log` param to the driver', () => {
+    const db = orchidORM(
+      {
+        databaseURL: 'postgres://user:@host:123/db?ssl=false',
+        log: true,
+      },
+      {},
+    );
+
+    const adapter = db.$qb.adapterNotInTransaction as unknown as {
+      config: RecordUnknown;
+    };
+    expect('log' in adapter.config).toBe(false);
+  });
+});

--- a/packages/orm/src/adapters/bun.ts
+++ b/packages/orm/src/adapters/bun.ts
@@ -1,0 +1,40 @@
+import {
+  TableClasses,
+  OrchidORM,
+  OrchidORMTables,
+  OrchidOrmParam,
+  bundleOrchidORMTables,
+  makeOrchidOrmDbWithAdapter,
+} from 'orchid-orm';
+import { BunAdapter, BunAdapterOptions, createDb as cdb } from 'pqb/bun';
+import { DbSharedOptions, AdapterClass } from 'pqb/internal';
+export { bunSchemaConfig } from 'pqb/bun';
+
+export interface BunOrchidORMOptions
+  extends BunAdapterOptions, DbSharedOptions {}
+
+export const Adapter = BunAdapter;
+
+export const createDb = cdb;
+
+export const makeOrchidOrmDb = <T extends TableClasses>(
+  orm: OrchidORMTables<T>,
+  { log, ...options }: OrchidOrmParam<BunOrchidORMOptions>,
+): OrchidORM<T> => {
+  return makeOrchidOrmDbWithAdapter(orm, {
+    ...options,
+    log,
+    adapter: new AdapterClass({
+      driverAdapter: BunAdapter,
+      config: options,
+    }),
+  });
+};
+
+export const orchidORM = <T extends TableClasses>(
+  options: OrchidOrmParam<BunOrchidORMOptions>,
+  tables: T,
+): OrchidORM<T> => {
+  const orm = bundleOrchidORMTables(tables);
+  return makeOrchidOrmDb(orm, options);
+};

--- a/packages/orm/src/adapters/node-postgres.ts
+++ b/packages/orm/src/adapters/node-postgres.ts
@@ -12,6 +12,7 @@ import {
   createDb as cdb,
 } from 'pqb/node-postgres';
 import { DbSharedOptions, AdapterClass } from 'pqb/internal';
+export { nodePostgresSchemaConfig } from 'pqb/node-postgres';
 
 export const Adapter = NodePostgresAdapter;
 

--- a/packages/orm/src/base-table.test.ts
+++ b/packages/orm/src/base-table.test.ts
@@ -9,13 +9,11 @@ import {
 import { orchidORMWithAdapter } from './orm';
 import {
   Column,
-  makeColumnTypes,
   Operators,
   TextColumn,
   getCallerFilePath,
   QueryHookUtils,
   DefaultSchemaConfig,
-  defaultSchemaConfig,
   QuerySchema,
 } from 'pqb/internal';
 import { useTestORM } from './test-utils/orm.test-utils';
@@ -29,6 +27,8 @@ import {
   testAdapter,
   testColumnTypes,
   UserData,
+  testDefaultColumnTypes,
+  testDefaultSchemaConfig,
 } from 'test-utils';
 import { z } from 'zod/v4';
 import { zodSchemaConfig } from 'orchid-orm-schema-to-zod';
@@ -101,7 +101,7 @@ describe('baseTable', () => {
   describe('setColumns', () => {
     it('should store columns in the prototype of the table', () => {
       const shape = {
-        id: makeColumnTypes(defaultSchemaConfig).identity().primaryKey(),
+        id: testDefaultColumnTypes.identity().primaryKey(),
       };
 
       class SomeTable extends BaseTable {
@@ -119,7 +119,7 @@ describe('baseTable', () => {
         dataType = 'type';
         operators = Operators.any;
         constructor() {
-          super(defaultSchemaConfig, defaultSchemaConfig.unknown);
+          super(testDefaultSchemaConfig, testDefaultSchemaConfig.unknown);
         }
         toCode() {
           return '';
@@ -150,7 +150,10 @@ describe('baseTable', () => {
     it('should return date as string by default', async () => {
       await db.user.create(UserData);
 
-      const BaseTable = createBaseTable();
+      const BaseTable = createBaseTable({
+        schemaConfig: () => testDefaultSchemaConfig,
+      });
+
       class UserTable extends BaseTable {
         schema = 'schema';
         readonly table = 'user';

--- a/packages/orm/src/base-table.ts
+++ b/packages/orm/src/base-table.ts
@@ -515,7 +515,7 @@ export function createBaseTable<
   SchemaConfig extends ColumnSchemaConfig = DefaultSchemaConfig,
   ColumnTypes = DefaultColumnTypes<SchemaConfig>,
 >({
-  schemaConfig = defaultSchemaConfig as unknown as SchemaConfig,
+  schemaConfig = defaultSchemaConfig as unknown as () => SchemaConfig,
   columnTypes: columnTypesArg,
   snakeCase,
   filePath: filePathArg,
@@ -524,7 +524,7 @@ export function createBaseTable<
   language,
   autoForeignKeys,
 }: {
-  schemaConfig?: SchemaConfig;
+  schemaConfig?: () => SchemaConfig;
   // concrete column types or a callback for overriding standard column types
   // this types will be used in tables to define their columns
   columnTypes?:
@@ -544,12 +544,14 @@ export function createBaseTable<
   // automatically create foreign keys for relations
   autoForeignKeys?: boolean | TableData.References.BaseOptions;
 } = {}): BaseTableClass<SchemaConfig, ColumnTypes> {
+  const schema = schemaConfig();
+
   const columnTypes = (
     typeof columnTypesArg === 'function'
       ? (
           columnTypesArg as (t: DefaultColumnTypes<SchemaConfig>) => ColumnTypes
-        )(makeColumnTypes(schemaConfig))
-      : columnTypesArg || makeColumnTypes(schemaConfig)
+        )(makeColumnTypes(schema))
+      : columnTypesArg || makeColumnTypes(schema)
   ) as ColumnTypes;
 
   // stack is needed only if filePath wasn't given
@@ -579,7 +581,7 @@ export function createBaseTable<
       this.instance();
       // Nullish coalescing assignment (??=), for some reason, compiles to != null and miss undefined
       return this._inputSchema === undefined
-        ? (this._inputSchema = schemaConfig.inputSchema.call(this as never))
+        ? (this._inputSchema = schema.inputSchema.call(this as never))
         : this._inputSchema;
     }
 
@@ -587,7 +589,7 @@ export function createBaseTable<
     static outputSchema() {
       this.instance();
       return this._outputSchema === undefined
-        ? (this._outputSchema = schemaConfig.outputSchema.call(this as never))
+        ? (this._outputSchema = schema.outputSchema.call(this as never))
         : this._outputSchema;
     }
 
@@ -595,7 +597,7 @@ export function createBaseTable<
     static querySchema() {
       this.instance();
       return this._querySchema === undefined
-        ? (this._querySchema = schemaConfig.querySchema.call(this as never))
+        ? (this._querySchema = schema.querySchema.call(this as never))
         : this._querySchema;
     }
 
@@ -603,7 +605,7 @@ export function createBaseTable<
     static createSchema() {
       this.instance();
       return this._createSchema === undefined
-        ? (this._createSchema = schemaConfig.createSchema.call(this as never))
+        ? (this._createSchema = schema.createSchema.call(this as never))
         : this._createSchema;
     }
 
@@ -611,7 +613,7 @@ export function createBaseTable<
     static updateSchema() {
       this.instance();
       return this._updateSchema === undefined
-        ? (this._updateSchema = schemaConfig.updateSchema.call(this as never))
+        ? (this._updateSchema = schema.updateSchema.call(this as never))
         : this._updateSchema;
     }
 
@@ -619,7 +621,7 @@ export function createBaseTable<
     static pkeySchema() {
       this.instance();
       return this._pkeySchema === undefined
-        ? (this._pkeySchema = schemaConfig.pkeySchema.call(this as never))
+        ? (this._pkeySchema = schema.pkeySchema.call(this as never))
         : this._pkeySchema;
     }
 

--- a/packages/orm/src/migrations/adapters/bun.ts
+++ b/packages/orm/src/migrations/adapters/bun.ts
@@ -1,0 +1,5 @@
+import { patchRakeDb } from 'orchid-orm/migrations';
+export * from '../patch-rake-db-types';
+export * from 'rake-db/bun';
+
+patchRakeDb();

--- a/packages/orm/src/migrations/generate/generate.ts
+++ b/packages/orm/src/migrations/generate/generate.ts
@@ -5,7 +5,6 @@ import {
   ArrayColumn,
   ColumnsShape,
   Column,
-  defaultSchemaConfig,
   DomainColumn,
   PickQueryInternal,
   QueryInternal,
@@ -467,8 +466,7 @@ const getActualItems = async (
         domains.set(column.dataType, {
           schemaName,
           name,
-          column: (column.data.as ??
-            new UnknownColumn(defaultSchemaConfig)) as Column,
+          column: (column.data.as ?? UnknownColumn.instance) as Column,
         });
       } else {
         const en =

--- a/packages/orm/src/migrations/generate/generators/columns.generator.ts
+++ b/packages/orm/src/migrations/generate/generators/columns.generator.ts
@@ -514,7 +514,7 @@ const getTypeCasts = async (
 ) => {
   let typeCasts = typeCastsCache.value;
   if (!typeCasts) {
-    const { rows } = await adapter.arrays(`SELECT s.typname, t.typname
+    const { rows } = await adapter.arrays(`SELECT s.typname s, t.typname t
 FROM pg_cast
 JOIN pg_type AS s ON s.oid = castsource
 JOIN pg_type AS t ON t.oid = casttarget`);

--- a/packages/orm/src/migrations/generate/generators/generators.utils.ts
+++ b/packages/orm/src/migrations/generate/generators/generators.utils.ts
@@ -5,6 +5,7 @@ import {
   Adapter,
   colors,
   TransactionAdapter,
+  getDriverErrorCode,
 } from 'pqb/internal';
 import { AbortSignal } from '../generate';
 
@@ -61,7 +62,7 @@ export const compareSqlExpressions = async (
       async (err) => {
         // ignore the "type ... does not exist" because the type may be added in the same migration,
         // but throw on other errors
-        if (err.code !== '42704') {
+        if (typeof err === 'object' && getDriverErrorCode(err) !== '42704') {
           throw err;
         }
       },

--- a/packages/orm/src/migrations/generate/generators/tables.generator.test.ts
+++ b/packages/orm/src/migrations/generate/generators/tables.generator.test.ts
@@ -2,7 +2,6 @@ import { useGeneratorsTestUtils } from './generators.test-utils';
 import {
   DefaultColumnTypes,
   DefaultSchemaConfig,
-  defaultSchemaConfig,
   UnknownColumn,
   colors,
 } from 'pqb/internal';
@@ -115,7 +114,7 @@ describe('tables', () => {
               (t) => ({
                 naMe: t.string(),
                 iNt: t.integer(),
-                virtUal: new UnknownColumn(defaultSchemaConfig),
+                virtUal: UnknownColumn.instance,
                 creatEd: t.timestamps().createdAt,
                 updatEd: t.timestamps().updatedAt,
               }),

--- a/packages/orm/src/migrations/generate/generators/tables.generator.ts
+++ b/packages/orm/src/migrations/generate/generators/tables.generator.ts
@@ -376,10 +376,10 @@ const applyCompareSql = async (compareSql: CompareSql, adapter: Adapter) => {
       'SELECT ' +
         compareSql.expressions
           .map(
-            (x) =>
+            (x, i) =>
               `${freezeSqlClock(x.inDb)} = (${
                 x.inCode && freezeSqlClock(x.inCode)
-              })`,
+              }) "${i}"`,
           )
           .join(', '),
       compareSql.values,

--- a/packages/orm/src/migrations/migrations.test-utils.ts
+++ b/packages/orm/src/migrations/migrations.test-utils.ts
@@ -1,14 +1,9 @@
 import { RakeDbConfig, rakeDbConfigDefaults } from 'rake-db';
-import {
-  defaultSchemaConfig,
-  makeColumnTypes,
-  noop,
-  QueryLogger,
-} from 'pqb/internal';
+import { noop, QueryLogger } from 'pqb/internal';
 import path from 'node:path';
 import { join } from 'node:path';
 import { createBaseTable } from '../base-table';
-import { testColumnTypes } from 'test-utils';
+import { testColumnTypes, testDefaultColumnTypes } from 'test-utils';
 
 export const BaseTable = createBaseTable({
   columnTypes: testColumnTypes,
@@ -26,7 +21,7 @@ export const testConfig: RakeDbConfig & {
   baseTable: BaseTable,
   dbPath: 'src/db/db.ts',
   dbScript: 'dbScript.ts',
-  columnTypes: makeColumnTypes(defaultSchemaConfig),
+  columnTypes: testDefaultColumnTypes,
   log: false,
   logger: {
     log: jest.fn(),

--- a/packages/orm/src/migrations/pull/pull.test.ts
+++ b/packages/orm/src/migrations/pull/pull.test.ts
@@ -52,7 +52,11 @@ export const db = orchidORM({ databaseURL: 'url' }, {});
   dbFile?: string;
 }) => {
   adapters = options.map(
-    (config) => new AdapterClass({ driverAdapter: TestAdapter, config }),
+    (config) =>
+      new AdapterClass({
+        driverAdapter: TestAdapter,
+        config,
+      }),
   );
   closers = adapters.map((adapter) => () => adapter.close());
 

--- a/packages/orm/src/orm.ts
+++ b/packages/orm/src/orm.ts
@@ -438,7 +438,7 @@ const privateOrchidORMWithAdapter = <T extends TableClasses>(
 
     qb = _initQueryBuilder(
       adapter,
-      makeColumnTypes(defaultSchemaConfig),
+      makeColumnTypes(defaultSchemaConfig(adapter.driverAdapter.schemaConfig)),
       asyncStorage,
       commonOptions,
       options,

--- a/packages/orm/src/relations/belongsTo.ts
+++ b/packages/orm/src/relations/belongsTo.ts
@@ -20,7 +20,6 @@ import {
   VirtualColumn,
   WhereArg,
   TableData,
-  defaultSchemaConfig,
   ColumnSchemaConfig,
   emptyArray,
   EmptyObject,
@@ -46,6 +45,7 @@ import {
   noop,
   _queryInsertMany,
   _hookSelectColumns,
+  internalSchemaConfig,
 } from 'pqb/internal';
 import {
   RelationConfigSelf,
@@ -367,7 +367,7 @@ export const makeBelongsToMethod = (
       return query.where(obj as never);
     },
     virtualColumn: new BelongsToVirtualColumn(
-      defaultSchemaConfig,
+      internalSchemaConfig,
       relationName,
       state,
     ),

--- a/packages/orm/src/relations/hasAndBelongsToMany.ts
+++ b/packages/orm/src/relations/hasAndBelongsToMany.ts
@@ -40,10 +40,10 @@ import {
   RelationJoinQuery,
   toArray,
   toSnakeCase,
-  defaultSchemaConfig,
   Column,
   QueryHasWhere,
   QuerySchema,
+  internalSchemaConfig,
 } from 'pqb/internal';
 import {
   addAutoForeignKey,
@@ -405,7 +405,7 @@ export const makeHasAndBelongsToManyMethod = (
     },
     virtualColumn: new HasAndBelongsToManyVirtualColumn(
       subQuery,
-      defaultSchemaConfig,
+      internalSchemaConfig,
       relationName,
       state,
     ),

--- a/packages/orm/src/relations/hasMany.ts
+++ b/packages/orm/src/relations/hasMany.ts
@@ -19,7 +19,6 @@ import {
   PickQueryQ,
   _queryWhere,
   SelectableFromShape,
-  defaultSchemaConfig,
   ColumnSchemaConfig,
   EmptyObject,
   getPrimaryKeys,
@@ -39,6 +38,7 @@ import {
   _clone,
   _appendQuery,
   _queryUpsert,
+  internalSchemaConfig,
 } from 'pqb/internal';
 import {
   addAutoForeignKey,
@@ -477,7 +477,7 @@ export const makeHasManyMethod = (
       return _queryDefaults(query.where(values as never), { ...on, ...values });
     },
     virtualColumn: new HasManyVirtualColumn(
-      defaultSchemaConfig,
+      internalSchemaConfig,
       relationName,
       state,
     ),

--- a/packages/orm/src/relations/hasOne.ts
+++ b/packages/orm/src/relations/hasOne.ts
@@ -1,5 +1,5 @@
 import { Query } from 'pqb';
-import { Column, RawSql } from 'pqb/internal';
+import { Column, internalSchemaConfig, RawSql } from 'pqb/internal';
 import {
   _appendQuery,
   _clone,
@@ -18,7 +18,6 @@ import {
   CreateData,
   CreateManyMethodsNames,
   CreateMethodsNames,
-  defaultSchemaConfig,
   EmptyObject,
   getPrimaryKeys,
   isQueryReturnsAll,
@@ -565,7 +564,7 @@ export const makeHasOneMethod = (
       return _queryDefaults(query.where(values as never), { ...on, ...values });
     },
     virtualColumn: new HasOneVirtualColumn(
-      defaultSchemaConfig,
+      internalSchemaConfig,
       relationName,
       state,
     ),

--- a/packages/pqb/package.json
+++ b/packages/pqb/package.json
@@ -61,11 +61,23 @@
         "default": "./dist/postgres-js.mjs",
         "types": "./dist/postgres-js.d.ts"
       }
+    },
+    "./bun": {
+      "require": {
+        "default": "./dist/bun.js",
+        "types": "./dist/bun.d.ts"
+      },
+      "import": {
+        "default": "./dist/bun.mjs",
+        "types": "./dist/bun.d.ts"
+      }
     }
   },
   "scripts": {
     "test": "jest --watch --reporters default --verbose false",
+    "bun:test": "bun --bun jest --watch --reporters default --verbose false --runInBand",
     "check": "jest",
+    "bun:check": "bun --bun jest --runInBand",
     "check:coverage": "jest --coverage --coverageReporters json-summary",
     "types": "tsc",
     "build": "rimraf ./dist/ && rolldown -c ./rolldown.config.mjs",

--- a/packages/pqb/rolldown.config.mjs
+++ b/packages/pqb/rolldown.config.mjs
@@ -43,9 +43,15 @@ export default [
     forbidImportFrom: packageJson.name,
   }),
   ...rolldownExportFile('src/adapters/node-postgres', 'dist/node-postgres', {
+    allowImportFrom: join(src, 'adapters'),
     forbidImportFrom: src,
   }),
   ...rolldownExportFile('src/adapters/postgres-js', 'dist/postgres-js', {
+    allowImportFrom: join(src, 'adapters'),
+    forbidImportFrom: src,
+  }),
+  ...rolldownExportFile('src/adapters/bun', 'dist/bun', {
+    allowImportFrom: join(src, 'adapters'),
     forbidImportFrom: src,
   }),
 ];

--- a/packages/pqb/src/adapters/adapter.test.ts
+++ b/packages/pqb/src/adapters/adapter.test.ts
@@ -5,473 +5,486 @@ import {
   TransactionAdapterClass,
 } from './adapter';
 import { OrchidOrmInternalError, QueryError } from '../query/errors';
-import { allDriverAdapters, testDb, testDbOptions } from 'test-utils';
+import { allDriverAdapters, sql, testDb, testDbOptions } from 'test-utils';
+import { createDbWithAdapter } from 'pqb';
+import { DefaultSchemaConfig } from 'pqb/index';
 
 describe('adapter runtime abstractions', () => {
   afterEach(() => jest.clearAllMocks());
 
-  Object.entries(allDriverAdapters).forEach(([name, driverAdapter]) => {
-    describe(name, () => {
-      const counterTable = `"adapter_test_counter"`;
-      const getCounterValueSql = `SELECT "value" FROM ${counterTable}`;
-      const incrementCounterSql = `UPDATE ${counterTable} SET "value" = "value" + 1`;
-      let adapter: AdapterClass;
-
-      beforeAll(async () => {
-        adapter = new AdapterClass({
+  Object.entries(allDriverAdapters).forEach(
+    ([name, { adapter: driverAdapter, schemaConfig }]) => {
+      describe(name, () => {
+        const counterTable = `"adapter_test_counter"`;
+        const getCounterValueSql = `SELECT "value" FROM ${counterTable}`;
+        const incrementCounterSql = `UPDATE ${counterTable} SET "value" = "value" + 1`;
+        const adapter = new AdapterClass({
           driverAdapter,
           config: testDbOptions,
         });
 
-        try {
-          await adapter.query(
-            `CREATE TABLE ${counterTable} ("value" integer NOT NULL)`,
-          );
-          await adapter.query(
-            `INSERT INTO ${counterTable}("value") VALUES (0)`,
-          );
-        } finally {
+        const db = createDbWithAdapter({
+          adapter,
+          schema: () => 'schema',
+          schemaConfig: schemaConfig as () => DefaultSchemaConfig,
+        });
+
+        beforeAll(async () => {
+          try {
+            await adapter.query(
+              `CREATE TABLE ${counterTable} ("value" integer NOT NULL)`,
+            );
+            await adapter.query(
+              `INSERT INTO ${counterTable}("value") VALUES (0)`,
+            );
+          } finally {
+            await adapter.close();
+          }
+        });
+
+        afterEach(async () => {
           await adapter.close();
-        }
-      });
-
-      beforeEach(async () => {
-        adapter = new AdapterClass({
-          driverAdapter,
-          config: testDbOptions,
-        });
-      });
-
-      afterEach(async () => {
-        await adapter.close();
-      });
-
-      afterAll(async () => {
-        adapter = new AdapterClass({
-          driverAdapter,
-          config: testDbOptions,
         });
 
-        try {
-          await adapter.query(`DROP TABLE ${counterTable}`);
-        } finally {
-          await adapter.close();
-        }
-      });
-
-      it('runs query and can be reopened after close', async () => {
-        const beforeClose = await adapter.query<{ num: number }>(
-          'SELECT 1 as num',
-        );
-
-        expect(beforeClose).toMatchObject({
-          rowCount: 1,
-          rows: [{ num: 1 }],
-          fields: [{ name: 'num' }],
+        afterAll(async () => {
+          try {
+            await adapter.query(`DROP TABLE ${counterTable}`);
+          } finally {
+            await adapter.close();
+          }
         });
 
-        await adapter.close();
+        it('should support querying multiple queries', async () => {
+          const res = await adapter.query(`SELECT 1 as one; SELECT 2 as two`);
 
-        const afterClose = await adapter.query<{ num: number }>(
-          'SELECT 1 as num',
-        );
-        expect(afterClose.rows[0].num).toBe(1);
-      });
-
-      it('does not parse specific postgres types', async () => {
-        const res = await adapter.query<{
-          date: string;
-          timestamp: string;
-          timestamptz: string;
-          circle: string;
-        }>(`
-          SELECT
-            now()::date as date,
-            now()::timestamp as timestamp,
-            now()::timestamptz as timestamptz,
-            '((3,4),5)'::circle as circle
-        `);
-
-        expect(res.rows[0]).toEqual({
-          date: expect.any(String),
-          timestamp: expect.any(String),
-          timestamptz: expect.any(String),
-          circle: expect.any(String),
-        });
-      });
-
-      it('returns arrays result shape', async () => {
-        const res = await adapter.arrays<[number]>('SELECT 1 as num');
-
-        expect(res).toMatchObject({
-          rowCount: 1,
-          rows: [[1]],
-          fields: [{ name: 'num' }],
-        });
-      });
-
-      describe('transaction', () => {
-        it('executes transaction callback with TransactionAdapterClass', async () => {
-          const result = await adapter.transaction(
-            undefined,
-            undefined,
-            async (trx) => {
-              expect(trx).toBeInstanceOf(TransactionAdapterClass);
-              const res = await trx.query<{ one: number }>('SELECT 1 as one');
-              return res.rows[0].one;
+          expect(res).toMatchObject([
+            {
+              rows: [{ one: 1 }],
             },
-          );
-
-          expect(result).toBe(1);
-        });
-
-        it('supports transaction options string', async () => {
-          const spy = jest.spyOn(adapter.driverAdapter, 'begin');
-
-          await Promise.all([
-            adapter.transaction(
-              undefined,
-              { level: 'REPEATABLE READ' },
-              async () => {},
-            ),
-            adapter.transaction(
-              undefined,
-              { level: 'READ COMMITTED', readOnly: false, deferrable: false },
-              async () => {},
-            ),
-            adapter.transaction(
-              undefined,
-              { level: 'READ UNCOMMITTED', readOnly: true, deferrable: true },
-              async () => {},
-            ),
-          ]);
-
-          // expect(res.rows[0].one).toBe(1);
-          expect(spy.mock.calls.map((call) => call[2])).toEqual([
-            'ISOLATION LEVEL REPEATABLE READ',
-            'ISOLATION LEVEL READ COMMITTED READ WRITE NOT DEFERRABLE',
-            'ISOLATION LEVEL READ UNCOMMITTED READ ONLY DEFERRABLE',
+            {
+              rows: [{ two: 2 }],
+            },
           ]);
         });
 
-        it('should run a nested transaction with SAVEPOINT and RELEASE SAVEPOINT', async () => {
-          const beginSpy = jest.spyOn(adapter.driverAdapter, 'begin');
-          const savepointSpy = jest.spyOn(
-            TransactionAdapterClass.prototype,
-            'savepoint',
-          );
-          const querySpy = jest.spyOn(adapter.driverAdapter, 'queryClient');
+        describe('column types handling', () => {
+          const user = db('user', (t) => ({
+            id: t.identity().primaryKey(),
+            name: t.text(),
+            password: t.text(),
+            data: t.json(),
+          }));
 
-          const {
-            rows: [{ result }],
-          } = await adapter.transaction(
-            testDb.internal.asyncStorage,
-            undefined,
-            async () =>
-              await adapter.transaction(
-                testDb.internal.asyncStorage,
+          const rollback = new Error('rollback');
+          const inTestTransaction = async (cb: () => Promise<void>) => {
+            await db
+              .transaction(async () => {
+                await cb();
+                throw rollback;
+              })
+              .catch((err) => {
+                if (err !== rollback) {
+                  throw err;
+                }
+              });
+          };
+
+          it('should store and parse json properly', async () => {
+            await inTestTransaction(async () => {
+              await user.insert({
+                name: 'name',
+                password: 'password',
+                data: [1, 'foo', { bar: true }],
+              });
+
+              const data = await user.get('data');
+              expect(data).toEqual([1, 'foo', { bar: true }]);
+            });
+          });
+
+          it('should parse array of jsons', async () => {
+            const testTable = db(
+              'adapter-test-table',
+              (t) => ({
+                array: t.array(t.json()),
+              }),
+              undefined,
+              { noPrimaryKey: 'ignore' },
+            );
+
+            await inTestTransaction(async () => {
+              await db.query`CREATE TABLE "schema"."adapter-test-table" ( "array" jsonb[] )`;
+
+              await testTable.insert({
+                array: [{ foo: 1 }, { bar: 'str' }],
+              });
+
+              const data = await testTable.get('array');
+
+              expect(data).toEqual([{ foo: 1 }, { bar: 'str' }]);
+            });
+          });
+
+          it('should parse interval', async () => {
+            const testTable = db(
+              'adapter-test-table',
+              (t) => ({
+                interval: t.interval(),
+              }),
+              undefined,
+              { noPrimaryKey: 'ignore' },
+            );
+
+            await inTestTransaction(async () => {
+              await db.query`CREATE TABLE "schema"."adapter-test-table" ( "interval" interval )`;
+
+              await testTable.insert({
+                interval: {
+                  years: 1,
+                  months: 2,
+                  days: 3,
+                  hours: 4,
+                  minutes: 5,
+                  seconds: 6,
+                  milliseconds: 7,
+                },
+              });
+
+              const data = await testTable.get('interval');
+
+              expect(data).toMatchObject({
+                years: 1,
+                months: 2,
+                days: 3,
+                hours: 4,
+                minutes: 5,
+                seconds: 6,
+                milliseconds: 7,
+              });
+            });
+          });
+        });
+
+        it('runs query and can be reopened after close', async () => {
+          const beforeClose = await adapter.query<{ num: number }>(
+            'SELECT 1 as num',
+          );
+
+          expect(beforeClose).toMatchObject({
+            rowCount: 1,
+            rows: [{ num: 1 }],
+            fields: [{ name: 'num' }],
+          });
+
+          await adapter.close();
+
+          const afterClose = await adapter.query<{ num: number }>(
+            'SELECT 1 as num',
+          );
+          expect(afterClose.rows[0].num).toBe(1);
+        });
+
+        it('does not parse specific postgres types', async () => {
+          const res = await db
+            .withSql(
+              'w',
+              // define column types of the expression:
+              (t) => ({
+                date: t.date(),
+                timestamp: t.timestamp(),
+                timestampNoTZ: t.timestampNoTZ(),
+                circle: t.circle(),
+              }),
+              // define SQL expression:
+              () =>
+                sql`VALUES (now()::date, now()::timestamptz, now()::timestamp, '((3,4),5)'::circle)`,
+            )
+            .from('w');
+
+          expect(res[0]).toEqual({
+            date: expect.any(String),
+            timestamp: expect.any(String),
+            timestampNoTZ: expect.any(String),
+            circle: expect.any(String),
+          });
+        });
+
+        it('returns arrays result shape', async () => {
+          const res = await adapter.arrays<[number]>('SELECT 1 as num');
+
+          expect(res).toMatchObject({
+            rowCount: 1,
+            rows: [[1]],
+          });
+        });
+
+        describe('transaction', () => {
+          it('executes transaction callback with TransactionAdapterClass', async () => {
+            const result = await adapter.transaction(
+              undefined,
+              undefined,
+              async (trx) => {
+                expect(trx).toBeInstanceOf(TransactionAdapterClass);
+                const res = await trx.query<{ one: number }>('SELECT 1 as one');
+                return res.rows[0].one;
+              },
+            );
+
+            expect(result).toBe(1);
+          });
+
+          it('supports transaction options string', async () => {
+            const spy = jest.spyOn(adapter.driverAdapter, 'begin');
+
+            await Promise.all([
+              adapter.transaction(
                 undefined,
-                async (client) => client.query('SELECT 123 as result'),
+                { level: 'REPEATABLE READ' },
+                async () => {},
               ),
-          );
+              adapter.transaction(
+                undefined,
+                { level: 'READ COMMITTED', readOnly: false, deferrable: false },
+                async () => {},
+              ),
+              adapter.transaction(
+                undefined,
+                { level: 'READ UNCOMMITTED', readOnly: true, deferrable: true },
+                async () => {},
+              ),
+            ]);
 
-          expect(result).toBe(123);
+            // expect(res.rows[0].one).toBe(1);
+            expect(spy.mock.calls.map((call) => call[2])).toEqual([
+              'ISOLATION LEVEL REPEATABLE READ',
+              'ISOLATION LEVEL READ COMMITTED READ WRITE NOT DEFERRABLE',
+              'ISOLATION LEVEL READ UNCOMMITTED READ ONLY DEFERRABLE',
+            ]);
+          });
 
-          expect(beginSpy).toHaveBeenCalledTimes(1);
-          expect(savepointSpy).toHaveBeenCalledTimes(1);
-          expect(querySpy.mock.calls.map((call) => call[1])).toEqual([
-            'SELECT 123 as result',
-          ]);
-        });
+          it('should run a nested transaction with SAVEPOINT and RELEASE SAVEPOINT', async () => {
+            const beginSpy = jest.spyOn(adapter.driverAdapter, 'begin');
+            const savepointSpy = jest.spyOn(
+              TransactionAdapterClass.prototype,
+              'savepoint',
+            );
+            const querySpy = jest.spyOn(adapter.driverAdapter, 'queryClient');
 
-        it('should rollback a nested transaction with ROLLBACK TO SAVEPOINT', async () => {
-          const beginSpy = jest.spyOn(adapter.driverAdapter, 'begin');
-          const savepointSpy = jest.spyOn(
-            TransactionAdapterClass.prototype,
-            'savepoint',
-          );
-          const querySpy = jest.spyOn(adapter.driverAdapter, 'queryClient');
-
-          await expect(() =>
-            adapter.transaction(
+            const {
+              rows: [{ result }],
+            } = await adapter.transaction(
               testDb.internal.asyncStorage,
               undefined,
               async () =>
                 await adapter.transaction(
                   testDb.internal.asyncStorage,
                   undefined,
-                  async () => {
-                    throw new Error('error');
-                  },
+                  async (client) => client.query('SELECT 123 as result'),
                 ),
-            ),
-          ).rejects.toThrow('error');
-
-          expect(beginSpy).toHaveBeenCalledTimes(1);
-          expect(savepointSpy).toHaveBeenCalledTimes(1);
-          expect(querySpy.mock.calls.map((call) => call[1])).toEqual([]);
-        });
-
-        it('sets search_path for transaction setConfig', async () => {
-          const res = await adapter.transaction(
-            undefined,
-            { setConfig: { search_path: 'schema' } },
-            async (trx) =>
-              trx.query<{ search_path: string }>('SHOW search_path'),
-          );
-
-          expect(res.rows[0].search_path).toBe('schema');
-        });
-
-        it('temporarily overrides setConfig in nested transaction call', async () => {
-          const getSearchPath = async (trx: Adapter) => {
-            const res = await trx.query<{ search_path: string }>(
-              'SHOW search_path',
             );
-            return res.rows[0].search_path;
-          };
 
-          const res = await adapter.transaction(
-            testDb.internal.asyncStorage,
-            { setConfig: { search_path: 'public' } },
-            async (trx) => {
-              const before = await getSearchPath(trx);
-              const nested = await trx.transaction(
-                testDb.internal.asyncStorage,
-                { setConfig: { search_path: 'schema' } },
-                (nestedTrx) => getSearchPath(nestedTrx),
-              );
-              const after = await getSearchPath(trx);
-              return { before, nested, after };
-            },
-          );
+            expect(result).toBe(123);
 
-          expect(res).toEqual({
-            before: 'public',
-            nested: 'schema',
-            after: 'public',
+            expect(beginSpy).toHaveBeenCalledTimes(1);
+            expect(savepointSpy).toHaveBeenCalledTimes(1);
+            expect(querySpy.mock.calls.map((call) => call[1])).toEqual([
+              'SELECT 123 as result',
+            ]);
           });
-        });
 
-        it('sets arbitrary setConfig and restores after nested transaction', async () => {
-          const getLocal = async (trx: Adapter) => {
-            const res = await trx.query<{ value: string }>(
-              `SELECT current_setting('app.user_id', true) as value`,
+          it('should rollback a nested transaction with ROLLBACK TO SAVEPOINT', async () => {
+            const beginSpy = jest.spyOn(adapter.driverAdapter, 'begin');
+            const savepointSpy = jest.spyOn(
+              TransactionAdapterClass.prototype,
+              'savepoint',
             );
-            return res.rows[0].value;
-          };
+            const querySpy = jest.spyOn(adapter.driverAdapter, 'queryClient');
 
-          const res = await adapter.transaction(
-            testDb.internal.asyncStorage,
-            { setConfig: { 'app.user_id': '1' } },
-            async (trx) => {
-              const before = await getLocal(trx);
-              const nested = await trx.transaction(
+            await expect(() =>
+              adapter.transaction(
                 testDb.internal.asyncStorage,
-                { setConfig: { 'app.user_id': '2' } },
-                (nestedTrx) => getLocal(nestedTrx),
-              );
-              const after = await getLocal(trx);
-              return { before, nested, after };
-            },
-          );
+                undefined,
+                async () =>
+                  await adapter.transaction(
+                    testDb.internal.asyncStorage,
+                    undefined,
+                    async () => {
+                      throw new Error('error');
+                    },
+                  ),
+              ),
+            ).rejects.toThrow('error');
 
-          expect(res).toEqual({
-            before: '1',
-            nested: '2',
-            after: '1',
+            expect(beginSpy).toHaveBeenCalledTimes(1);
+            expect(savepointSpy).toHaveBeenCalledTimes(1);
+            expect(querySpy.mock.calls.map((call) => call[1])).toEqual([]);
           });
-        });
 
-        it('stores transaction session context in async storage', async () => {
-          await adapter.transaction(
-            testDb.internal.asyncStorage,
-            {
-              role: 'app-user',
-              setConfig: {
-                'app.user_id': 1,
+          it('sets search_path for transaction setConfig', async () => {
+            const res = await adapter.transaction(
+              undefined,
+              { setConfig: { search_path: 'schema' } },
+              async (trx) =>
+                trx.query<{ search_path: string }>('SHOW search_path'),
+            );
+
+            expect(res.rows[0].search_path).toBe('schema');
+          });
+
+          it('temporarily overrides setConfig in nested transaction call', async () => {
+            const getSearchPath = async (trx: Adapter) => {
+              const res = await trx.query<{ search_path: string }>(
+                'SHOW search_path',
+              );
+              return res.rows[0].search_path;
+            };
+
+            const res = await adapter.transaction(
+              testDb.internal.asyncStorage,
+              { setConfig: { search_path: 'public' } },
+              async (trx) => {
+                const before = await getSearchPath(trx);
+                const nested = await trx.transaction(
+                  testDb.internal.asyncStorage,
+                  { setConfig: { search_path: 'schema' } },
+                  (nestedTrx) => getSearchPath(nestedTrx),
+                );
+                const after = await getSearchPath(trx);
+                return { before, nested, after };
               },
-            },
-            async () => {
-              const state = testDb.internal.asyncStorage.getStore();
+            );
 
-              expect(state?.role).toBeUndefined();
-              expect(state?.setConfig).toBeUndefined();
-              expect(state?.transactionRole).toBe('app-user');
-              expect(state?.transactionSetConfig).toMatchObject({
-                'app.user_id': 1,
-              });
-            },
-          );
-        });
+            expect(res).toEqual({
+              before: 'public',
+              nested: 'schema',
+              after: 'public',
+            });
+          });
 
-        it('restores top-level transaction session context when reusing existing async storage state', async () => {
-          await testDb.internal.asyncStorage.run(
-            {
-              transactionRole: 'outer-role',
-              transactionSetConfig: {
-                'app.outer': 'outer-value',
+          it('sets arbitrary setConfig and restores after nested transaction', async () => {
+            const getLocal = async (trx: Adapter) => {
+              const res = await trx.query<{ value: string }>(
+                `SELECT current_setting('app.user_id', true) as value`,
+              );
+              return res.rows[0].value;
+            };
+
+            const res = await adapter.transaction(
+              testDb.internal.asyncStorage,
+              { setConfig: { 'app.user_id': '1' } },
+              async (trx) => {
+                const before = await getLocal(trx);
+                const nested = await trx.transaction(
+                  testDb.internal.asyncStorage,
+                  { setConfig: { 'app.user_id': '2' } },
+                  (nestedTrx) => getLocal(nestedTrx),
+                );
+                const after = await getLocal(trx);
+                return { before, nested, after };
               },
-            },
-            async () => {
-              const before = testDb.internal.asyncStorage.getStore();
+            );
 
-              expect(before?.transactionRole).toBe('outer-role');
-              expect(before?.transactionSetConfig).toEqual({
-                'app.outer': 'outer-value',
-              });
+            expect(res).toEqual({
+              before: '1',
+              nested: '2',
+              after: '1',
+            });
+          });
 
-              await adapter.transaction(
-                testDb.internal.asyncStorage,
-                {
-                  role: 'app-user',
-                  setConfig: {
-                    'app.user_id': '42',
+          it('stores transaction session context in async storage', async () => {
+            await adapter.transaction(
+              testDb.internal.asyncStorage,
+              {
+                role: 'app-user',
+                setConfig: {
+                  'app.user_id': 1,
+                },
+              },
+              async () => {
+                const state = testDb.internal.asyncStorage.getStore();
+
+                expect(state?.role).toBeUndefined();
+                expect(state?.setConfig).toBeUndefined();
+                expect(state?.transactionRole).toBe('app-user');
+                expect(state?.transactionSetConfig).toMatchObject({
+                  'app.user_id': 1,
+                });
+              },
+            );
+          });
+
+          it('restores top-level transaction session context when reusing existing async storage state', async () => {
+            await testDb.internal.asyncStorage.run(
+              {
+                transactionRole: 'outer-role',
+                transactionSetConfig: {
+                  'app.outer': 'outer-value',
+                },
+              },
+              async () => {
+                const before = testDb.internal.asyncStorage.getStore();
+
+                expect(before?.transactionRole).toBe('outer-role');
+                expect(before?.transactionSetConfig).toEqual({
+                  'app.outer': 'outer-value',
+                });
+
+                await adapter.transaction(
+                  testDb.internal.asyncStorage,
+                  {
+                    role: 'app-user',
+                    setConfig: {
+                      'app.user_id': '42',
+                    },
                   },
-                },
-                async () => {
-                  const during = testDb.internal.asyncStorage.getStore();
+                  async () => {
+                    const during = testDb.internal.asyncStorage.getStore();
 
-                  expect(during?.transactionRole).toBe('app-user');
-                  expect(during?.transactionSetConfig).toEqual({
-                    'app.outer': 'outer-value',
-                    'app.user_id': '42',
-                  });
-                },
-              );
-
-              const after = testDb.internal.asyncStorage.getStore();
-              expect(after?.transactionRole).toBe('outer-role');
-              expect(after?.transactionSetConfig).toEqual({
-                'app.outer': 'outer-value',
-              });
-            },
-          );
-        });
-
-        it('overrides and restores transaction session context for nested transactions', async () => {
-          const currentRole = adapter.getUser();
-
-          await adapter.transaction(
-            testDb.internal.asyncStorage,
-            {
-              role: 'app-user',
-              setConfig: {
-                'app.user_id': '1',
-              },
-            },
-            async (trx) => {
-              const before = testDb.internal.asyncStorage.getStore();
-
-              expect(before?.transactionRole).toBe('app-user');
-              expect(before?.transactionSetConfig).toMatchObject({
-                'app.user_id': '1',
-              });
-
-              const [role, userId] = await Promise.all([
-                trx.query('SELECT current_role role'),
-                trx.query(`SELECT current_setting('app.user_id') "userId"`),
-              ]);
-
-              expect(role).toMatchObject({ rows: [{ role: 'app-user' }] });
-              expect(userId).toMatchObject({ rows: [{ userId: '1' }] });
-
-              await trx.transaction(
-                testDb.internal.asyncStorage,
-                {
-                  role: currentRole,
-                  setConfig: {
-                    'app.tenant_id': 'tenant-2',
+                    expect(during?.transactionRole).toBe('app-user');
+                    expect(during?.transactionSetConfig).toEqual({
+                      'app.outer': 'outer-value',
+                      'app.user_id': '42',
+                    });
                   },
+                );
+
+                const after = testDb.internal.asyncStorage.getStore();
+                expect(after?.transactionRole).toBe('outer-role');
+                expect(after?.transactionSetConfig).toEqual({
+                  'app.outer': 'outer-value',
+                });
+              },
+            );
+          });
+
+          it('overrides and restores transaction session context for nested transactions', async () => {
+            const currentRole = adapter.getUser();
+
+            await adapter.transaction(
+              testDb.internal.asyncStorage,
+              {
+                role: 'app-user',
+                setConfig: {
+                  'app.user_id': '1',
                 },
-                async () => {
-                  const nested = testDb.internal.asyncStorage.getStore();
+              },
+              async (trx) => {
+                const before = testDb.internal.asyncStorage.getStore();
 
-                  expect(nested?.transactionRole).toBe(currentRole);
-                  expect(nested?.transactionSetConfig).toMatchObject({
-                    'app.user_id': '1',
-                    'app.tenant_id': 'tenant-2',
-                  });
+                expect(before?.transactionRole).toBe('app-user');
+                expect(before?.transactionSetConfig).toMatchObject({
+                  'app.user_id': '1',
+                });
 
-                  const [role, userId, tenantId] = await Promise.all([
-                    trx.query('SELECT current_role role'),
-                    trx.query(`SELECT current_setting('app.user_id') "userId"`),
-                    trx.query(
-                      `SELECT current_setting('app.tenant_id') "tenantId"`,
-                    ),
-                  ]);
-
-                  expect(role).toMatchObject({ rows: [{ role: currentRole }] });
-                  expect(userId).toMatchObject({ rows: [{ userId: '1' }] });
-                  expect(tenantId).toMatchObject({
-                    rows: [{ tenantId: 'tenant-2' }],
-                  });
-                },
-              );
-
-              const after = testDb.internal.asyncStorage.getStore();
-
-              expect(after?.transactionRole).toBe('app-user');
-              expect(after?.transactionSetConfig).toEqual(
-                before?.transactionSetConfig,
-              );
-
-              const [afterRole, afterUserId, afterTenantId] = await Promise.all(
-                [
+                const [role, userId] = await Promise.all([
                   trx.query('SELECT current_role role'),
                   trx.query(`SELECT current_setting('app.user_id') "userId"`),
-                  trx.query(
-                    `SELECT current_setting('app.tenant_id') "tenantId"`,
-                  ),
-                ],
-              );
+                ]);
 
-              expect(afterRole).toMatchObject(role);
-              expect(afterUserId).toMatchObject(userId);
-              expect(afterTenantId).toMatchObject({
-                rows: [{ tenantId: '' }],
-              });
-            },
-          );
+                expect(role).toMatchObject({ rows: [{ role: 'app-user' }] });
+                expect(userId).toMatchObject({ rows: [{ userId: '1' }] });
 
-          const [afterRole, afterUserId, afterTenantId] = await Promise.all([
-            adapter.query('SELECT current_role role'),
-            adapter.query(
-              `SELECT current_setting('app.user_id', true) "userId"`,
-            ),
-            adapter.query(
-              `SELECT current_setting('app.tenant_id', true) "tenantId"`,
-            ),
-          ]);
-
-          expect(afterRole).toMatchObject({ rows: [{ role: currentRole }] });
-          expect(afterUserId).toMatchObject({ rows: [{ userId: null }] });
-          expect(afterTenantId).toMatchObject({
-            rows: [{ tenantId: null }],
-          });
-        });
-
-        it('restores role and setConfig after nested transaction failure', async () => {
-          const currentRole = adapter.getUser();
-
-          await adapter.transaction(
-            testDb.internal.asyncStorage,
-            {
-              role: 'app-user',
-              setConfig: {
-                'app.user_id': '1',
-              },
-            },
-            async (trx) => {
-              const before = testDb.internal.asyncStorage.getStore();
-
-              expect(before?.transactionRole).toBe('app-user');
-              expect(before?.transactionSetConfig).toMatchObject({
-                'app.user_id': '1',
-              });
-
-              await expect(
-                trx.transaction(
+                await trx.transaction(
                   testDb.internal.asyncStorage,
                   {
                     role: currentRole,
@@ -488,95 +501,7 @@ describe('adapter runtime abstractions', () => {
                       'app.tenant_id': 'tenant-2',
                     });
 
-                    await trx.query(
-                      'SELECT * FROM "schema"."table_that_does_not_exist"',
-                    );
-                  },
-                ),
-              ).rejects.toThrow();
-
-              const after = testDb.internal.asyncStorage.getStore();
-
-              expect(after?.transactionRole).toBe('app-user');
-              expect(after?.transactionSetConfig).toEqual(
-                before?.transactionSetConfig,
-              );
-
-              const [role, userId, tenantId] = await Promise.all([
-                trx.query('SELECT current_role role'),
-                trx.query(`SELECT current_setting('app.user_id') "userId"`),
-                trx.query(
-                  `SELECT current_setting('app.tenant_id', true) "tenantId"`,
-                ),
-              ]);
-
-              expect(role).toMatchObject({ rows: [{ role: 'app-user' }] });
-              expect(userId).toMatchObject({ rows: [{ userId: '1' }] });
-              expect(tenantId).toMatchObject({ rows: [{ tenantId: '' }] });
-            },
-          );
-        });
-
-        it('restores effective parent context for deeper nested transactions', async () => {
-          const currentRole = adapter.getUser();
-
-          await adapter.transaction(
-            testDb.internal.asyncStorage,
-            {
-              role: 'app-user',
-              setConfig: {
-                'app.user_id': '1',
-              },
-            },
-            async (trx) => {
-              await trx.transaction(
-                testDb.internal.asyncStorage,
-                {
-                  role: currentRole,
-                  setConfig: {
-                    'app.tenant_id': 'tenant-2',
-                  },
-                },
-                async () => {
-                  await trx.transaction(
-                    testDb.internal.asyncStorage,
-                    {
-                      role: 'app-user',
-                      setConfig: {
-                        'app.user_id': '3',
-                        'app.project_id': 'project-3',
-                      },
-                    },
-                    async () => {
-                      const [role, userId, tenantId, projectId] =
-                        await Promise.all([
-                          trx.query('SELECT current_role role'),
-                          trx.query(
-                            `SELECT current_setting('app.user_id') "userId"`,
-                          ),
-                          trx.query(
-                            `SELECT current_setting('app.tenant_id') "tenantId"`,
-                          ),
-                          trx.query(
-                            `SELECT current_setting('app.project_id') "projectId"`,
-                          ),
-                        ]);
-
-                      expect(role).toMatchObject({
-                        rows: [{ role: 'app-user' }],
-                      });
-                      expect(userId).toMatchObject({ rows: [{ userId: '3' }] });
-                      expect(tenantId).toMatchObject({
-                        rows: [{ tenantId: 'tenant-2' }],
-                      });
-                      expect(projectId).toMatchObject({
-                        rows: [{ projectId: 'project-3' }],
-                      });
-                    },
-                  );
-
-                  const [role, userId, tenantId, projectId] = await Promise.all(
-                    [
+                    const [role, userId, tenantId] = await Promise.all([
                       trx.query('SELECT current_role role'),
                       trx.query(
                         `SELECT current_setting('app.user_id') "userId"`,
@@ -584,206 +509,377 @@ describe('adapter runtime abstractions', () => {
                       trx.query(
                         `SELECT current_setting('app.tenant_id') "tenantId"`,
                       ),
-                      trx.query(
-                        `SELECT current_setting('app.project_id', true) "projectId"`,
-                      ),
-                    ],
-                  );
+                    ]);
 
-                  expect(role).toMatchObject({ rows: [{ role: currentRole }] });
-                  expect(userId).toMatchObject({ rows: [{ userId: '1' }] });
-                  expect(tenantId).toMatchObject({
-                    rows: [{ tenantId: 'tenant-2' }],
-                  });
-                  expect(projectId).toMatchObject({
-                    rows: [{ projectId: '' }],
-                  });
-                },
-              );
+                    expect(role).toMatchObject({
+                      rows: [{ role: currentRole }],
+                    });
+                    expect(userId).toMatchObject({ rows: [{ userId: '1' }] });
+                    expect(tenantId).toMatchObject({
+                      rows: [{ tenantId: 'tenant-2' }],
+                    });
+                  },
+                );
 
-              const [role, userId, tenantId, projectId] = await Promise.all([
-                trx.query('SELECT current_role role'),
-                trx.query(`SELECT current_setting('app.user_id') "userId"`),
-                trx.query(
-                  `SELECT current_setting('app.tenant_id', true) "tenantId"`,
-                ),
-                trx.query(
-                  `SELECT current_setting('app.project_id', true) "projectId"`,
-                ),
-              ]);
+                const after = testDb.internal.asyncStorage.getStore();
 
-              expect(role).toMatchObject({ rows: [{ role: 'app-user' }] });
-              expect(userId).toMatchObject({ rows: [{ userId: '1' }] });
-              expect(tenantId).toMatchObject({ rows: [{ tenantId: '' }] });
-              expect(projectId).toMatchObject({ rows: [{ projectId: '' }] });
-            },
-          );
-        });
+                expect(after?.transactionRole).toBe('app-user');
+                expect(after?.transactionSetConfig).toEqual(
+                  before?.transactionSetConfig,
+                );
 
-        it('keeps withOptions nested-scope behavior unchanged inside transaction context', async () => {
-          await adapter.transaction(
-            testDb.internal.asyncStorage,
-            {
-              role: 'app-user',
-              setConfig: {
-                'app.tx': 'value',
-              },
-            },
-            async () => {
-              await testDb.withOptions({ role: 'app_user' }, async () => {
-                const state = testDb.internal.asyncStorage.getStore();
-
-                expect(state?.transactionRole).toBe('app-user');
-                expect(state?.role).toBe('app_user');
-
-                await expect(
-                  testDb.withOptions({ role: 'other_role' }, async () => {}),
-                ).rejects.toThrow(OrchidOrmInternalError);
-              });
-
-              await testDb.withOptions(
-                { setConfig: { 'app.scope_a': 'a' } },
-                async () => {
-                  await expect(
-                    testDb.withOptions(
-                      { setConfig: { 'app.scope_b': 'b' } },
-                      async () => {},
+                const [afterRole, afterUserId, afterTenantId] =
+                  await Promise.all([
+                    trx.query('SELECT current_role role'),
+                    trx.query(`SELECT current_setting('app.user_id') "userId"`),
+                    trx.query(
+                      `SELECT current_setting('app.tenant_id') "tenantId"`,
                     ),
-                  ).rejects.toThrow(OrchidOrmInternalError);
-                },
-              );
-            },
-          );
-        });
-      });
+                  ]);
 
-      describe('hackySavepoint', () => {
-        const getCounterValue = async (trx: Adapter) => {
-          const res = await trx.query<{ value: number }>(getCounterValueSql);
-          return res.rows[0].value;
-        };
-
-        beforeEach(async () => {
-          await adapter.query(`UPDATE ${counterTable} SET "value" = 0`);
-        });
-
-        it('persists savepoint changes after release', async () => {
-          const before = await getCounterValue(adapter);
-
-          await adapter.transaction(undefined, undefined, async (trx) => {
-            const state: HackySavepointState = { name: 'hacky_release' };
-
-            const res = await trx.hackySavepoint<{ value: number }>(
-              state,
-              `${incrementCounterSql} RETURNING "value"`,
+                expect(afterRole).toMatchObject(role);
+                expect(afterUserId).toMatchObject(userId);
+                expect(afterTenantId).toMatchObject({
+                  rows: [{ tenantId: '' }],
+                });
+              },
             );
 
-            expect(res.rows[0].value).toBe(before + 1);
-
-            await trx.query(incrementCounterSql);
-
-            await state.activeSavepoint!.release();
-          });
-
-          const after = await getCounterValue(adapter);
-          expect(after).toBe(before + 2);
-        });
-
-        it('rolls back savepoint changes when rollback is called', async () => {
-          const before = await getCounterValue(adapter);
-          const err = new Error('rollback savepoint');
-
-          await adapter.transaction(undefined, undefined, async (trx) => {
-            const state: HackySavepointState = { name: 'hacky_rollback' };
-
-            await trx.hackySavepoint(state, incrementCounterSql);
-            await trx.query(incrementCounterSql);
-
-            await state.activeSavepoint!.rollback(err);
-          });
-
-          const after = await getCounterValue(adapter);
-          expect(after).toBe(before);
-        });
-
-        it('continues transaction after savepoint rollback', async () => {
-          const before = await getCounterValue(adapter);
-
-          await adapter.transaction(undefined, undefined, async (trx) => {
-            const state: HackySavepointState = { name: 'hacky_continue' };
-
-            await trx.hackySavepoint(state, incrementCounterSql);
-            await trx.query(incrementCounterSql);
-
-            await state.activeSavepoint!.rollback(new Error('rollback'));
-
-            await trx.query(incrementCounterSql);
-          });
-
-          const after = await getCounterValue(adapter);
-          expect(after).toBe(before + 1);
-        });
-
-        it('auto-rolls back on savepoint query failure and release fails afterwards', async () => {
-          const before = await getCounterValue(adapter);
-
-          await adapter.transaction(undefined, undefined, async (trx) => {
-            const state: HackySavepointState = { name: 'hacky_query_fail' };
-
-            await expect(
-              trx.hackySavepoint(
-                state,
-                'SELECT * FROM "table_that_does_not_exist"',
+            const [afterRole, afterUserId, afterTenantId] = await Promise.all([
+              adapter.query('SELECT current_role role'),
+              adapter.query(
+                `SELECT current_setting('app.user_id', true) "userId"`,
               ),
-            ).rejects.toThrow();
+              adapter.query(
+                `SELECT current_setting('app.tenant_id', true) "tenantId"`,
+              ),
+            ]);
 
-            await expect(state.activeSavepoint!.release()).rejects.toThrow();
-
-            await trx.query(incrementCounterSql);
+            expect(afterRole).toMatchObject({ rows: [{ role: currentRole }] });
+            expect(afterUserId).toMatchObject({ rows: [{ userId: null }] });
+            expect(afterTenantId).toMatchObject({
+              rows: [{ tenantId: null }],
+            });
           });
 
-          const after = await getCounterValue(adapter);
-          expect(after).toBe(before + 1);
+          it('restores role and setConfig after nested transaction failure', async () => {
+            const currentRole = adapter.getUser();
+
+            await adapter.transaction(
+              testDb.internal.asyncStorage,
+              {
+                role: 'app-user',
+                setConfig: {
+                  'app.user_id': '1',
+                },
+              },
+              async (trx) => {
+                const before = testDb.internal.asyncStorage.getStore();
+
+                expect(before?.transactionRole).toBe('app-user');
+                expect(before?.transactionSetConfig).toMatchObject({
+                  'app.user_id': '1',
+                });
+
+                await expect(
+                  trx.transaction(
+                    testDb.internal.asyncStorage,
+                    {
+                      role: currentRole,
+                      setConfig: {
+                        'app.tenant_id': 'tenant-2',
+                      },
+                    },
+                    async () => {
+                      const nested = testDb.internal.asyncStorage.getStore();
+
+                      expect(nested?.transactionRole).toBe(currentRole);
+                      expect(nested?.transactionSetConfig).toMatchObject({
+                        'app.user_id': '1',
+                        'app.tenant_id': 'tenant-2',
+                      });
+
+                      await trx.query(
+                        'SELECT * FROM "schema"."table_that_does_not_exist"',
+                      );
+                    },
+                  ),
+                ).rejects.toThrow();
+
+                const after = testDb.internal.asyncStorage.getStore();
+
+                expect(after?.transactionRole).toBe('app-user');
+                expect(after?.transactionSetConfig).toEqual(
+                  before?.transactionSetConfig,
+                );
+
+                const [role, userId, tenantId] = await Promise.all([
+                  trx.query('SELECT current_role role'),
+                  trx.query(`SELECT current_setting('app.user_id') "userId"`),
+                  trx.query(
+                    `SELECT current_setting('app.tenant_id', true) "tenantId"`,
+                  ),
+                ]);
+
+                expect(role).toMatchObject({ rows: [{ role: 'app-user' }] });
+                expect(userId).toMatchObject({ rows: [{ userId: '1' }] });
+                expect(tenantId).toMatchObject({ rows: [{ tenantId: '' }] });
+              },
+            );
+          });
+
+          it('restores effective parent context for deeper nested transactions', async () => {
+            const currentRole = adapter.getUser();
+
+            await adapter.transaction(
+              testDb.internal.asyncStorage,
+              {
+                role: 'app-user',
+                setConfig: {
+                  'app.user_id': '1',
+                },
+              },
+              async (trx) => {
+                await trx.transaction(
+                  testDb.internal.asyncStorage,
+                  {
+                    role: currentRole,
+                    setConfig: {
+                      'app.tenant_id': 'tenant-2',
+                    },
+                  },
+                  async () => {
+                    await trx.transaction(
+                      testDb.internal.asyncStorage,
+                      {
+                        role: 'app-user',
+                        setConfig: {
+                          'app.user_id': '3',
+                          'app.project_id': 'project-3',
+                        },
+                      },
+                      async () => {
+                        const [role, userId, tenantId, projectId] =
+                          await Promise.all([
+                            trx.query('SELECT current_role role'),
+                            trx.query(
+                              `SELECT current_setting('app.user_id') "userId"`,
+                            ),
+                            trx.query(
+                              `SELECT current_setting('app.tenant_id') "tenantId"`,
+                            ),
+                            trx.query(
+                              `SELECT current_setting('app.project_id') "projectId"`,
+                            ),
+                          ]);
+
+                        expect(role).toMatchObject({
+                          rows: [{ role: 'app-user' }],
+                        });
+                        expect(userId).toMatchObject({
+                          rows: [{ userId: '3' }],
+                        });
+                        expect(tenantId).toMatchObject({
+                          rows: [{ tenantId: 'tenant-2' }],
+                        });
+                        expect(projectId).toMatchObject({
+                          rows: [{ projectId: 'project-3' }],
+                        });
+                      },
+                    );
+
+                    const [role, userId, tenantId, projectId] =
+                      await Promise.all([
+                        trx.query('SELECT current_role role'),
+                        trx.query(
+                          `SELECT current_setting('app.user_id') "userId"`,
+                        ),
+                        trx.query(
+                          `SELECT current_setting('app.tenant_id') "tenantId"`,
+                        ),
+                        trx.query(
+                          `SELECT current_setting('app.project_id', true) "projectId"`,
+                        ),
+                      ]);
+
+                    expect(role).toMatchObject({
+                      rows: [{ role: currentRole }],
+                    });
+                    expect(userId).toMatchObject({ rows: [{ userId: '1' }] });
+                    expect(tenantId).toMatchObject({
+                      rows: [{ tenantId: 'tenant-2' }],
+                    });
+                    expect(projectId).toMatchObject({
+                      rows: [{ projectId: '' }],
+                    });
+                  },
+                );
+
+                const [role, userId, tenantId, projectId] = await Promise.all([
+                  trx.query('SELECT current_role role'),
+                  trx.query(`SELECT current_setting('app.user_id') "userId"`),
+                  trx.query(
+                    `SELECT current_setting('app.tenant_id', true) "tenantId"`,
+                  ),
+                  trx.query(
+                    `SELECT current_setting('app.project_id', true) "projectId"`,
+                  ),
+                ]);
+
+                expect(role).toMatchObject({ rows: [{ role: 'app-user' }] });
+                expect(userId).toMatchObject({ rows: [{ userId: '1' }] });
+                expect(tenantId).toMatchObject({ rows: [{ tenantId: '' }] });
+                expect(projectId).toMatchObject({ rows: [{ projectId: '' }] });
+              },
+            );
+          });
+
+          it('keeps withOptions nested-scope behavior unchanged inside transaction context', async () => {
+            await adapter.transaction(
+              testDb.internal.asyncStorage,
+              {
+                role: 'app-user',
+                setConfig: {
+                  'app.tx': 'value',
+                },
+              },
+              async () => {
+                await testDb.withOptions({ role: 'app_user' }, async () => {
+                  const state = testDb.internal.asyncStorage.getStore();
+
+                  expect(state?.transactionRole).toBe('app-user');
+                  expect(state?.role).toBe('app_user');
+
+                  await expect(
+                    testDb.withOptions({ role: 'other_role' }, async () => {}),
+                  ).rejects.toThrow(OrchidOrmInternalError);
+                });
+
+                await testDb.withOptions(
+                  { setConfig: { 'app.scope_a': 'a' } },
+                  async () => {
+                    await expect(
+                      testDb.withOptions(
+                        { setConfig: { 'app.scope_b': 'b' } },
+                        async () => {},
+                      ),
+                    ).rejects.toThrow(OrchidOrmInternalError);
+                  },
+                );
+              },
+            );
+          });
         });
-      });
 
-      describe('sql session state', () => {
-        it('applies role in query', async () => {
-          const withRole = await adapter.query<{ current_user: string }>(
-            'SELECT current_user',
-            undefined,
-            { role: 'app-user' },
-          );
+        describe('hackySavepoint', () => {
+          const getCounterValue = async (trx: Adapter) => {
+            const res = await trx.query<{ value: number }>(getCounterValueSql);
+            return res.rows[0].value;
+          };
 
-          expect(withRole.rows[0].current_user).toBe('app-user');
+          beforeEach(async () => {
+            await adapter.query(`UPDATE ${counterTable} SET "value" = 0`);
+          });
+
+          it('persists savepoint changes after release', async () => {
+            const before = await getCounterValue(adapter);
+
+            await adapter.transaction(undefined, undefined, async (trx) => {
+              const state: HackySavepointState = { name: 'hacky_release' };
+
+              const res = await trx.hackySavepoint<{ value: number }>(
+                state,
+                `${incrementCounterSql} RETURNING "value"`,
+              );
+
+              expect(res.rows[0].value).toBe(before + 1);
+
+              await trx.query(incrementCounterSql);
+
+              await state.activeSavepoint!.release();
+            });
+
+            const after = await getCounterValue(adapter);
+            expect(after).toBe(before + 2);
+          });
+
+          it('rolls back savepoint changes when rollback is called', async () => {
+            const before = await getCounterValue(adapter);
+            const err = new Error('rollback savepoint');
+
+            await adapter.transaction(undefined, undefined, async (trx) => {
+              const state: HackySavepointState = { name: 'hacky_rollback' };
+
+              await trx.hackySavepoint(state, incrementCounterSql);
+              await trx.query(incrementCounterSql);
+
+              await state.activeSavepoint!.rollback(err);
+            });
+
+            const after = await getCounterValue(adapter);
+            expect(after).toBe(before);
+          });
+
+          it('continues transaction after savepoint rollback', async () => {
+            const before = await getCounterValue(adapter);
+
+            await adapter.transaction(undefined, undefined, async (trx) => {
+              const state: HackySavepointState = { name: 'hacky_continue' };
+
+              await trx.hackySavepoint(state, incrementCounterSql);
+              await trx.query(incrementCounterSql);
+
+              await state.activeSavepoint!.rollback(new Error('rollback'));
+
+              await trx.query(incrementCounterSql);
+            });
+
+            const after = await getCounterValue(adapter);
+            expect(after).toBe(before + 1);
+          });
+
+          it('auto-rolls back on savepoint query failure and release fails afterwards', async () => {
+            const before = await getCounterValue(adapter);
+
+            await adapter.transaction(undefined, undefined, async (trx) => {
+              const state: HackySavepointState = { name: 'hacky_query_fail' };
+
+              await expect(
+                trx.hackySavepoint(
+                  state,
+                  'SELECT * FROM "table_that_does_not_exist"',
+                ),
+              ).rejects.toThrow();
+
+              await expect(state.activeSavepoint!.release()).rejects.toThrow();
+
+              await trx.query(incrementCounterSql);
+            });
+
+            const after = await getCounterValue(adapter);
+            expect(after).toBe(before + 1);
+          });
         });
 
-        it('applies setConfig in query', async () => {
-          const during = await adapter.query<{ preset: string; fresh: string }>(
-            `SELECT
+        describe('sql session state', () => {
+          it('applies role in query', async () => {
+            const withRole = await adapter.query<{ current_user: string }>(
+              'SELECT current_user',
+              undefined,
+              { role: 'app-user' },
+            );
+
+            expect(withRole.rows[0].current_user).toBe('app-user');
+          });
+
+          it('applies setConfig in query', async () => {
+            const during = await adapter.query<{
+              preset: string;
+              fresh: string;
+            }>(
+              `SELECT
               current_setting('app.preset_key', true) as preset,
               current_setting('app.new_key', true) as fresh`,
-            undefined,
-            {
-              setConfig: {
-                'app.preset_key': 'new_preset_value',
-                'app.new_key': 'new_value',
-              },
-            },
-          );
-
-          expect(during.rows[0]).toEqual({
-            preset: 'new_preset_value',
-            fresh: 'new_value',
-          });
-        });
-
-        it('applies setConfig in transaction query', async () => {
-          await adapter.transaction(undefined, undefined, async (trx) => {
-            const during = await trx.query<{ preset: string; fresh: string }>(
-              `SELECT
-                current_setting('app.preset_key', true) as preset,
-                current_setting('app.new_key', true) as fresh`,
               undefined,
               {
                 setConfig: {
@@ -798,74 +894,97 @@ describe('adapter runtime abstractions', () => {
               fresh: 'new_value',
             });
           });
-        });
 
-        it('applies setConfig in arrays query', async () => {
-          const during = await adapter.arrays<[string, string]>(
-            `SELECT
-              current_setting('app.arr_preset', true),
-              current_setting('app.arr_new', true)`,
-            undefined,
-            {
-              setConfig: {
-                'app.arr_preset': 'new_preset',
-                'app.arr_new': 'new_val',
-              },
-            },
-          );
-
-          expect(during.rows[0]).toEqual(['new_preset', 'new_val']);
-        });
-
-        it('applies sqlSessionState from transaction options', async () => {
-          await adapter.transaction(
-            undefined,
-            {
-              setConfig: {
-                'app.trx_preset': 'inner_value',
-              },
-            },
-            async (trx) => {
-              const duringConfig = await trx.query<{ val: string }>(
-                `SELECT current_setting('app.trx_preset', true) as val`,
+          it('applies setConfig in transaction query', async () => {
+            await adapter.transaction(undefined, undefined, async (trx) => {
+              const during = await trx.query<{ preset: string; fresh: string }>(
+                `SELECT
+                current_setting('app.preset_key', true) as preset,
+                current_setting('app.new_key', true) as fresh`,
+                undefined,
+                {
+                  setConfig: {
+                    'app.preset_key': 'new_preset_value',
+                    'app.new_key': 'new_value',
+                  },
+                },
               );
 
-              expect(duringConfig.rows[0].val).toBe('inner_value');
-            },
-          );
-        });
-      });
+              expect(during.rows[0]).toEqual({
+                preset: 'new_preset_value',
+                fresh: 'new_value',
+              });
+            });
+          });
 
-      it('assigns db error properties to QueryError', async () => {
-        let duplicateId = 0;
-        const dbErr = await adapter
-          .transaction(undefined, undefined, async (trx) => {
-            const inserted = await trx.query<{ id: number }>(
-              `INSERT INTO "schema"."user"("name", "password")
+          it('applies setConfig in arrays query', async () => {
+            const during = await adapter.arrays<[string, string]>(
+              `SELECT
+              current_setting('app.arr_preset', true) as preset,
+              current_setting('app.arr_new', true) as fresh`,
+              undefined,
+              {
+                setConfig: {
+                  'app.arr_preset': 'new_preset',
+                  'app.arr_new': 'new_val',
+                },
+              },
+            );
+
+            expect(during.rows[0]).toEqual(['new_preset', 'new_val']);
+          });
+
+          it('applies sqlSessionState from transaction options', async () => {
+            await adapter.transaction(
+              undefined,
+              {
+                setConfig: {
+                  'app.trx_preset': 'inner_value',
+                },
+              },
+              async (trx) => {
+                const duringConfig = await trx.query<{ val: string }>(
+                  `SELECT current_setting('app.trx_preset', true) as val`,
+                );
+
+                expect(duringConfig.rows[0].val).toBe('inner_value');
+              },
+            );
+          });
+        });
+
+        it('assigns db error properties to QueryError', async () => {
+          let duplicateId = 0;
+          const dbErr = await adapter
+            .transaction(undefined, undefined, async (trx) => {
+              const inserted = await trx.query<{ id: number }>(
+                `INSERT INTO "schema"."user"("name", "password")
                VALUES ('name', 'password')
                RETURNING "id"`,
-            );
-            duplicateId = inserted.rows[0].id;
+              );
+              duplicateId = inserted.rows[0].id;
 
-            await trx.query(
-              `INSERT INTO "schema"."user"("id", "name", "password")
+              await trx.query(
+                `INSERT INTO "schema"."user"("id", "name", "password")
                VALUES (${duplicateId}, 'name', 'password')`,
-            );
-          })
-          .catch((err) => err as Error);
+              );
+            })
+            .catch((err) => err as Error);
 
-        class TestError extends QueryError {}
-        const err = new TestError({} as never);
-        adapter.assignError(err, dbErr as never);
+          class TestError extends QueryError {}
+          const err = new TestError({} as never);
+          adapter.assignError(err, dbErr as never);
 
-        expect(err).toMatchObject({
-          message: 'duplicate key value violates unique constraint "user_pkey"',
-          code: '23505',
-          detail: `Key (id)=(${duplicateId}) already exists.`,
-          severity: 'ERROR',
-          constraint: 'user_pkey',
+          expect(err).toMatchObject({
+            message:
+              'duplicate key value violates unique constraint "user_pkey"',
+            code: '23505',
+            detail: `Key (id)=(${duplicateId}) already exists.`,
+            severity: 'ERROR',
+            constraint: 'user_pkey',
+          });
         });
       });
-    });
-  });
+    },
+  );
 });

--- a/packages/pqb/src/adapters/adapter.ts
+++ b/packages/pqb/src/adapters/adapter.ts
@@ -10,7 +10,6 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { setTimeout } from 'node:timers/promises';
 import { QueryError } from '../query/errors';
 import {
-  _runAfterCommitHooks,
   AfterCommitErrorHandler,
   IsolationLevel,
   Query,
@@ -34,6 +33,8 @@ import {
   getSetConfigSql,
   getSetRoleSql,
 } from './adapter.utils';
+import { _runAfterCommitHooks } from '../query/basic-features/transaction/transaction';
+import { PostgresInterval } from './driver-adapter-shared';
 
 export type { SqlSessionState } from './features/sql-session-context';
 
@@ -46,19 +47,16 @@ export interface QueryResultRow {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface QueryResult<T extends QueryResultRow = any> {
+export interface QueryResult<T = any> {
   rowCount: number;
   rows: T[];
+  /**
+   * node-postgres and postgres-js: fields are present even for empty results.
+   * Bun doesn't implement fields in the same way, fields are empty if no rows returned.
+   */
   fields: {
     name: string;
   }[];
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface QueryArraysResult<R extends any[] = any[]> {
-  rowCount: number;
-  rows: R[];
-  fields: { name: string }[];
 }
 
 export interface AdapterConfigBase {
@@ -175,7 +173,9 @@ export interface Adapter {
     sqlSessionState?: SqlSessionState,
   ): Promise<QueryResult<T>>;
 
-  // make a query to get rows as array of column values
+  // make a query to get rows as array of column values.
+  // Selecting fields of the same names works fine with node-postgres and postgres-js,
+  // but not for Bun SQL until it supports parsing fields info from Postgres response.
   arrays<
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     R extends any[] = any[],
@@ -184,7 +184,7 @@ export interface Adapter {
     values?: unknown[],
     // SQL session state (role and setConfig) from async storage
     sqlSessionState?: SqlSessionState,
-  ): Promise<QueryArraysResult<R>>;
+  ): Promise<QueryResult<R>>;
 
   /**
    * Run a transaction
@@ -237,10 +237,23 @@ type Pool = any;
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 type Client = any;
 
+export interface AdapterSchemaConfigOptions {
+  // true by default, node-postgres has false
+  jsonEncodedByDriver?: boolean;
+  // false by default, Bun has true
+  dateParsedByDriver?: boolean;
+  // Bun requires wrapping arrays in `sql.array`
+  arrayEncode?(input: unknown): unknown;
+  // node-postgres does that out of the box, postgres-js does it with default parsers, Bun provides this function
+  intervalParse?(input: string): PostgresInterval;
+}
+
 /**
  * Adapter class used by runtime orchestrator to create driver-specific adapters.
  */
 export interface DriverAdapter {
+  noFieldsForArrays?: boolean;
+  schemaConfig?: AdapterSchemaConfigOptions;
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   errorClass: new (...args: any[]) => Error;
   errorFields: RecordString;
@@ -248,11 +261,10 @@ export interface DriverAdapter {
   manualPool: boolean;
   borrow(pool: Pool): Client;
   release(client: Client): void;
-  queryClient<T extends QueryResultRow = QueryResultRow>(
+  queryClient<T = QueryResultRow>(
     client: Client,
     text: string,
     values?: unknown[],
-    // SQL session state (role and setConfig) from async storage
     arraysMode?: boolean,
   ): Promise<QueryResult<T>>;
   begin<DriverClient, Result>(
@@ -335,7 +347,7 @@ export class AdapterClass implements Adapter {
     // SQL session state (role and setConfig) from async storage
     sqlSessionState?: SqlSessionState,
   ): Promise<QueryResult<T>> {
-    return runQueryHandlePool<T>(
+    return runQueryHandlePool<QueryResult<T>>(
       this.pool,
       this.driverAdapter,
       text,
@@ -353,8 +365,8 @@ export class AdapterClass implements Adapter {
     values?: unknown[],
     // SQL session state (role and setConfig) from async storage
     sqlSessionState?: SqlSessionState,
-  ): Promise<QueryArraysResult<R>> {
-    return runQueryHandlePool<R>(
+  ): Promise<QueryResult<R>> {
+    return runQueryHandlePool<QueryResult<R>>(
       this.pool,
       this.driverAdapter,
       text,
@@ -461,7 +473,7 @@ export class TransactionAdapterClass implements TransactionAdapter {
   ): Promise<QueryResult<T>> {
     const setup = sqlSessionContextComputeSetup(sqlSessionState);
 
-    return runQueryHandleSetupAndCleanup<T>(
+    return runQueryHandleSetupAndCleanup<QueryResult<T>>(
       this.driverAdapter,
       this.client,
       text,
@@ -479,10 +491,10 @@ export class TransactionAdapterClass implements TransactionAdapter {
     values?: unknown[],
     // SQL session state (role and setConfig) from async storage
     sqlSessionState?: SqlSessionState,
-  ): Promise<QueryArraysResult<R>> {
+  ): Promise<QueryResult<R>> {
     const setup = sqlSessionContextComputeSetup(sqlSessionState);
 
-    return runQueryHandleSetupAndCleanup<R>(
+    return runQueryHandleSetupAndCleanup<QueryResult<R>>(
       this.driverAdapter,
       this.client,
       text,
@@ -870,7 +882,7 @@ const runAfterCommit = (
   });
 };
 
-const runQueryHandlePool = async <T extends QueryResultRow = QueryResultRow>(
+const runQueryHandlePool = async <Result extends QueryResult = QueryResult>(
   pool: Pool,
   driverAdapter: DriverAdapter,
   text: string,
@@ -879,11 +891,11 @@ const runQueryHandlePool = async <T extends QueryResultRow = QueryResultRow>(
   sqlSessionState?: SqlSessionState,
   arraysMode?: boolean,
   client?: Client,
-): Promise<QueryResult<T>> => {
+): Promise<Result> => {
   const setup = sqlSessionContextComputeSetup(sqlSessionState);
 
   if (client || (!driverAdapter.manualPool && !setup)) {
-    return runQueryHandleSetupAndCleanup(
+    return runQueryHandleSetupAndCleanup<Result>(
       driverAdapter,
       client || pool,
       text,
@@ -896,7 +908,7 @@ const runQueryHandlePool = async <T extends QueryResultRow = QueryResultRow>(
   client = await driverAdapter.borrow(pool);
 
   try {
-    return await runQueryHandleSetupAndCleanup(
+    return await runQueryHandleSetupAndCleanup<Result>(
       driverAdapter,
       client,
       text,
@@ -910,7 +922,7 @@ const runQueryHandlePool = async <T extends QueryResultRow = QueryResultRow>(
 };
 
 const runQueryHandleSetupAndCleanup = <
-  T extends QueryResultRow = QueryResultRow,
+  Result extends QueryResult = QueryResult,
 >(
   driverAdapter: DriverAdapter,
   client: Client,
@@ -918,16 +930,19 @@ const runQueryHandleSetupAndCleanup = <
   values?: unknown[],
   setup?: SqlSessionContextSetupResult,
   arraysMode?: boolean,
-): Promise<QueryResult<T>> => {
+): Promise<Result> => {
+  const mainQuery = () =>
+    driverAdapter.queryClient(client, text, values, arraysMode);
+
   if (setup) {
-    return sqlSessionContextExecute<T>(
+    return sqlSessionContextExecute<Result>(
       (text, values) => driverAdapter.queryClient(client, text, values, true),
       setup,
-      () => driverAdapter.queryClient(client, text, values, arraysMode),
+      mainQuery as () => Promise<Result>,
     );
   }
 
-  return driverAdapter.queryClient(client, text, values, arraysMode);
+  return mainQuery() as Promise<Result>;
 };
 
 interface AdapterConnectionState {
@@ -1160,3 +1175,6 @@ const defaultConnectRetryStrategy = (
   return (attempt) =>
     setTimeout((param.factor ?? 1.5) ** (attempt - 1) * (param.delay ?? 50));
 };
+
+export const getDriverErrorCode = (err: object) =>
+  'errno' in err ? err.errno : (err as { code?: string }).code;

--- a/packages/pqb/src/adapters/bun.test.ts
+++ b/packages/pqb/src/adapters/bun.test.ts
@@ -1,0 +1,120 @@
+import { BunAdapter } from './bun';
+
+describe('bun', () => {
+  const hasBunSql = Boolean(
+    (globalThis as unknown as { Bun?: { SQL?: unknown } }).Bun?.SQL,
+  );
+  const itWithBunSql = hasBunSql ? it : it.skip;
+
+  it('uses values() for arrays query', async () => {
+    const objectResult = Object.assign([{ one: 1 }], { count: 1 });
+    const arrayResult = Object.assign([[1]], { count: 1 });
+
+    const query = Promise.resolve(objectResult) as Promise<unknown> & {
+      values: jest.Mock;
+    };
+    query.values = jest.fn(() => Promise.resolve(arrayResult));
+
+    const client = {
+      unsafe: jest.fn(() => query),
+    };
+
+    const result = await BunAdapter.queryClient<[number]>(
+      client as never,
+      'SELECT 1 AS one',
+      undefined,
+      true,
+    );
+
+    expect(client.unsafe).toHaveBeenCalledWith('SELECT 1 AS one', undefined);
+    expect(query.values).toHaveBeenCalledTimes(1);
+    expect(result.rowCount).toBe(1);
+    expect(result.rows[0]).toEqual([1]);
+    expect(() => result.fields).toThrow(
+      'Bun does not support fields on array result',
+    );
+  });
+
+  it('computes fields lazily and memoizes them', async () => {
+    const keys = jest.spyOn(Object, 'keys');
+    const query = Promise.resolve(
+      Object.assign([{ one: 1 }], { count: 1 }),
+    ) as Promise<unknown> & {
+      values: jest.Mock;
+    };
+    query.values = jest.fn();
+
+    const client = {
+      unsafe: jest.fn(() => query),
+    };
+
+    const result = await BunAdapter.queryClient(
+      client as never,
+      'SELECT 1 AS one',
+    );
+
+    const keysCallsAfterQuery = keys.mock.calls.length;
+    const fields = result.fields;
+    const sameFields = result.fields === result.fields;
+    const keysCallsAfterFields = keys.mock.calls.length;
+    keys.mockRestore();
+
+    expect(keysCallsAfterQuery).toBe(0);
+    expect(fields).toEqual([{ name: 'one' }]);
+    expect(sameFields).toBe(true);
+    expect(keysCallsAfterFields).toBe(1);
+  });
+
+  it('returns multiple query results for semicolon-separated queries', async () => {
+    const query = Promise.resolve([
+      Object.assign([{ one: 1 }], { count: 1 }),
+      Object.assign([{ two: 2 }], { count: 1 }),
+    ]) as Promise<unknown> & {
+      values: jest.Mock;
+    };
+    query.values = jest.fn();
+
+    const client = {
+      unsafe: jest.fn(() => query),
+    };
+
+    const result = await BunAdapter.queryClient(
+      client as never,
+      'SELECT 1 AS one; SELECT 2 AS two',
+    );
+
+    expect(client.unsafe).toHaveBeenCalledWith(
+      'SELECT 1 AS one; SELECT 2 AS two',
+      undefined,
+    );
+    expect(result).toMatchObject([
+      {
+        rowCount: 1,
+        rows: [{ one: 1 }],
+        fields: [{ name: 'one' }],
+      },
+      {
+        rowCount: 1,
+        rows: [{ two: 2 }],
+        fields: [{ name: 'two' }],
+      },
+    ]);
+  });
+
+  itWithBunSql('queries SELECT 1 with Bun adapter', async () => {
+    const client = BunAdapter.configure({ databaseURL: process.env.PG_URL });
+
+    try {
+      const result = await BunAdapter.queryClient<{ one: number }>(
+        client,
+        'SELECT 1 AS one',
+      );
+
+      expect(result.rowCount).toBe(1);
+      expect([...result.rows]).toEqual([{ one: 1 }]);
+      expect(result.fields).toEqual([{ name: 'one' }]);
+    } finally {
+      await BunAdapter.close(client);
+    }
+  });
+});

--- a/packages/pqb/src/adapters/bun.ts
+++ b/packages/pqb/src/adapters/bun.ts
@@ -1,0 +1,428 @@
+import {
+  AdapterClass,
+  AdapterConfigBase,
+  ColumnSchemaConfig,
+  DbOptions,
+  DbResult,
+  DefaultColumnTypes,
+  defaultSchemaConfig,
+  DefaultSchemaConfig,
+  DriverAdapter,
+  noop,
+  QueryResult,
+  QueryResultRow,
+  QuerySchema,
+  quoteIdentifier,
+  RecordUnknown,
+  AdapterSchemaConfigOptions,
+} from 'pqb/internal';
+import { createDbWithAdapter } from 'pqb';
+import { HackySavepointState } from './adapter';
+import { parseInterval } from './driver-adapter-shared';
+
+const schemaConfig: AdapterSchemaConfigOptions = {
+  arrayEncode: (input) => {
+    return getBun().sql.array(input);
+  },
+  intervalParse: parseInterval,
+  jsonEncodedByDriver: true,
+  dateParsedByDriver: true,
+};
+
+export const bunSchemaConfig = Object.assign(
+  () => defaultSchemaConfig(schemaConfig),
+  schemaConfig,
+);
+
+export interface CreateBunDbOptions<
+  SchemaConfig extends ColumnSchemaConfig,
+  ColumnTypes,
+>
+  extends BunAdapterOptions, DbOptions<SchemaConfig, ColumnTypes> {}
+
+export const createDb = <
+  SchemaConfig extends ColumnSchemaConfig = DefaultSchemaConfig,
+  ColumnTypes = DefaultColumnTypes<SchemaConfig>,
+>({
+  log,
+  ...options
+}: CreateBunDbOptions<SchemaConfig, ColumnTypes>): DbResult<ColumnTypes> => {
+  return createDbWithAdapter({
+    schemaConfig: bunSchemaConfig as unknown as () => SchemaConfig,
+    ...options,
+    log,
+    adapter: new AdapterClass({
+      driverAdapter: BunAdapter,
+      config: options,
+    }),
+  });
+};
+
+export interface BunOptions {
+  hostname?: string;
+  port?: number;
+  database?: string;
+  username?: string;
+  password?: string | (() => string | Promise<string>);
+  max?: number;
+  idleTimeout?: number;
+  maxLifetime?: number;
+  connectionTimeout?: number;
+  prepare?: boolean;
+  tls?: unknown;
+}
+
+export interface BunAdapterOptions extends AdapterConfigBase, BunOptions {
+  schema?: QuerySchema;
+  searchPath?: string;
+  ssl?: unknown;
+}
+
+interface Bun {
+  SQL: BunSqlConstructor;
+  sql: {
+    array(input: unknown): unknown;
+  };
+}
+
+interface BunSqlConstructor {
+  new (options?: BunSqlOptions | string): BunSql;
+  PostgresError: ErrorClass;
+}
+
+interface BunSqlOptions extends BunOptions {
+  url?: string;
+  ssl?: unknown;
+}
+
+interface BunSql {
+  unsafe<Row extends QueryResultRow = QueryResultRow>(
+    text: string,
+    values?: unknown[],
+  ): BunSqlQuery<Row>;
+  reserve(): Promise<BunReservedSql>;
+  close(options?: { timeout?: number }): Promise<void>;
+}
+
+interface BunReservedSql extends BunSql {
+  release(): void;
+}
+
+interface BunSqlQuery<
+  Row extends QueryResultRow = QueryResultRow,
+> extends PromiseLike<BunSqlResult<Row>> {
+  values(): Promise<BunSqlResult<unknown[]>>;
+}
+
+interface BunSqlResult<Row = unknown> extends Array<Row> {
+  count?: number;
+  affectedRows?: number;
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any
+type ErrorClass = new (...args: any[]) => Error;
+
+const getBun = (): Bun => {
+  const Bun = (globalThis as unknown as { Bun?: Bun }).Bun;
+  if (!Bun?.SQL) {
+    throw new Error('Bun.SQL is only available when running in Bun');
+  }
+
+  return Bun;
+};
+
+const getBunPostgresError = (): ErrorClass => {
+  return (
+    (globalThis as unknown as { Bun?: { SQL: BunSqlConstructor } }).Bun?.SQL
+      .PostgresError ?? (Error as ErrorClass)
+  );
+};
+
+const queryClient = <T = QueryResultRow>(
+  client: BunSql,
+  text: string,
+  values?: unknown[],
+  arraysMode?: boolean,
+): Promise<QueryResult<T>> => {
+  const runQuery = () => {
+    const query = client.unsafe(text, values);
+    const resultPromise: PromiseLike<BunSqlResult> = arraysMode
+      ? query.values()
+      : query;
+
+    return Promise.resolve(resultPromise).then((result) => {
+      return normalizeResult(result, arraysMode) as QueryResult<T>;
+    });
+  };
+
+  // Keep a single transactional connection ordered when savepoints are active.
+  const { __lock } = client as unknown as { __lock?: Promise<unknown> };
+  if (__lock) {
+    let resolve: (() => void) | undefined;
+    (client as unknown as RecordUnknown).__lock = new Promise<void>((res) => {
+      resolve = res;
+    });
+
+    return __lock.then(() => {
+      const promise = runQuery();
+      promise.then(resolve, resolve);
+      return promise;
+    });
+  }
+
+  const promise = runQuery();
+
+  (client as unknown as { __lock?: Promise<unknown> }).__lock =
+    promise.catch(noop);
+
+  return promise;
+};
+
+const borrowBunClient = (pool: BunSql): Promise<BunReservedSql> => {
+  return pool.reserve();
+};
+
+const releaseBunClient = (client: BunReservedSql): void => {
+  client.release();
+};
+
+export const BunAdapter: DriverAdapter = {
+  noFieldsForArrays: true,
+  manualPool: true,
+  schemaConfig,
+  errorClass: getBunPostgresError(),
+  errorFields: {
+    message: 'message',
+    severity: 'severity',
+    code: 'errno',
+    detail: 'detail',
+    schema: 'schema',
+    table: 'table',
+    column: 'column',
+    dataType: 'dataType',
+    constraint: 'constraint',
+    hint: 'hint',
+    position: 'position',
+    internalPosition: 'internalPosition',
+    internalQuery: 'internalQuery',
+    where: 'where',
+    file: 'file',
+    line: 'line',
+    routine: 'routine',
+  },
+
+  configure(config: BunAdapterOptions): BunSql {
+    return new (getBun().SQL)(makeOptions(config));
+  },
+
+  queryClient,
+
+  borrow(pool: BunSql): Promise<BunReservedSql> {
+    return borrowBunClient(pool);
+  },
+
+  release(client: BunReservedSql): void {
+    releaseBunClient(client);
+  },
+
+  async begin<DriverClient, Result>(
+    pool: BunSql,
+    cb: (adapter: DriverClient) => Promise<Result>,
+    options?: string,
+  ): Promise<Result> {
+    const client = await borrowBunClient(pool);
+
+    try {
+      await queryClient(client, options ? 'BEGIN ' + options : 'BEGIN');
+
+      let result;
+      try {
+        result = await cb(client as DriverClient);
+      } catch (err) {
+        await queryClient(client, 'ROLLBACK');
+        throw err;
+      }
+
+      await queryClient(client, 'COMMIT');
+      return result as Result;
+    } finally {
+      releaseBunClient(client);
+    }
+  },
+
+  async savepoint<T>(
+    client: BunSql,
+    // Bun doesn't need to switch the client in a savepoint.
+    _setClient: (client: BunSql) => void,
+    name: string,
+    cb: () => Promise<T>,
+  ): Promise<T> {
+    const safeName = quoteIdentifier(name);
+    try {
+      await queryClient(client, `SAVEPOINT ${safeName}`);
+      const res = await cb();
+      await queryClient(client, `RELEASE SAVEPOINT ${safeName}`);
+      return res;
+    } catch (err) {
+      await queryClient(client, `ROLLBACK TO SAVEPOINT ${safeName}`);
+      throw err;
+    }
+  },
+
+  async hackySavepoint<T extends QueryResultRow>(
+    client: BunSql,
+    // Bun doesn't need to switch the client in a savepoint.
+    _setClient: (client: BunSql) => void,
+    state: HackySavepointState,
+    text: string,
+    values?: unknown[],
+    arraysMode?: boolean,
+  ): Promise<QueryResult<T>> {
+    const safeName = quoteIdentifier(state.name);
+
+    let resolve: (() => void) | undefined;
+    let reject: ((err: unknown) => void) | undefined;
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    let resultResolve: ((res: QueryResult<T>) => void) | undefined;
+    let resultReject: ((err: unknown) => void) | undefined;
+    const resultPromise = new Promise<QueryResult<T>>((res, rej) => {
+      resultResolve = res;
+      resultReject = rej;
+    });
+
+    const savepointPromise = (async () => {
+      try {
+        await queryClient(client, `SAVEPOINT ${safeName}`);
+
+        try {
+          const res = await queryClient<T>(client, text, values, arraysMode);
+          resultResolve?.(res as QueryResult<T>);
+        } catch (err) {
+          resultReject?.(err);
+          throw err;
+        }
+
+        const result = await promise;
+        await queryClient(client, `RELEASE SAVEPOINT ${safeName}`);
+        return result;
+      } catch (err) {
+        await queryClient(client, `ROLLBACK TO SAVEPOINT ${safeName}`);
+        throw err;
+      }
+    })();
+
+    state.activeSavepoint = {
+      async release() {
+        resolve?.();
+        await savepointPromise;
+      },
+      async rollback(err) {
+        reject?.(err);
+        await savepointPromise.catch(noop);
+      },
+    };
+
+    return resultPromise;
+  },
+
+  close(pool: BunSql): Promise<void> {
+    return pool.close();
+  },
+};
+
+const makeOptions = (config: BunAdapterOptions): BunSqlOptions => {
+  const {
+    databaseURL,
+    host,
+    user,
+    password,
+    port,
+    database,
+    max,
+    idleTimeout,
+    maxLifetime,
+    connectionTimeout,
+    prepare,
+    tls,
+    ssl,
+    setConfig,
+    searchPath,
+  } = config;
+
+  return {
+    url:
+      databaseURL && makeUrl(databaseURL, setConfig?.search_path ?? searchPath),
+    hostname: host,
+    username: user,
+    password,
+    port,
+    database,
+    max,
+    idleTimeout,
+    maxLifetime,
+    connectionTimeout,
+    prepare,
+    tls,
+    ssl,
+  };
+};
+
+const makeUrl = (databaseURL: string, searchPath?: string): string => {
+  if (!searchPath) return databaseURL;
+
+  const url = new URL(databaseURL);
+  url.searchParams.set('options', `-c search_path=${searchPath}`);
+  return url.toString();
+};
+
+const normalizeResult = <T>(
+  result: BunSqlResult<T>,
+  arraysMode?: boolean,
+): QueryResult<T> | QueryResult<T>[] => {
+  if (!arraysMode && isMultiResult(result)) {
+    return result.map((item) => new BunQueryResult(item, arraysMode));
+  }
+
+  return new BunQueryResult(result, arraysMode);
+};
+
+class BunQueryResult<T> implements QueryResult<T> {
+  public rowCount: number;
+  public rows: T[];
+  private _fields?: QueryResult<T>['fields'];
+
+  constructor(
+    private result: BunSqlResult<T>,
+    private isArray?: boolean,
+  ) {
+    this.rowCount = result.count ?? result.affectedRows ?? result.length;
+
+    // creating new Array because BunSqlResult is not a real array - can't do spread on it
+    this.rows = Array.from(result) as T[];
+  }
+
+  get fields(): QueryResult<T>['fields'] {
+    if (this.isArray) {
+      throw new Error('Bun does not support fields on array result');
+    }
+
+    return (this._fields ??= getFields(this.result));
+  }
+}
+
+const isMultiResult = <T>(
+  result: BunSqlResult<T>,
+): result is BunSqlResult<T>[] & BunSqlResult<T> => {
+  return Array.isArray(result[0]);
+};
+
+const getFields = <T>(rows: T[]): { name: string }[] => {
+  const first = rows[0];
+  if (!first || Array.isArray(first) || typeof first !== 'object') return [];
+
+  return Object.keys(first).map((name) => ({ name }));
+};

--- a/packages/pqb/src/adapters/driver-adapter-shared.ts
+++ b/packages/pqb/src/adapters/driver-adapter-shared.ts
@@ -1,0 +1,32 @@
+export interface PostgresInterval {
+  years: number;
+  months: number;
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  milliseconds: number;
+}
+
+const intervalRegExp =
+  /^\s*(?:([+-]?\d+)\s+years?)?\s*(?:([+-]?\d+)\s+mons?)?\s*(?:([+-]?\d+)\s+days?)?\s*(?:([+-])?(\d+):(\d\d):(\d\d(?:\.\d{1,6})?))?\s*$/;
+
+export const parseInterval = (str: string): PostgresInterval => {
+  const [, years, months, days, timeSign, hours, minutes, seconds] =
+    intervalRegExp.exec(str) || [];
+  const timeMultiplier = timeSign === '-' ? -1 : 1;
+  const secondsFloat = Number(seconds) || 0;
+  const wholeSeconds = Math.floor(secondsFloat);
+
+  return {
+    years: years ? Number(years) : 0,
+    months: months ? Number(months) : 0,
+    days: days ? Number(days) : 0,
+    hours: hours ? timeMultiplier * Number(hours) : 0,
+    minutes: minutes ? timeMultiplier * Number(minutes) : 0,
+    seconds: timeMultiplier * wholeSeconds,
+    milliseconds:
+      Math.round(timeMultiplier * (secondsFloat - wholeSeconds) * 1000000) /
+      1000,
+  };
+};

--- a/packages/pqb/src/adapters/features/sql-session-context.test.ts
+++ b/packages/pqb/src/adapters/features/sql-session-context.test.ts
@@ -1,4 +1,4 @@
-import { db } from 'test-utils';
+import { BaseTable, TestAdapter, testDbOptions } from 'test-utils';
 import { OrchidOrmInternalError } from '../../query/errors';
 import {
   SqlSessionState,
@@ -7,6 +7,8 @@ import {
   sqlSessionContextExecute,
   sqlSessionContextHasState,
 } from './sql-session-context';
+import { orchidORMWithAdapter } from 'orchid-orm';
+import { AdapterClass } from '../adapter';
 
 describe('adapter.utils', () => {
   describe('sqlSessionContextComputeSetup', () => {
@@ -271,6 +273,30 @@ describe('adapter.utils', () => {
 });
 
 describe('storage', () => {
+  class UserTable extends BaseTable {
+    readonly table = 'user';
+    columns = this.setColumns((t) => ({
+      Id: t.name('id').identity().primaryKey(),
+    }));
+  }
+
+  const db = orchidORMWithAdapter(
+    {
+      adapter: new AdapterClass({
+        driverAdapter: TestAdapter,
+        config: {
+          ...testDbOptions,
+          max: 1,
+        } as never,
+      }),
+      log: !process.env.CI,
+      schema: () => 'schema',
+    },
+    {
+      user: UserTable,
+    },
+  );
+
   afterAll(db.$close);
 
   describe('sql session state', () => {

--- a/packages/pqb/src/adapters/features/sql-session-context.ts
+++ b/packages/pqb/src/adapters/features/sql-session-context.ts
@@ -1,7 +1,7 @@
 import { type IsQuery } from '../../query';
 import { NestedSqlSessionError } from '../../query/errors';
 import { type PickQueryQ } from '../../query/pick-query-types';
-import { type QueryResult, type QueryResultRow } from '../adapter';
+import { type QueryResult } from '../adapter';
 import { quoteIdentifier } from '../../utils';
 
 export interface SqlSessionState {
@@ -30,7 +30,7 @@ export interface SqlSessionContextSetupResult {
 }
 
 export interface SqlSessionContextQueryFn {
-  (sql: string, values?: unknown[]): Promise<QueryResult<QueryResultRow>>;
+  (sql: string, values?: unknown[]): Promise<QueryResult>;
 }
 
 interface CapturedSessionState {
@@ -161,11 +161,11 @@ export const sqlSessionContextHasState = (
   );
 };
 
-export const sqlSessionContextExecute = async <T extends QueryResultRow>(
+export const sqlSessionContextExecute = async <T extends QueryResult>(
   query: SqlSessionContextQueryFn,
   setup: SqlSessionContextSetupResult | undefined,
-  mainQuery: () => Promise<QueryResult<T>>,
-): Promise<QueryResult<T>> => {
+  mainQuery: () => Promise<T>,
+): Promise<T> => {
   if (!setup) {
     return mainQuery();
   }

--- a/packages/pqb/src/adapters/node-postgres.test.ts
+++ b/packages/pqb/src/adapters/node-postgres.test.ts
@@ -4,7 +4,7 @@ import { NodePostgresAdapter } from './node-postgres';
 interface MockQueryResult<Row = unknown> {
   rowCount: number;
   rows: Row[];
-  fields: Array<{ name: string }>;
+  fields?: Array<{ name: string }>;
 }
 
 const makeQueryResult = <Row>(
@@ -46,7 +46,7 @@ describe('node-postgres', () => {
       expect(result.fields).toEqual([{ name: 'one' }]);
     });
 
-    it('uses rowMode=array in arrays mode', async () => {
+    it('uses rowMode=array for arrays query', async () => {
       const rawResult = makeQueryResult([[1]], [{ name: 'one' }]);
       const client = {
         query: jest.fn(() => Promise.resolve(rawResult)),
@@ -68,7 +68,6 @@ describe('node-postgres', () => {
       );
       expect(result.rowCount).toBe(1);
       expect(result.rows[0]).toEqual([1]);
-      expect(result.fields).toEqual([{ name: 'one' }]);
     });
   });
 });

--- a/packages/pqb/src/adapters/node-postgres.ts
+++ b/packages/pqb/src/adapters/node-postgres.ts
@@ -14,9 +14,21 @@ import {
   QuerySchema,
   AdapterClass,
   DriverAdapter,
+  defaultSchemaConfig,
+  quoteIdentifier,
+  AdapterSchemaConfigOptions,
 } from 'pqb/internal';
 import { createDbWithAdapter } from 'pqb';
 import { HackySavepointState } from './adapter';
+
+const schemaConfig: AdapterSchemaConfigOptions = {
+  jsonEncodedByDriver: false,
+};
+
+export const nodePostgresSchemaConfig = Object.assign(
+  () => defaultSchemaConfig(schemaConfig),
+  schemaConfig,
+);
 
 export const createDb = <
   SchemaConfig extends ColumnSchemaConfig = DefaultSchemaConfig,
@@ -27,6 +39,7 @@ export const createDb = <
 }: DbOptions<SchemaConfig, ColumnTypes> &
   Omit<NodePostgresAdapterOptions, 'log'>): DbResult<ColumnTypes> => {
   return createDbWithAdapter({
+    schemaConfig: nodePostgresSchemaConfig as unknown as () => SchemaConfig,
     ...options,
     log,
     adapter: new AdapterClass({
@@ -54,7 +67,6 @@ for (const key in types.builtins) {
   types.builtins.TIMESTAMP,
   types.builtins.TIMESTAMPTZ,
   types.builtins.CIRCLE,
-  types.builtins.BYTEA,
 ].forEach((id) => {
   delete defaultTypeParsers[id];
 });
@@ -70,11 +82,10 @@ export interface NodePostgresAdapterOptions extends Omit<AdapterConfig, 'log'> {
   schema?: QuerySchema;
 }
 
-const queryClient = <T extends QueryResultRow = QueryResultRow>(
+const queryClient = <T = QueryResultRow>(
   client: PoolClient,
   text: string,
   values?: unknown[],
-  // SQL session state (role and setConfig) from async storage
   arraysMode?: boolean,
 ): Promise<QueryResult<T>> => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -98,23 +109,27 @@ const queryClient = <T extends QueryResultRow = QueryResultRow>(
     });
 
     return __lock.then(() => {
-      const promise = client.query(params);
+      const promise = client.query(params) as Promise<QueryResult>;
       promise.then(resolve, resolve);
-      return promise;
+      return promise.then((result) =>
+        arraysMode ? normalizeArraysResult(result) : result,
+      ) as Promise<QueryResult<T>>;
     });
   }
 
-  const promise = client.query(params);
+  const promise = client.query(params) as Promise<QueryResult>;
 
   (client as unknown as { __lock?: Promise<unknown> }).__lock =
     promise.catch(noop);
 
-  return promise;
+  return promise.then((result) =>
+    arraysMode ? normalizeArraysResult(result) : result,
+  ) as Promise<QueryResult<T>>;
 };
 
 export const NodePostgresAdapter: DriverAdapter = {
   manualPool: true,
-
+  schemaConfig,
   errorClass: DatabaseError,
   errorFields: {
     message: 'message',
@@ -194,14 +209,14 @@ export const NodePostgresAdapter: DriverAdapter = {
     name: string,
     cb: () => Promise<T>,
   ): Promise<T> {
-    const safeName = name.replaceAll('"', '""');
+    const safeName = quoteIdentifier(name);
     try {
-      await queryClient(client, `SAVEPOINT "${safeName}"`);
+      await queryClient(client, `SAVEPOINT ${safeName}`);
       const res = await cb();
-      await queryClient(client, `RELEASE SAVEPOINT "${safeName}"`);
+      await queryClient(client, `RELEASE SAVEPOINT ${safeName}`);
       return res;
     } catch (err) {
-      await queryClient(client, `ROLLBACK TO SAVEPOINT "${safeName}"`);
+      await queryClient(client, `ROLLBACK TO SAVEPOINT ${safeName}`);
       throw err;
     }
   },
@@ -233,21 +248,21 @@ export const NodePostgresAdapter: DriverAdapter = {
 
     const savepointPromise = (async () => {
       try {
-        await queryClient(client, `SAVEPOINT "${safeName}"`);
+        await queryClient(client, `SAVEPOINT ${safeName}`);
 
         try {
           const res = await queryClient<T>(client, text, values, arraysMode);
-          resultResolve!(res);
+          resultResolve!(res as QueryResult<T>);
         } catch (err) {
           resultReject!(err);
           throw err;
         }
 
         const result = await promise;
-        await queryClient(client, `RELEASE SAVEPOINT "${safeName}"`);
+        await queryClient(client, `RELEASE SAVEPOINT ${safeName}`);
         return result;
       } catch (err) {
-        await queryClient(client, `ROLLBACK TO SAVEPOINT "${safeName}"`);
+        await queryClient(client, `ROLLBACK TO SAVEPOINT ${safeName}`);
         throw err;
       }
     })();
@@ -275,4 +290,13 @@ const defaultTypesConfig = {
   getTypeParser(id: number) {
     return defaultTypeParsers[id] || returnArg;
   },
+};
+
+const normalizeArraysResult = <
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  R extends any[] = any[],
+>(
+  result: QueryResult,
+): QueryResult<R> => {
+  return result as unknown as QueryResult<R>;
 };

--- a/packages/pqb/src/adapters/postgres-js.test.ts
+++ b/packages/pqb/src/adapters/postgres-js.test.ts
@@ -40,7 +40,7 @@ describe('postgres-js', () => {
       expect(result.fields).toEqual([{ name: 'one' }]);
     });
 
-    it('uses values() in arrays mode', async () => {
+    it('uses values() for arrays query', async () => {
       const objectResult = makeRawResult([{ one: 1 }], [{ name: 'one' }]);
       const arraysResult = makeRawResult([[1]], [{ name: 'one' }]);
 
@@ -63,7 +63,6 @@ describe('postgres-js', () => {
       expect(query.values).toHaveBeenCalledTimes(1);
       expect(result.rowCount).toBe(1);
       expect(result.rows[0]).toEqual([1]);
-      expect(result.fields).toEqual([{ name: 'one' }]);
     });
   });
 });

--- a/packages/pqb/src/adapters/postgres-js.ts
+++ b/packages/pqb/src/adapters/postgres-js.ts
@@ -16,6 +16,7 @@ import {
 } from 'pqb/internal';
 import { createDbWithAdapter } from 'pqb';
 import { HackySavepointState } from './adapter';
+import { parseInterval } from './driver-adapter-shared';
 
 export interface CreatePostgresJsDbOptions<
   SchemaConfig extends ColumnSchemaConfig,
@@ -59,12 +60,27 @@ class PostgresJsResult<T extends QueryResultRow> implements QueryResult<T> {
   }
 }
 
+class PostgresJsArraysResult<
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  R extends any[],
+> implements QueryResult<R> {
+  rowCount: number;
+  rows: R[];
+  fields: QueryResult['fields'];
+
+  constructor(result: RawResult) {
+    this.rowCount = result.count;
+    this.rows = result as never;
+    this.fields = result.statement.columns;
+  }
+}
+
 const types: Record<string, Partial<postgres.PostgresType>> = {
   bytea: {
     to: 17,
     from: 17 as never,
     serialize: (x) => '\\x' + Buffer.from(x).toString('hex'),
-    // omit parse, let bytea return a string, so it remains consistent with when it's selected via JSON
+    parse: (x: string) => Buffer.from(x.slice(2), 'hex'),
   },
   dateAndTimestampAsStrings: {
     to: 25,
@@ -74,25 +90,11 @@ const types: Record<string, Partial<postgres.PostgresType>> = {
   interval: {
     from: [1186],
     serialize: returnArg,
-    parse(str: string) {
-      const [years, , months, , days, , time] = str.split(' ');
-      const [hours, minutes, seconds] = time.split(':');
-
-      return {
-        years: years ? Number(years) : 0,
-        months: months ? Number(months) : 0,
-        days: days ? Number(days) : 0,
-        hours: hours ? Number(hours) : 0,
-        minutes: minutes ? Number(minutes) : 0,
-        seconds: seconds ? Number(seconds) : 0,
-      };
-    },
+    parse: parseInterval,
   },
-  // overrides the built-in json type to not serialize it, because it incorrectly serializes
   json: {
     to: 114,
     from: [114, 3802],
-    serialize: returnArg,
     parse: (x) => {
       return JSON.parse(x);
     },
@@ -120,7 +122,10 @@ export const PostgresJsAdapter: DriverAdapter = {
   },
 
   configure(params: PostgresJsAdapterOptions): postgres.Sql {
-    const config: PostgresJsAdapterOptions = { ...params, types };
+    const config: PostgresJsAdapterOptions = {
+      ...params,
+      types,
+    };
 
     if (config.setConfig?.search_path) {
       config.connection = {
@@ -139,11 +144,10 @@ export const PostgresJsAdapter: DriverAdapter = {
     return sql;
   },
 
-  async queryClient<T extends QueryResultRow = QueryResultRow>(
+  async queryClient<T = QueryResultRow>(
     client: TransactionSql,
     text: string,
     values?: unknown[],
-    // SQL session state (role and setConfig) from async storage
     arraysMode?: boolean,
   ): Promise<QueryResult<T>> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -153,11 +157,14 @@ export const PostgresJsAdapter: DriverAdapter = {
 
     const result = await query;
     if (result.constructor === Array) {
-      return (result as RawResult[]).map(
-        (res) => new PostgresJsResult(res),
+      return (result as RawResult[]).map((res) =>
+        makePostgresJsResult(res, arraysMode),
       ) as never;
     } else {
-      return new PostgresJsResult(result as RawResult);
+      return makePostgresJsResult(
+        result as RawResult,
+        arraysMode,
+      ) as QueryResult<T>;
     }
   },
 
@@ -243,7 +250,7 @@ export const PostgresJsAdapter: DriverAdapter = {
             values,
             arraysMode,
           );
-          resultResolve(res);
+          resultResolve(res as QueryResult<T>);
         } catch (err) {
           resultReject(err);
           throw err;
@@ -272,4 +279,13 @@ export const PostgresJsAdapter: DriverAdapter = {
   close(client: postgres.Sql): Promise<void> {
     return client.end();
   },
+};
+
+const makePostgresJsResult = (
+  result: RawResult,
+  arraysMode?: boolean,
+): QueryResult => {
+  return arraysMode
+    ? new PostgresJsArraysResult(result)
+    : new PostgresJsResult(result);
 };

--- a/packages/pqb/src/columns/column-schema.ts
+++ b/packages/pqb/src/columns/column-schema.ts
@@ -1,4 +1,6 @@
 import { Column } from './column';
+import { PostgresInterval } from '../adapters/driver-adapter-shared';
+import { AdapterSchemaConfigOptions } from '../adapters/adapter';
 
 export interface ColumnSchemaGetterTableClass {
   prototype: {
@@ -29,9 +31,14 @@ export interface ColumnTypeSchemaArg {
   error?: unknown;
 }
 
+export interface SchemaConfigFnWithOptions extends AdapterSchemaConfigOptions {
+  (): ColumnSchemaConfig;
+}
+
 export interface ColumnSchemaConfig<
   T extends Column.Pick.Data = Column.Pick.Data,
 > extends ColumnTypeSchemaArg {
+  intervalParse?(input: unknown): PostgresInterval;
   dateAsNumber: unknown;
   dateAsDate: unknown;
   enum: unknown;

--- a/packages/pqb/src/columns/column-types.ts
+++ b/packages/pqb/src/columns/column-types.ts
@@ -158,7 +158,12 @@ export const makeColumnTypes = <SchemaConfig extends ColumnSchemaConfig>(
       return new TimeColumn<SchemaConfig>(schema, precision);
     },
     interval(fields, precision) {
-      return new IntervalColumn<SchemaConfig>(schema, fields, precision);
+      return new IntervalColumn(
+        schema,
+        fields,
+        precision,
+        schema.intervalParse,
+      );
     },
     boolean() {
       return new BooleanColumn<SchemaConfig>(schema);

--- a/packages/pqb/src/columns/column-types/array.ts
+++ b/packages/pqb/src/columns/column-types/array.ts
@@ -8,7 +8,7 @@ import {
 } from '../code';
 import { columnCode } from '../code';
 import { Operators, OperatorsArray } from '../operators';
-import { setColumnDefaultParse } from '../column.utils';
+import { setColumnDefaultEncode, setColumnDefaultParse } from '../column.utils';
 import { ArrayMethodsData } from '../column-data-types';
 import { ColumnSchemaConfig, ColumnTypeSchemaArg } from '../column-schema';
 
@@ -60,6 +60,7 @@ export class ArrayColumn<
     schema: Schema,
     item: Item,
     inputType: InputType,
+    defaultEncode?: (input: unknown) => unknown,
     outputType?: OutputType,
     queryType?: QueryType,
   ) {
@@ -69,6 +70,9 @@ export class ArrayColumn<
     item.data.isNullable = true;
 
     setColumnDefaultParse(this, (input) => parse.call(this as never, input));
+    if (defaultEncode) {
+      setColumnDefaultEncode(this, defaultEncode);
+    }
 
     this.data.item = item instanceof ArrayColumn ? item.data.item : item;
     this.data.name = item.data.name;

--- a/packages/pqb/src/columns/column-types/boolean.ts
+++ b/packages/pqb/src/columns/column-types/boolean.ts
@@ -3,8 +3,8 @@ import { columnCode, ColumnToCodeCtx } from '../code';
 import { Code } from '../code';
 import { Operators, OperatorsBoolean } from '../operators';
 import {
-  defaultSchemaConfig,
   DefaultSchemaConfig,
+  internalSchemaConfig,
 } from '../default-schema-config';
 import { ColumnSchemaConfig } from '../column-schema';
 
@@ -20,7 +20,7 @@ export class BooleanColumn<Schema extends ColumnSchemaConfig> extends Column<
 
   private static _instance: BooleanColumn<DefaultSchemaConfig> | undefined;
   static get instance() {
-    return (this._instance ??= new BooleanColumn(defaultSchemaConfig));
+    return (this._instance ??= new BooleanColumn(internalSchemaConfig));
   }
 
   constructor(schema: Schema) {

--- a/packages/pqb/src/columns/column-types/date-time.test.ts
+++ b/packages/pqb/src/columns/column-types/date-time.test.ts
@@ -8,11 +8,13 @@ import {
   testDb,
   testSchemaConfig,
   useTestDatabase,
+  testAdapterName,
+  testDefaultColumnTypes,
 } from 'test-utils';
-import { TimeInterval } from '../types';
 import { z } from 'zod/v4';
 import { Column } from '../column';
 import { ColumnToCodeCtx } from '../code';
+import { PostgresInterval } from '../../adapters/driver-adapter-shared';
 
 const ctx: ColumnToCodeCtx = {
   t: 't',
@@ -37,10 +39,16 @@ describe('date time columns', () => {
   describe('date', () => {
     it('should output string', async () => {
       const result = await testDb.get(
-        testDb.sql`'1999-01-08'::date`.type(() => t.date()),
+        testDb.sql`'1999-01-08'::date`.type(() =>
+          testDefaultColumnTypes.date(),
+        ),
       );
 
-      expect(result).toBe('1999-01-08');
+      if (testAdapterName === 'bun') {
+        expect(result).toBe('1999-01-08T00:00:00.000Z');
+      } else {
+        expect(result).toBe('1999-01-08');
+      }
 
       assertType<typeof result, string>();
     });
@@ -82,11 +90,16 @@ describe('date time columns', () => {
 
     it('should output string', async () => {
       const result = await testDb.get(
-        testDb.sql`'1999-01-08 04:05:06'::timestamp`.type(
-          () => new TimestampTZColumn(testSchemaConfig),
+        testDb.sql`'1999-01-08 04:05:06'::timestamp`.type(() =>
+          testDefaultColumnTypes.timestampNoTZ(),
         ),
       );
-      expect(result).toBe('1999-01-08 04:05:06');
+
+      if (testAdapterName === 'bun') {
+        expect(result).toBe('1999-01-08T04:05:06.000Z');
+      } else {
+        expect(result).toBe('1999-01-08 04:05:06');
+      }
 
       assertType<typeof result, string>();
     });
@@ -141,10 +154,15 @@ describe('date time columns', () => {
     it('should output string', async () => {
       const result = await testDb.get(
         testDb.sql`'1999-01-08 04:05:06 +0'::timestamptz AT TIME ZONE 'UTC'`.type(
-          () => new TimestampTZColumn(testSchemaConfig),
+          () => testDefaultColumnTypes.timestamp(),
         ),
       );
-      expect(result).toBe('1999-01-08 04:05:06');
+
+      if (testAdapterName === 'bun') {
+        expect(result).toBe('1999-01-08T04:05:06.000Z');
+      } else {
+        expect(result).toBe('1999-01-08 04:05:06');
+      }
 
       assertType<typeof result, string>();
     });
@@ -211,10 +229,11 @@ describe('date time columns', () => {
   describe('interval', () => {
     it('should output string', async () => {
       const result = await testDb.get(
-        testDb.sql`'1 year 2 months 3 days 4 hours 5 minutes 6 seconds'::interval`.type(
-          () => t.interval(),
+        testDb.sql`'1 year 2 months 3 days 4 hours 5 minutes 6 seconds 7 milliseconds'::interval`.type(
+          (t) => t.interval(),
         ),
       );
+
       expect(result).toEqual({
         years: 1,
         months: 2,
@@ -222,9 +241,10 @@ describe('date time columns', () => {
         hours: 4,
         minutes: 5,
         seconds: 6,
+        milliseconds: 7,
       });
 
-      assertType<typeof result, TimeInterval>();
+      assertType<typeof result, PostgresInterval>();
     });
 
     it('should have toCode', () => {
@@ -372,8 +392,8 @@ describe('date time columns', () => {
 
       assertType<typeof user, { createdAt: Date; updatedAt: Date }>();
 
-      expect(user.createdAt).toBeInstanceOf(Date);
-      expect(user.updatedAt).toBeInstanceOf(Date);
+      expect(user.createdAt).toEqual(expect.any(Date));
+      expect(user.updatedAt).toEqual(expect.any(Date));
 
       const updateQuery = UserWithNumberTimestamp.find(id).update({
         createdAt: now,

--- a/packages/pqb/src/columns/column-types/date-time.ts
+++ b/packages/pqb/src/columns/column-types/date-time.ts
@@ -1,18 +1,45 @@
 import { Column } from '../column';
 import { joinTruthy } from '../../utils';
-import { TimeInterval } from '../types';
 import { Code, ColumnToCodeCtx, dateDataToCode } from '../code';
 import { columnCode } from '../code';
 import { Operators, OperatorsDate, OperatorsTime } from '../operators';
 import { DateColumnData } from '../column-data-types';
 import { ColumnSchemaConfig } from '../column-schema';
+import { PostgresInterval } from '../../adapters/driver-adapter-shared';
+import { setColumnDefaultParse } from '../column.utils';
 
 export type DateColumnInput = string | number | Date;
 
+const dateToString = (value: Date): string => value.toISOString();
+
 // encode string, number, or Date to a Date object,
-const dateTimeEncode = (input: DateColumnInput) => {
-  return typeof input === 'number' ? new Date(input) : input;
+const dateTimeEncode = (value: DateColumnInput) => {
+  return typeof value === 'number' ? new Date(value) : value;
 };
+
+// In Bun, it is Date normally, but string in case of nested json
+const parseStringOrDateToNumber = (value: unknown): number =>
+  typeof value === 'string' ? Date.parse(value) : (value as Date).getTime();
+
+export const getDateAsNumberFn = (column: {
+  data: Column.Data;
+  dateParsedByDriver?: boolean;
+}) =>
+  column.dateParsedByDriver
+    ? parseStringOrDateToNumber
+    : (Date.parse as (input: unknown) => number);
+
+// parse a date string to date object, with respect to null
+const parseDateToDate = (value: unknown): Date => new Date(value as string);
+
+// In Bun, it is Date normally, but string in case of nested json
+const parseStringOrDateToDate = (value: unknown): Date =>
+  typeof value === 'string' ? new Date(value) : (value as Date);
+
+export const getDateAsDateFn = (column: {
+  data: Column.Data;
+  dateParsedByDriver?: boolean;
+}) => (column.dateParsedByDriver ? parseStringOrDateToDate : parseDateToDate);
 
 // common class for Date and DateTime columns
 export abstract class DateBaseColumn<
@@ -31,13 +58,19 @@ export abstract class DateBaseColumn<
   asNumber: Schema['dateAsNumber'];
   asDate: Schema['dateAsDate'];
 
-  constructor(schema: Schema) {
+  constructor(
+    schema: Schema,
+    public dateParsedByDriver?: boolean,
+  ) {
     super(
       schema,
       schema.stringNumberDate() as never,
       schema.stringSchema() as never,
       schema.stringNumberDate() as never,
     );
+    if (dateParsedByDriver) {
+      this._parse = dateToString as never;
+    }
     this.asNumber = schema.dateAsNumber;
     this.asDate = schema.dateAsDate;
     this.data.encode = dateTimeEncode;
@@ -64,8 +97,12 @@ export abstract class DateTimeBaseClass<
 > extends DateBaseColumn<Schema> {
   declare data: DateColumnData & { dateTimePrecision?: number };
 
-  constructor(schema: Schema, dateTimePrecision?: number) {
-    super(schema);
+  constructor(
+    schema: Schema,
+    dateTimePrecision?: number,
+    dateParsedByDriver?: boolean,
+  ) {
+    super(schema, dateParsedByDriver);
     this.data.dateTimePrecision = dateTimePrecision;
   }
 
@@ -188,21 +225,58 @@ export class TimeColumn<Schema extends ColumnSchemaConfig> extends Column<
   }
 }
 
+const addIntervalPart = (
+  parts: string[],
+  value: number | undefined,
+  unit: string,
+) => {
+  if (value) {
+    parts.push(`${value} ${unit}`);
+  }
+};
+
+const serializePostgresInterval = (
+  input: Partial<PostgresInterval>,
+): string => {
+  const parts: string[] = [];
+
+  addIntervalPart(parts, input.years, 'years');
+  addIntervalPart(parts, input.months, 'months');
+  addIntervalPart(parts, input.days, 'days');
+  addIntervalPart(parts, input.hours, 'hours');
+  addIntervalPart(parts, input.minutes, 'minutes');
+  addIntervalPart(parts, input.seconds, 'seconds');
+  addIntervalPart(parts, input.milliseconds, 'milliseconds');
+
+  return parts.length ? parts.join(' ') : '0 seconds';
+};
+
 // interval [ fields ] [ (p) ]	16 bytes	time interval	-178000000 years	178000000 years	1 microsecond
 export class IntervalColumn<Schema extends ColumnSchemaConfig> extends Column<
   Schema,
-  TimeInterval,
+  PostgresInterval,
   ReturnType<Schema['timeInterval']>,
-  OperatorsDate
+  OperatorsDate,
+  Partial<PostgresInterval>,
+  PostgresInterval
 > {
   declare data: Column.Data & { fields?: string; precision?: number };
   dataType = 'interval' as const;
   operators = Operators.date;
 
-  constructor(schema: Schema, fields?: string, precision?: number) {
+  constructor(
+    schema: Schema,
+    fields?: string,
+    precision?: number,
+    parse?: (input: string) => PostgresInterval,
+  ) {
     super(schema, schema.timeInterval() as never);
     this.data.fields = fields;
     this.data.precision = precision;
+    if (parse) {
+      setColumnDefaultParse(this, parse);
+    }
+    this.data.encode = serializePostgresInterval;
   }
 
   toCode(ctx: ColumnToCodeCtx, key: string): Code {

--- a/packages/pqb/src/columns/column-types/enum.test.ts
+++ b/packages/pqb/src/columns/column-types/enum.test.ts
@@ -1,6 +1,10 @@
-import { assertType, testZodColumnTypes as t, testDb } from 'test-utils';
+import {
+  assertType,
+  testZodColumnTypes as t,
+  testDb,
+  testDefaultSchemaConfig,
+} from 'test-utils';
 import { makeColumnTypes } from '../column-types';
-import { defaultSchemaConfig } from '../default-schema-config';
 
 import { ColumnToCodeCtx } from '../code';
 
@@ -42,7 +46,7 @@ describe('enum column', () => {
   });
 
   it('should have string literal union output and input type', () => {
-    const t = makeColumnTypes(defaultSchemaConfig);
+    const t = makeColumnTypes(testDefaultSchemaConfig);
     const column = t.enum('mood', ['sad', 'ok', 'happy']);
 
     assertType<typeof column.outputType, 'sad' | 'ok' | 'happy'>();

--- a/packages/pqb/src/columns/column-types/json.test.ts
+++ b/packages/pqb/src/columns/column-types/json.test.ts
@@ -1,6 +1,12 @@
 import { codeToString, ColumnToCodeCtx } from '../code';
-import { testZodColumnTypes as t } from 'test-utils';
+import {
+  BaseTable,
+  db,
+  testZodColumnTypes as t,
+  useTestDatabase,
+} from 'test-utils';
 import { z } from 'zod/v4';
+import { orchidORMWithAdapter } from 'orchid-orm';
 
 const ctx: ColumnToCodeCtx = {
   t: 't',
@@ -8,25 +14,54 @@ const ctx: ColumnToCodeCtx = {
   currentSchema: 'public',
 };
 
+const ormParams = {
+  db: db.$qb,
+};
+
 describe('json columns', () => {
+  describe('json and jsonText', () => {
+    useTestDatabase();
+
+    it('should encode and parse jsonb, should not encode and parse json', async () => {
+      class Table extends BaseTable {
+        readonly table = 'test-json-columns';
+        readonly noPrimaryKey = true;
+        columns = this.setColumns((t) => ({
+          jsonb: t.json(),
+          json: t.jsonText(),
+        }));
+      }
+
+      const db = orchidORMWithAdapter(ormParams, {
+        table: Table,
+      });
+
+      await db.$query`CREATE TABLE "test-json-columns" ( "jsonb" jsonb, "json" json )`;
+
+      await db.table.insert({
+        jsonb: { jsonb: true },
+        json: { json: true },
+      });
+
+      const res = await db.table.take();
+
+      expect(res).toEqual({
+        jsonb: { jsonb: true },
+        json: { json: true },
+      });
+    });
+  });
+
   describe('json', () => {
     it('should have toCode', () => {
       const code = t.json(z.object({ foo: z.string() })).toCode(ctx, 'key');
       expect(codeToString(code, '', '  ')).toBe(`t.json()`);
-    });
-
-    it(`should have encode because pg driver fails to encode arrays on its own`, async () => {
-      expect(t.json().data.encode?.([1, '2', true])).toBe('[1,"2",true]');
     });
   });
 
   describe('jsonText', () => {
     it('should have toCode', () => {
       expect(t.jsonText().toCode(ctx, 'key')).toBe('t.jsonText()');
-    });
-
-    it(`should not have encode because it expects a JSON string`, async () => {
-      expect(t.jsonText().data.encode).toBe(undefined);
     });
   });
 });

--- a/packages/pqb/src/columns/column-types/json.ts
+++ b/packages/pqb/src/columns/column-types/json.ts
@@ -3,12 +3,12 @@ import { columnCode, ColumnToCodeCtx } from '../code';
 import { Operators, OperatorsJson, OperatorsText } from '../operators';
 import { Code } from '../code';
 import {
-  defaultSchemaConfig,
   DefaultSchemaConfig,
+  internalSchemaConfig,
 } from '../default-schema-config';
 import { ColumnSchemaConfig, ColumnTypeSchemaArg } from '../column-schema';
 
-const encode = (x: unknown) => (x === null ? x : JSON.stringify(x));
+export const encodeJson = (x: unknown) => (x === null ? x : JSON.stringify(x));
 
 // Type of JSON column (jsonb).
 export class JSONColumn<
@@ -19,9 +19,15 @@ export class JSONColumn<
   dataType = 'jsonb' as const;
   operators = Operators.json;
 
-  constructor(schema: Schema, inputType: Schema['type']) {
+  constructor(
+    schema: Schema,
+    inputType: Schema['type'],
+    encodedByDriver = true,
+  ) {
     super(schema, inputType as InputSchema);
-    this.data.encode = encode;
+    if (!encodedByDriver) {
+      this.data.encode = encodeJson;
+    }
     this.data.parseItem = JSON.parse;
   }
 
@@ -33,8 +39,8 @@ export class JSONColumn<
 // JSON non-binary type, stored as a text in the database, so it doesn't have rich functionality.
 export class JSONTextColumn<Schema extends ColumnSchemaConfig> extends Column<
   Schema,
-  string,
-  ReturnType<Schema['stringSchema']>,
+  unknown,
+  ReturnType<Schema['unknown']>,
   OperatorsText
 > {
   dataType = 'json' as const;
@@ -42,7 +48,7 @@ export class JSONTextColumn<Schema extends ColumnSchemaConfig> extends Column<
 
   private static _instance: JSONTextColumn<DefaultSchemaConfig> | undefined;
   static get instance() {
-    return (this._instance ??= new JSONTextColumn(defaultSchemaConfig));
+    return (this._instance ??= new JSONTextColumn(internalSchemaConfig));
   }
 
   constructor(schema: Schema) {

--- a/packages/pqb/src/columns/column-types/postgis.test.ts
+++ b/packages/pqb/src/columns/column-types/postgis.test.ts
@@ -1,10 +1,9 @@
-import { testDb } from 'test-utils';
+import { testDb, testDefaultSchemaConfig } from 'test-utils';
 import {
   PostgisGeographyPointColumn,
   PostgisPoint,
   postgisTypmodToSql,
 } from './postgis';
-import { defaultSchemaConfig } from '../default-schema-config';
 
 import { ColumnToCodeCtx } from '../code';
 
@@ -21,7 +20,9 @@ describe('postgis columns', () => {
   };
 
   describe('geography.point', () => {
-    const pointColumn = new PostgisGeographyPointColumn(defaultSchemaConfig);
+    const pointColumn = new PostgisGeographyPointColumn(
+      testDefaultSchemaConfig,
+    );
 
     it('should parse coords with default srid', async () => {
       const result = await testDb.get(

--- a/packages/pqb/src/columns/column-types/string.test.ts
+++ b/packages/pqb/src/columns/column-types/string.test.ts
@@ -169,18 +169,6 @@ describe('string columns', () => {
 
   describe('binary', () => {
     describe('bytea', () => {
-      it('is a string originally, if we remove the default parser', async () => {
-        const result = await testDb.get(
-          testDb.sql`'text'::bytea`.type(() =>
-            t.bytea().parse(z.string(), (str) => str),
-          ),
-        );
-
-        assertType<typeof result, string>();
-
-        expect(result).toBe('\\x' + Buffer.from('text').toString('hex'));
-      });
-
       it('should output Buffer', async () => {
         const result = await testDb.get(
           testDb.sql`'text'::bytea`.type(() => t.bytea()),

--- a/packages/pqb/src/columns/column-types/string.ts
+++ b/packages/pqb/src/columns/column-types/string.ts
@@ -11,8 +11,8 @@ import {
 } from '../operators';
 import { setColumnDefaultParse } from '../column.utils';
 import {
-  defaultSchemaConfig,
   DefaultSchemaConfig,
+  internalSchemaConfig,
 } from '../default-schema-config';
 import { StringData } from '../column-data-types';
 import { ColumnSchemaConfig } from '../column-schema';
@@ -143,7 +143,7 @@ export class TextColumn<
 
   private static _instance: TextColumn<DefaultSchemaConfig> | undefined;
   static get instance() {
-    return (this._instance ??= new TextColumn(defaultSchemaConfig));
+    return (this._instance ??= new TextColumn(internalSchemaConfig));
   }
 
   constructor(schema: Schema) {
@@ -698,7 +698,7 @@ export class XMLColumn<Schema extends ColumnSchemaConfig> extends Column<
 
   private static _instance: XMLColumn<DefaultSchemaConfig> | undefined;
   static get instance() {
-    return (this._instance ??= new XMLColumn(defaultSchemaConfig));
+    return (this._instance ??= new XMLColumn(internalSchemaConfig));
   }
 
   constructor(schema: Schema) {

--- a/packages/pqb/src/columns/column-types/unknown.ts
+++ b/packages/pqb/src/columns/column-types/unknown.ts
@@ -1,13 +1,13 @@
 import { VirtualColumn } from './virtual';
 import { RawSql } from '../../query/expressions/raw-sql';
-import { defaultSchemaConfig } from '../default-schema-config';
+import { internalSchemaConfig } from '../default-schema-config';
 import { ColumnSchemaConfig } from '../column-schema';
 
 // unknown column is used for the case of raw SQL when user doesn't specify a column
 export class UnknownColumn<
   Schema extends ColumnSchemaConfig,
 > extends VirtualColumn<Schema> {
-  static instance = new UnknownColumn(defaultSchemaConfig);
+  static instance = new UnknownColumn(internalSchemaConfig);
 
   selectable = true;
 

--- a/packages/pqb/src/columns/column.test.ts
+++ b/packages/pqb/src/columns/column.test.ts
@@ -16,12 +16,13 @@ import {
   db,
   UserData,
   UserDefaultSelect,
+  testJsonValue,
+  testAdapterConfig,
 } from 'test-utils';
 import { raw } from '../query/expressions/raw-sql';
 import { Operators } from './operators';
 import { z, ZodLiteral, ZodNumber } from 'zod/v4';
 import { assignDbDataToColumn } from './column-from-db.utils';
-import { zodSchemaConfig } from 'orchid-orm-schema-to-zod';
 import { ColumnSchemaConfig } from './column-schema';
 
 describe('column type', () => {
@@ -386,16 +387,16 @@ describe('column type', () => {
           },
         );
 
-        expect(typeof (await UserWithPlainTimestamp.take()).createdAt).toBe(
-          'string',
+        expect((await UserWithPlainTimestamp.take()).createdAt).toEqual(
+          expect.any(testAdapterConfig?.dateParsedByDriver ? Date : String),
         );
       });
 
       it('should parse all columns', async () => {
-        expect((await db.user.all())[0].createdAt instanceof Date).toBe(true);
-        expect((await db.user.take()).createdAt instanceof Date).toBe(true);
+        expect((await db.user.all())[0].createdAt).toEqual(expect.any(Date));
+        expect((await db.user.take()).createdAt).toEqual(expect.any(Date));
         const idx = Object.keys(db.user.q.shape).indexOf('createdAt');
-        expect((await db.user.rows())[0][idx] instanceof Date).toBe(true);
+        expect((await db.user.rows())[0][idx]).toEqual(expect.any(Date));
       });
 
       it('should parse joined record columns', async () => {
@@ -504,7 +505,7 @@ describe('column type', () => {
     const dbZod = createDbWithAdapter({
       snakeCase: true,
       adapter: testAdapter,
-      schemaConfig: zodSchemaConfig,
+      schemaConfig: () => testSchemaConfig,
       columnTypes: (t) => ({
         ...t,
         numberTimestamp: () =>
@@ -549,7 +550,7 @@ describe('column type', () => {
     );
 
     const userColumnsSql =
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      //
       UserWithCustomTimestamps.q.selectAllColumns!.join(', ');
 
     describe.each`
@@ -815,7 +816,7 @@ describe('column type', () => {
       expectSql(
         q.toSQL(),
         `INSERT INTO "schema"."user"("name", "password", "data") VALUES ($1, $2, $3)`,
-        [userData.name, userData.password, '["foo"]'],
+        [userData.name, userData.password, testJsonValue(['foo'])],
       );
     });
   });
@@ -1026,7 +1027,7 @@ describe('column type', () => {
     it('should have toSQL', () => {
       const values: unknown[] = [];
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      //
       const sql = column.generated`1 + ${2}`.data.generated!.toSQL({
         values,
         snakeCase: undefined,
@@ -1037,14 +1038,14 @@ describe('column type', () => {
     });
 
     it('should have toCode', () => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      //
       const sql = column.generated`1 + ${2}`.data.generated!;
 
       expect(sql.toCode()).toBe('.generated`1 + ${2}`');
     });
 
     it('should have toCode for raw argument', () => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      //
       const sql = column.generated({ raw: 'raw' }).data.generated!;
 
       expect(sql.toCode()).toBe(".generated({ raw: 'raw' })");
@@ -1052,7 +1053,7 @@ describe('column type', () => {
 
     it('should have toCode for raw argument with values', () => {
       const sql =
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        //
         column.generated({ raw: 'raw', values: { num: 123 } }).data.generated!;
 
       expect(sql.toCode()).toBe(

--- a/packages/pqb/src/columns/column.utils.ts
+++ b/packages/pqb/src/columns/column.utils.ts
@@ -48,7 +48,7 @@ export const setColumnParse = (
 
 export const setColumnParseNull = (
   column: Column.Pick.Data,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  //
   fn: () => unknown,
   nullSchema?: unknown,
 ) => {
@@ -62,6 +62,13 @@ export const setColumnParseNull = (
     : (input: unknown) => (input === null ? fn() : input);
 
   return c;
+};
+
+export const setColumnDefaultEncode = (
+  column: Column.Pick.Data,
+  fn: (input: any) => unknown, // eslint-disable-line @typescript-eslint/no-explicit-any
+) => {
+  column.data.encode = fn;
 };
 
 export const setColumnEncode = (

--- a/packages/pqb/src/columns/default-schema-config.test.ts
+++ b/packages/pqb/src/columns/default-schema-config.test.ts
@@ -1,6 +1,6 @@
-import { assertType, columnTypes } from 'test-utils';
+import { assertType, testDefaultColumnTypes } from 'test-utils';
 
-const t = columnTypes;
+const t = testDefaultColumnTypes;
 const text = t.text();
 const timestamp = t.timestamp();
 

--- a/packages/pqb/src/columns/default-schema-config.ts
+++ b/packages/pqb/src/columns/default-schema-config.ts
@@ -1,5 +1,7 @@
 import {
   DateColumn,
+  getDateAsDateFn,
+  getDateAsNumberFn,
   TimestampColumn,
   TimestampTZColumn,
 } from './column-types/date-time';
@@ -28,6 +30,7 @@ import { Column, setColumnData } from './column';
 import { setColumnParse, setColumnParseNull } from './column.utils';
 import { ColumnSchemaConfig } from './column-schema';
 import { MaybeArray, noop } from '../utils';
+import { AdapterSchemaConfigOptions } from '../adapters/adapter';
 
 export interface DefaultSchemaConfig extends ColumnSchemaConfig<Column> {
   parse<T extends Column.Pick.ForParse, Output>(
@@ -58,7 +61,7 @@ export interface DefaultSchemaConfig extends ColumnSchemaConfig<Column> {
     },
   >(
     this: T,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    //
     _fn: (
       type: <Type, Input = Type, Output = Type, Query = Type>() => {
         type: Type;
@@ -74,7 +77,7 @@ export interface DefaultSchemaConfig extends ColumnSchemaConfig<Column> {
     Types extends Column.InputOutputQueryTypes,
   >(
     this: T,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    //
     _fn: (
       type: <
         Type extends T['inputType'] extends T['outputType'] & T['queryType']
@@ -93,7 +96,7 @@ export interface DefaultSchemaConfig extends ColumnSchemaConfig<Column> {
     Types extends Column.InputOutputQueryTypes,
   >(
     this: T,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    //
     _fn: (
       type: <
         Types extends {
@@ -168,89 +171,108 @@ export interface DefaultSchemaConfig extends ColumnSchemaConfig<Column> {
   timestamp(precision?: number): TimestampTZColumn<DefaultSchemaConfig>;
 }
 
-// parse a date string to date object, with respect to null
-const parseDateToDate = (value: unknown): Date => new Date(value as string);
+export const defaultSchemaConfig = (
+  options?: AdapterSchemaConfigOptions,
+): DefaultSchemaConfig => {
+  const schemaConfig = {
+    intervalParse: options?.intervalParse,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    parse(fn: (input: any) => unknown) {
+      return setColumnParse(this as never, fn);
+    },
+    parseNull(fn: () => unknown) {
+      return setColumnParseNull(this as never, fn);
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    encode(fn: (input: any) => unknown) {
+      return setColumnData(this as Column.Pick.Data, 'encode', fn);
+    },
+    asType() {
+      return this as never;
+    },
+    narrowType() {
+      return this as never;
+    },
+    narrowAllTypes() {
+      return this as never;
+    },
+    dateAsNumber(this: { data: Column.Data; parse(fn: unknown): unknown }) {
+      return this.parse(getDateAsNumberFn(this)) as never;
+    },
+    dateAsDate(this: { data: Column.Data; parse(fn: unknown): unknown }) {
+      return this.parse(getDateAsDateFn(this)) as never;
+    },
+    enum<const T extends readonly [string, ...string[]]>(
+      dataType: string,
+      type: T,
+    ) {
+      return new EnumColumn(schemaConfig, dataType, type, undefined);
+    },
+    array<Item extends ArrayColumnValue>(item: Item) {
+      return new ArrayColumn(
+        schemaConfig,
+        item,
+        undefined,
+        options?.arrayEncode,
+      );
+    },
+    boolean: noop,
+    buffer: noop,
+    unknown: noop,
+    never: noop,
+    stringSchema: noop,
+    stringMin: noop,
+    stringMax: noop,
+    stringMinMax: noop,
+    number: noop,
+    int: noop,
+    stringNumberDate: noop,
+    timeInterval: noop,
+    bit: noop,
+    uuid: noop,
+    nullable(this: Column.Pick.ForNullable) {
+      return setColumnData(this, 'isNullable', true);
+    },
+    json() {
+      return new JSONColumn(
+        schemaConfig,
+        undefined,
+        options?.jsonEncodedByDriver,
+      );
+    },
+    setErrors: noop,
 
-export const defaultSchemaConfig = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  parse(fn: (input: any) => unknown) {
-    return setColumnParse(this as never, fn);
-  },
-  parseNull(fn: () => unknown) {
-    return setColumnParseNull(this as never, fn);
-  },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  encode(fn: (input: any) => unknown) {
-    return setColumnData(this as Column.Pick.Data, 'encode', fn);
-  },
-  asType() {
-    return this as never;
-  },
-  narrowType() {
-    return this as never;
-  },
-  narrowAllTypes() {
-    return this as never;
-  },
-  dateAsNumber(this: { data: Column.Data; parse(fn: unknown): unknown }) {
-    return this.parse(Date.parse) as never;
-  },
-  dateAsDate(this: { data: Column.Data; parse(fn: unknown): unknown }) {
-    return this.parse(parseDateToDate) as never;
-  },
-  enum<const T extends readonly [string, ...string[]]>(
-    dataType: string,
-    type: T,
-  ) {
-    return new EnumColumn(defaultSchemaConfig, dataType, type, undefined);
-  },
-  array<Item extends ArrayColumnValue>(item: Item) {
-    return new ArrayColumn(defaultSchemaConfig, item, undefined);
-  },
-  boolean: noop,
-  buffer: noop,
-  unknown: noop,
-  never: noop,
-  stringSchema: noop,
-  stringMin: noop,
-  stringMax: noop,
-  stringMinMax: noop,
-  number: noop,
-  int: noop,
-  stringNumberDate: noop,
-  timeInterval: noop,
-  bit: noop,
-  uuid: noop,
-  nullable(this: Column.Pick.ForNullable) {
-    return setColumnData(this, 'isNullable', true);
-  },
-  json() {
-    return new JSONColumn(defaultSchemaConfig, undefined);
-  },
-  setErrors: noop,
+    smallint: () => new SmallIntColumn(schemaConfig),
+    integer: () => new IntegerColumn(schemaConfig),
+    real: () => new RealColumn(schemaConfig),
+    smallSerial: () => new SmallSerialColumn(schemaConfig),
+    serial: () => new SerialColumn(schemaConfig),
 
-  smallint: () => new SmallIntColumn(defaultSchemaConfig),
-  integer: () => new IntegerColumn(defaultSchemaConfig),
-  real: () => new RealColumn(defaultSchemaConfig),
-  smallSerial: () => new SmallSerialColumn(defaultSchemaConfig),
-  serial: () => new SerialColumn(defaultSchemaConfig),
+    bigint: () => new BigIntColumn(schemaConfig),
+    decimal: (precision?: number, scale?: number) =>
+      new DecimalColumn(schemaConfig, precision, scale),
+    doublePrecision: () => new DoublePrecisionColumn(schemaConfig),
+    bigSerial: () => new BigSerialColumn(schemaConfig),
+    money: () => new MoneyColumn(schemaConfig),
+    varchar: (limit: number) => new VarCharColumn(schemaConfig, limit),
+    text: () => new TextColumn(schemaConfig),
+    string: (limit?: number) => new StringColumn(schemaConfig, limit),
+    citext: () => new CitextColumn(schemaConfig),
 
-  bigint: () => new BigIntColumn(defaultSchemaConfig),
-  decimal: (precision?: number, scale?: number) =>
-    new DecimalColumn(defaultSchemaConfig, precision, scale),
-  doublePrecision: () => new DoublePrecisionColumn(defaultSchemaConfig),
-  bigSerial: () => new BigSerialColumn(defaultSchemaConfig),
-  money: () => new MoneyColumn(defaultSchemaConfig),
-  varchar: (limit: number) => new VarCharColumn(defaultSchemaConfig, limit),
-  text: () => new TextColumn(defaultSchemaConfig),
-  string: (limit?: number) => new StringColumn(defaultSchemaConfig, limit),
-  citext: () => new CitextColumn(defaultSchemaConfig),
+    date: () => new DateColumn(schemaConfig, options?.dateParsedByDriver),
+    timestampNoTZ: (precision?: number) =>
+      new TimestampColumn(schemaConfig, precision, options?.dateParsedByDriver),
+    timestamp: (precision?: number) =>
+      new TimestampTZColumn(
+        schemaConfig,
+        precision,
+        options?.dateParsedByDriver,
+      ),
 
-  date: () => new DateColumn(defaultSchemaConfig),
-  timestampNoTZ: (precision?: number) =>
-    new TimestampColumn(defaultSchemaConfig, precision),
-  timestamp: (precision?: number) =>
-    new TimestampTZColumn(defaultSchemaConfig, precision),
+    geographyPointSchema: noop,
+  } as unknown as DefaultSchemaConfig;
 
-  geographyPointSchema: noop,
-} as unknown as DefaultSchemaConfig;
+  return schemaConfig;
+};
+
+export const internalSchemaConfig = defaultSchemaConfig();

--- a/packages/pqb/src/columns/index.ts
+++ b/packages/pqb/src/columns/index.ts
@@ -21,4 +21,3 @@ export * from './any-shape';
 export * from './column-data-types';
 export * from './column-schema';
 export * from './timestamps';
-export * from './types';

--- a/packages/pqb/src/columns/operators.test.ts
+++ b/packages/pqb/src/columns/operators.test.ts
@@ -1,7 +1,7 @@
 import { UserDataType } from '../test-utils/pqb.test-utils';
 import {
   assertType,
-  columnTypes,
+  testDefaultColumnTypes,
   db,
   expectSql,
   sql,
@@ -11,7 +11,7 @@ import {
   useTestDatabase,
 } from 'test-utils';
 
-const t = columnTypes;
+const t = testDefaultColumnTypes;
 
 describe('operators', () => {
   it('should ignore undefined values', () => {

--- a/packages/pqb/src/columns/types.ts
+++ b/packages/pqb/src/columns/types.ts
@@ -1,8 +1,0 @@
-export interface TimeInterval {
-  years?: number;
-  months?: number;
-  days?: number;
-  hours?: number;
-  minutes?: number;
-  seconds?: number;
-}

--- a/packages/pqb/src/index.ts
+++ b/packages/pqb/src/index.ts
@@ -79,6 +79,7 @@ export {
 // Column schema configuration
 export {
   defaultSchemaConfig,
+  internalSchemaConfig,
   getColumnTypes,
   makeColumnTypes,
   setColumnData,
@@ -96,7 +97,10 @@ export {
   DateTimeBaseClass,
   DateTimeTzBaseClass,
   Column,
+  getDateAsNumberFn,
+  getDateAsDateFn,
   type ColumnSchemaConfig,
+  type SchemaConfigFnWithOptions,
   type ColumnSchemaGetterColumns,
   type ColumnSchemaGetterTableClass,
   type ColumnTypeSchemaArg,
@@ -347,15 +351,16 @@ export {
   TransactionAdapterClass,
   makeConnectRetryConfig,
   wrapAdapterFnWithConnectRetry,
+  getDriverErrorCode,
   type Adapter,
   type TransactionAdapter,
   type DriverAdapter,
   type AdapterParams,
   type AdapterConfigBase,
   type QueryResult,
-  type QueryArraysResult,
   type QueryResultRow,
   type AfterCommitStandaloneHook,
+  type AdapterSchemaConfigOptions,
 } from './adapters/adapter';
 
 // Default privileges

--- a/packages/pqb/src/internal.ts
+++ b/packages/pqb/src/internal.ts
@@ -70,6 +70,7 @@ export {
 // Column schema configuration
 export {
   defaultSchemaConfig,
+  internalSchemaConfig,
   getColumnTypes,
   makeColumnTypes,
   setColumnData,
@@ -79,7 +80,10 @@ export {
   setDataValue,
   makeColumnNullable,
   Column,
+  getDateAsNumberFn,
+  getDateAsDateFn,
   type ColumnSchemaConfig,
+  type SchemaConfigFnWithOptions,
   type ColumnSchemaGetterColumns,
   type ColumnSchemaGetterTableClass,
   type ColumnTypeSchemaArg,
@@ -307,15 +311,16 @@ export {
   TransactionAdapterClass,
   makeConnectRetryConfig,
   wrapAdapterFnWithConnectRetry,
+  getDriverErrorCode,
   type Adapter,
   type TransactionAdapter,
   type DriverAdapter,
   type AdapterParams,
   type AdapterConfigBase,
   type QueryResult,
-  type QueryArraysResult,
   type QueryResultRow,
   type AfterCommitStandaloneHook,
+  type AdapterSchemaConfigOptions,
 } from './index';
 
 // Default privileges

--- a/packages/pqb/src/query/basic-features/aggregate/aggregate.ts
+++ b/packages/pqb/src/query/basic-features/aggregate/aggregate.ts
@@ -21,6 +21,7 @@ import {
   BooleanColumn,
   DecimalColumn,
   IntegerColumn,
+  internalSchemaConfig,
   JSONTextColumn,
   NumberAsStringBaseColumn,
   NumberBaseColumn,
@@ -29,7 +30,6 @@ import {
   XMLColumn,
 } from '../../../columns';
 import { Column } from '../../../columns/column';
-import { defaultSchemaConfig } from '../../../columns/default-schema-config';
 import {
   _getSelectableColumn,
   _queryGetOptional,
@@ -60,12 +60,12 @@ export const isSelectingCount = (q: PickQueryQ) => {
 
 // `count` returns `bigint` type that is represented by a string.
 // This is needed to parse the value back to a number.
-const intNullable = new IntegerColumn(defaultSchemaConfig)
+const intNullable = new IntegerColumn(internalSchemaConfig)
   .nullable()
   .parse(parseInt as never);
 
 // double-precision is represented by string in JS, parse it to float.
-const floatNullable = new RealColumn(defaultSchemaConfig)
+const floatNullable = new RealColumn(internalSchemaConfig)
   .nullable()
   .parse(parseFloat as never);
 
@@ -79,7 +79,7 @@ const xmlNullable = XMLColumn.instance.nullable();
 
 const stringAsNumberNullable =
   new (NumberAsStringBaseColumn as unknown as typeof DecimalColumn)(
-    defaultSchemaConfig,
+    internalSchemaConfig,
   ).nullable();
 
 const numericResultColumn = (

--- a/packages/pqb/src/query/basic-features/cte/cte.query.ts
+++ b/packages/pqb/src/query/basic-features/cte/cte.query.ts
@@ -270,7 +270,7 @@ export class CteQuery {
   ) {
     const q = _clone(this);
 
-    // eslint-disable-next-line prefer-const
+    //
     let [options, queryArg] = third
       ? [second as CteArgsOptions, third]
       : [undefined, second];
@@ -391,7 +391,7 @@ export class CteQuery {
   withRecursive(name: string, ...args: unknown[]) {
     const q = _clone(this);
 
-    // eslint-disable-next-line prefer-const
+    //
     let [options, baseFn, recursiveFn] = (
       args.length === 2 ? [{}, args[0], args[1]] : args
     ) as [
@@ -445,7 +445,7 @@ export class CteQuery {
    *       two: t.string(),
    *     }),
    *     // define SQL expression:
-   *     (q) => sql`(VALUES (1, 'two')) t(one, two)`,
+   *     (q) => sql`VALUES (1, 'two')`,
    *   )
    *   // is not prefixed in the middle of a query chain
    *   .withSql(
@@ -453,7 +453,7 @@ export class CteQuery {
    *     (t) => ({
    *       x: t.integer(),
    *     }),
-   *     (q) => sql`(VALUES (1)) t(x)`,
+   *     (q) => sql`VALUES (1)`,
    *   )
    *   .from('alias');
    * ```
@@ -476,7 +476,7 @@ export class CteQuery {
    *       one: t.integer(),
    *       two: t.string(),
    *     }),
-   *     (q) => sql`(VALUES (1, 'two')) t(one, two)`,
+   *     (q) => sql`VALUES (1, 'two')`,
    *   )
    *   .from('alias');
    * ```

--- a/packages/pqb/src/query/basic-features/mutate/create.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/create.test.ts
@@ -103,7 +103,7 @@ describe('create functions', () => {
 
       assertType<typeof res, UserRecord>();
 
-      expect(res.updatedAt).toBeInstanceOf(Date);
+      expect(res.updatedAt).toEqual(expect.any(Date));
     });
 
     it('should support a query builder for a column', () => {

--- a/packages/pqb/src/query/basic-features/mutate/update.test.ts
+++ b/packages/pqb/src/query/basic-features/mutate/update.test.ts
@@ -23,6 +23,7 @@ import {
   MessageData,
   sql,
   testDb,
+  testJsonValue,
   UserData,
   useTestDatabase,
 } from 'test-utils';
@@ -1787,7 +1788,7 @@ describe('updateMany', () => {
           FROM (VALUES ($1::int4, $2::jsonb)) "v"("id", "meta")
           WHERE "message"."id" = "v"."id"
         `,
-        [1, '{"foo":1}'],
+        [1, testJsonValue({ foo: 1 })],
       );
     });
   });

--- a/packages/pqb/src/query/basic-features/select/select.test.ts
+++ b/packages/pqb/src/query/basic-features/select/select.test.ts
@@ -21,9 +21,9 @@ import {
 } from '../../../test-utils/pqb.test-utils';
 import {
   DateColumn,
-  defaultSchemaConfig,
   DefaultSchemaConfig,
   IntegerColumn,
+  internalSchemaConfig,
   JSONTextColumn,
   VirtualColumn,
 } from '../../../columns';
@@ -99,7 +99,7 @@ describe('select', () => {
 
       const Table = Object.create(User);
       Table.q = {
-        shape: { ...Table.shape, virtual: new Virtual(defaultSchemaConfig) },
+        shape: { ...Table.shape, virtual: new Virtual(internalSchemaConfig) },
       };
 
       const q = Table.select('*');
@@ -368,10 +368,10 @@ describe('select', () => {
           createdAt: User.shape.createdAt,
         });
 
-        expect((await q.all())[0].createdAt instanceof Date).toBe(true);
-        expect((await q.take()).createdAt instanceof Date).toBe(true);
-        expect((await q.rows())[0][0] instanceof Date).toBe(true);
-        expect((await q.get('createdAt')) instanceof Date).toBe(true);
+        expect((await q.all())[0].createdAt).toEqual(expect.any(Date));
+        expect((await q.take()).createdAt).toEqual(expect.any(Date));
+        expect((await q.rows())[0][0]).toEqual(expect.any(Date));
+        expect(await q.get('createdAt')).toEqual(expect.any(Date));
       });
 
       it('should parse columns of the table, selected by column name and table name', async () => {
@@ -383,10 +383,10 @@ describe('select', () => {
           createdAt: User.shape.createdAt,
         });
 
-        expect((await q.all())[0].createdAt instanceof Date).toBe(true);
-        expect((await q.take()).createdAt instanceof Date).toBe(true);
-        expect((await q.rows())[0][0] instanceof Date).toBe(true);
-        expect((await q.get('user.createdAt')) instanceof Date).toBe(true);
+        expect((await q.all())[0].createdAt).toEqual(expect.any(Date));
+        expect((await q.take()).createdAt).toEqual(expect.any(Date));
+        expect((await q.rows())[0][0]).toEqual(expect.any(Date));
+        expect(await q.get('user.createdAt')).toEqual(expect.any(Date));
       });
 
       it('should parse columns of joined table', async () => {
@@ -400,10 +400,10 @@ describe('select', () => {
           createdAt: User.shape.createdAt,
         });
 
-        expect((await q.all())[0].createdAt instanceof Date).toBe(true);
-        expect((await q.take()).createdAt instanceof Date).toBe(true);
-        expect((await q.rows())[0][0] instanceof Date).toBe(true);
-        expect((await q.get('user.createdAt')) instanceof Date).toBe(true);
+        expect((await q.all())[0].createdAt).toEqual(expect.any(Date));
+        expect((await q.take()).createdAt).toEqual(expect.any(Date));
+        expect((await q.rows())[0][0]).toEqual(expect.any(Date));
+        expect(await q.get('user.createdAt')).toEqual(expect.any(Date));
       });
     });
 
@@ -1168,9 +1168,9 @@ describe('select', () => {
         date: User.shape.createdAt,
       });
 
-      expect((await q.all())[0].date instanceof Date).toBe(true);
-      expect((await q.take()).date instanceof Date).toBe(true);
-      expect((await q.rows())[0][0] instanceof Date).toBe(true);
+      expect((await q.all())[0].date).toEqual(expect.any(Date));
+      expect((await q.take()).date).toEqual(expect.any(Date));
+      expect((await q.rows())[0][0]).toEqual(expect.any(Date));
     });
 
     it('should parse columns of the table, selected by column name and table name', async () => {
@@ -1184,9 +1184,9 @@ describe('select', () => {
         date: User.shape.createdAt,
       });
 
-      expect((await q.all())[0].date instanceof Date).toBe(true);
-      expect((await q.take()).date instanceof Date).toBe(true);
-      expect((await q.rows())[0][0] instanceof Date).toBe(true);
+      expect((await q.all())[0].date).toEqual(expect.any(Date));
+      expect((await q.take()).date).toEqual(expect.any(Date));
+      expect((await q.rows())[0][0]).toEqual(expect.any(Date));
     });
 
     it('should parse columns of joined table', async () => {
@@ -1200,9 +1200,9 @@ describe('select', () => {
         date: User.shape.createdAt,
       });
 
-      expect((await q.all())[0].date instanceof Date).toBe(true);
-      expect((await q.take()).date instanceof Date).toBe(true);
-      expect((await q.rows())[0][0] instanceof Date).toBe(true);
+      expect((await q.all())[0].date).toEqual(expect.any(Date));
+      expect((await q.take()).date).toEqual(expect.any(Date));
+      expect((await q.rows())[0][0]).toEqual(expect.any(Date));
     });
 
     it('should parse raw column', async () => {
@@ -1218,9 +1218,9 @@ describe('select', () => {
         date: expect.any(DateColumn),
       });
 
-      expect((await q.all())[0].date instanceof Date).toBe(true);
-      expect((await q.take()).date instanceof Date).toBe(true);
-      expect((await q.rows())[0][0] instanceof Date).toBe(true);
+      expect((await q.all())[0].date).toEqual(expect.any(Date));
+      expect((await q.take()).date).toEqual(expect.any(Date));
+      expect((await q.rows())[0][0]).toEqual(expect.any(Date));
     });
 
     describe('sub query', () => {
@@ -1235,11 +1235,9 @@ describe('select', () => {
           users: expect.any(JSONTextColumn),
         });
 
-        expect((await q.all())[0].users[0].createdAt instanceof Date).toBe(
-          true,
-        );
-        expect((await q.take()).users[0].createdAt instanceof Date).toBe(true);
-        expect((await q.rows())[0][0][0].createdAt instanceof Date).toBe(true);
+        expect((await q.all())[0].users[0].createdAt).toEqual(expect.any(Date));
+        expect((await q.take()).users[0].createdAt).toEqual(expect.any(Date));
+        expect((await q.rows())[0][0][0].createdAt).toEqual(expect.any(Date));
       });
 
       it('should parse subquery item columns', async () => {
@@ -1253,9 +1251,9 @@ describe('select', () => {
           user: expect.any(JSONTextColumn),
         });
 
-        expect((await q.all())[0].user?.createdAt instanceof Date).toBe(true);
-        expect((await q.take()).user?.createdAt instanceof Date).toBe(true);
-        expect((await q.rows())[0][0]?.createdAt instanceof Date).toBe(true);
+        expect((await q.all())[0].user?.createdAt).toEqual(expect.any(Date));
+        expect((await q.take()).user?.createdAt).toEqual(expect.any(Date));
+        expect((await q.rows())[0][0]?.createdAt).toEqual(expect.any(Date));
       });
 
       it('should parse subquery single value', async () => {
@@ -1285,9 +1283,9 @@ describe('select', () => {
           dates: expect.any(JSONTextColumn),
         });
 
-        expect((await q.all())[0].dates[0] instanceof Date).toBe(true);
-        expect((await q.take()).dates[0] instanceof Date).toBe(true);
-        expect((await q.rows())[0][0][0] instanceof Date).toBe(true);
+        expect((await q.all())[0].dates[0]).toEqual(expect.any(Date));
+        expect((await q.take()).dates[0]).toEqual(expect.any(Date));
+        expect((await q.rows())[0][0][0]).toEqual(expect.any(Date));
       });
 
       it('should cast decimal to text for a sub-selected record', () => {

--- a/packages/pqb/src/query/basic-features/select/select.utils.ts
+++ b/packages/pqb/src/query/basic-features/select/select.utils.ts
@@ -14,7 +14,7 @@ import {
 import {
   addColumnParserToQuery,
   Column,
-  defaultSchemaConfig,
+  internalSchemaConfig,
   JSONTextColumn,
   setColumnData,
   UnknownColumn,
@@ -260,7 +260,7 @@ export const addParserForSelectItem = <T extends PickQuerySelectable>(
             let tempColumns: Set<string> | undefined;
             let renames: RecordString | undefined;
             for (const column of hookSelect.keys()) {
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              //
               const select = hookSelect!.get(column)!;
 
               if (select.as) (renames ??= {})[column] = select.as;
@@ -357,7 +357,7 @@ const collectNestedSelectBatches = (
   );
 
   while (stack.length > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    //
     const item = stack.pop()!;
     const { i } = item;
     if (i === last) {
@@ -537,7 +537,7 @@ export const setParserForSelectedString = (
           q.batchParsers = [...(q.batchParsers || [])];
           cloned = true;
         }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        //
         q.batchParsers!.push(bp);
       }
     }
@@ -661,7 +661,7 @@ export const getShapeFromSelect = (
                   )
                 : UnknownColumn.instance;
             } else {
-              result[key] = new JSONTextColumn(defaultSchemaConfig);
+              result[key] = new JSONTextColumn(internalSchemaConfig);
             }
           }
         }

--- a/packages/pqb/src/query/db.test.ts
+++ b/packages/pqb/src/query/db.test.ts
@@ -3,7 +3,7 @@ import { createDbWithAdapter } from './db';
 import {
   assertType,
   BaseTable,
-  columnTypes,
+  testDefaultColumnTypes,
   createTestDb,
   expectSql,
   sql,
@@ -11,11 +11,12 @@ import {
   testDb,
   testDbOptions,
   useTestDatabase,
+  testDefaultSchemaConfig,
 } from 'test-utils';
 import { raw } from './expressions/raw-sql';
 import {
   DefaultSchemaConfig,
-  defaultSchemaConfig,
+  internalSchemaConfig,
   VirtualColumn,
 } from '../columns';
 import { RecordUnknown } from '../utils';
@@ -68,8 +69,8 @@ describe('db', () => {
     class Virtual extends VirtualColumn<DefaultSchemaConfig> {}
 
     const Table = testDb('table', () => ({
-      id: columnTypes.identity().primaryKey(),
-      virtual: new Virtual(defaultSchemaConfig),
+      id: testDefaultColumnTypes.identity().primaryKey(),
+      virtual: new Virtual(internalSchemaConfig),
     }));
 
     expect(Table.q.selectAllShape).toEqual({
@@ -128,12 +129,13 @@ describe('db', () => {
   });
 
   describe('overriding column types', () => {
-    it('should return date as string by default', async () => {
+    it('should return date as string by default unless it is Bun SQL', async () => {
       await User.create(userData);
 
       const db = createDbWithAdapter({
         adapter: testAdapter,
         snakeCase: true,
+        schemaConfig: () => testDefaultSchemaConfig,
       });
       const table = db(
         'user',

--- a/packages/pqb/src/query/db.ts
+++ b/packages/pqb/src/query/db.ts
@@ -64,7 +64,7 @@ import {
   toArray,
   toSnakeCase,
 } from '../utils';
-import { Adapter, QueryArraysResult } from '../adapters/adapter';
+import { Adapter, QueryResult } from '../adapters/adapter';
 import { NotFoundError, QueryError, QueryErrorName } from './errors';
 import { ColumnsParsers } from './query-columns/query-column-parsers';
 import { DynamicSQLArg, StaticSQLArgs } from './expressions/expression';
@@ -149,7 +149,7 @@ export interface DbOptions<
   SchemaConfig extends ColumnSchemaConfig,
   ColumnTypes,
 > extends DbSharedOptions {
-  schemaConfig?: SchemaConfig;
+  schemaConfig?: () => SchemaConfig;
   // concrete column types or a callback for overriding standard column types
   // this types will be used in tables to define their columns
   columnTypes?:
@@ -635,8 +635,8 @@ export class Db<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   queryArrays<R extends any[] = any[]>(
     ...args: SQLQueryArgs
-  ): Promise<QueryArraysResult<R>> {
-    return performQuery<QueryArraysResult<R>>(this, args, 'arrays');
+  ): Promise<QueryResult<R>> {
+    return performQuery<QueryResult<R>>(this, args, 'arrays');
   }
 }
 
@@ -790,13 +790,20 @@ export const createDbWithAdapter = <
   log,
   logger,
   snakeCase,
-  schemaConfig = defaultSchemaConfig as unknown as SchemaConfig,
-  columnTypes: ctOrFn = makeColumnTypes(schemaConfig) as unknown as ColumnTypes,
+  schemaConfig:
+    schemaConfigFn = defaultSchemaConfig as unknown as () => SchemaConfig,
+  columnTypes,
   schema,
   ...options
 }: DbOptionsWithAdapter<SchemaConfig, ColumnTypes>): DbResult<ColumnTypes> => {
   const { adapter } = options;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
+  const schemaConfig = schemaConfigFn();
+
+  const ctOrFn =
+    columnTypes || (makeColumnTypes(schemaConfig) as unknown as ColumnTypes);
+
+  // oxlint-disable-next-line typescript/no-explicit-any
   const commonOptions: DbTableOptions<any, any, Column.QueryColumns> = {
     log,
     logger,
@@ -855,7 +862,7 @@ export const createDbWithAdapter = <
 
   Object.setPrototypeOf(db, Db.prototype);
 
-  db.sql = _createDbSqlMethod(ct) as typeof db.sql;
+  db.sql = _createDbSqlMethod(ct) as unknown as typeof db.sql;
 
   return db as never;
 };

--- a/packages/pqb/src/query/query-methods.test.ts
+++ b/packages/pqb/src/query/query-methods.test.ts
@@ -192,11 +192,13 @@ describe('queryMethods', () => {
 
   describe('rows', () => {
     it('returns array of rows', async () => {
+      await User.insert(userData);
+
       const { rows: expected } = await testAdapter.arrays(
-        `SELECT ${userColumnsSql} FROM "schema"."user"`,
+        `SELECT "id", "name" FROM "schema"."user"`,
       );
 
-      const received = await User.rows();
+      const received = await User.select('id', 'name').rows();
 
       expect(received).toEqual(expected);
     });

--- a/packages/pqb/src/query/sql/sql.test.ts
+++ b/packages/pqb/src/query/sql/sql.test.ts
@@ -3,7 +3,7 @@ import { BooleanColumn, Column } from '../../columns';
 import { createDbWithAdapter } from '../db';
 import { User, userColumnsSql } from '../../test-utils/pqb.test-utils';
 import { Expression } from '../expressions/expression';
-import { emptyObject } from '../../utils';
+import { emptyObject, noop } from '../../utils';
 import { ToSQLCtx } from './to-sql';
 
 describe('sql', () => {
@@ -12,6 +12,7 @@ describe('sql', () => {
     const db = createDbWithAdapter({
       adapter: testAdapter,
       columnTypes: {
+        setDriverAdapter: noop,
         type: () => type,
       },
     });

--- a/packages/pqb/src/query/then/then.ts
+++ b/packages/pqb/src/query/then/then.ts
@@ -11,6 +11,7 @@ import { getValueKey } from '../basic-features/get/get-value-key';
 import {
   Adapter,
   AfterCommitHook,
+  getDriverErrorCode,
   HackySavepointState,
   QueryResult,
   SqlSessionState,
@@ -350,7 +351,8 @@ const then = async (
     const tempReturnType =
       tableHook?.select ||
       cteHooks?.hasSelect ||
-      (returnType === 'rows' && q.q.batchParsers) ||
+      (returnType === 'rows' &&
+        (q.q.batchParsers || adapter.driverAdapter.noFieldsForArrays)) ||
       checkIfNeedResultAllForMutativeQueriesSelectRelations(sql)
         ? 'all'
         : returnType;
@@ -788,10 +790,11 @@ const then = async (
   } catch (err) {
     let error;
     if (err instanceof adapter.errorClass) {
+      // errno for Bun SQL, code for others
+      const code = getDriverErrorCode(err);
       if (
         // a special not found error thrown by 'not-found'::int
-        'code' in err &&
-        err.code === '22P02' &&
+        code === '22P02' &&
         err.message.endsWith(`"not-found"`)
       ) {
         error = new NotFoundError(q);

--- a/packages/pqb/src/test-utils/pqb.test-utils.ts
+++ b/packages/pqb/src/test-utils/pqb.test-utils.ts
@@ -3,7 +3,11 @@ import { escapeForLog } from '../quote';
 import { expectSql, testDb } from 'test-utils';
 import { RecordUnknown } from '../utils';
 import { quoteTableWithSchema } from '../query/sql/sql';
-import { TransactionAdapterClass } from '../adapters/adapter';
+import {
+  QueryResult,
+  QueryResultRow,
+  TransactionAdapterClass,
+} from '../adapters/adapter';
 
 export type UserRecord = typeof User.outputType;
 export type UserInsert = typeof User.inputType;
@@ -200,15 +204,26 @@ export const emulateReturnNoRowsOnce = (
   method: 'query' | 'arrays' = 'query',
 ) => {
   // emulate the edge case when first query doesn't find the record, and then in CTE it appears
-  const query = TransactionAdapterClass.prototype[method];
-  TransactionAdapterClass.prototype[method] = async function (
-    this: unknown,
-    text: string,
-    values?: unknown[],
-  ) {
-    const result = await query.call(this, text, values);
-    result.rowCount = 0;
-    TransactionAdapterClass.prototype[method] = query as never;
-    return result;
-  } as never;
+  if (method === 'query') {
+    const query = TransactionAdapterClass.prototype.query;
+    TransactionAdapterClass.prototype.query = async function <
+      T extends QueryResultRow = QueryResultRow,
+    >(this: TransactionAdapterClass, text: string, values?: unknown[]) {
+      const result = await query.call(this, text, values);
+      result.rowCount = 0;
+      TransactionAdapterClass.prototype.query = query;
+      return result as QueryResult<T>;
+    };
+  } else {
+    const arrays = TransactionAdapterClass.prototype.arrays;
+    TransactionAdapterClass.prototype.arrays = async function <
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      R extends any[] = any[],
+    >(this: TransactionAdapterClass, text: string, values?: unknown[]) {
+      const result = await arrays.call(this, text, values);
+      result.rowCount = 0;
+      TransactionAdapterClass.prototype.arrays = arrays;
+      return result as QueryResult<R>;
+    };
+  }
 };

--- a/packages/rake-db/package.json
+++ b/packages/rake-db/package.json
@@ -53,13 +53,25 @@
         "default": "./dist/postgres-js.mjs",
         "types": "./dist/postgres-js.d.ts"
       }
+    },
+    "./bun": {
+      "require": {
+        "default": "./dist/bun.js",
+        "types": "./dist/bun.d.ts"
+      },
+      "import": {
+        "default": "./dist/bun.mjs",
+        "types": "./dist/bun.d.ts"
+      }
     }
   },
   "scripts": {
     "db": "tsx app/db-script.ts",
     "prompt": "tsx src/prompt.ts",
-    "test": "jest --watch --verbose false",
+    "test": "jest --watch --reporters default --verbose false",
+    "bun:test": "bun --bun jest --watch --reporters default --verbose false",
     "check": "jest",
+    "bun:check": "bun --bun jest",
     "check:coverage": "jest --coverage --coverageReporters json-summary",
     "types": "tsc",
     "build": "rimraf ./dist/ && rolldown -c ./rolldown.config.mjs",

--- a/packages/rake-db/rolldown.config.mjs
+++ b/packages/rake-db/rolldown.config.mjs
@@ -19,4 +19,7 @@ export default [
   ...rolldownExportFile('src/adapters/postgres-js', 'dist/postgres-js', {
     forbidImportFrom: src,
   }),
+  ...rolldownExportFile('src/adapters/bun', 'dist/bun', {
+    forbidImportFrom: src,
+  }),
 ];

--- a/packages/rake-db/src/adapters/bun.test.ts
+++ b/packages/rake-db/src/adapters/bun.test.ts
@@ -1,0 +1,24 @@
+import { rakeDb } from './bun';
+import { rakeDbCliWithAdapter, setRakeDbCliRunFn } from '../cli/rake-db.cli';
+
+jest.mock('../cli/rake-db.cli', () => ({
+  rakeDbCliWithAdapter: Object.assign(jest.fn(), { run: jest.fn() }),
+  setRakeDbCliRunFn: jest.fn((rakeDb) => {
+    rakeDb.run = jest.fn();
+  }),
+}));
+
+describe('bun', () => {
+  it('should instantiate rakeDb with bun adapter', () => {
+    const config = {
+      migrations: {},
+    };
+    const args = ['arg'];
+
+    rakeDb(config, args);
+
+    expect(rakeDbCliWithAdapter).toHaveBeenCalledWith(config, args);
+
+    expect(setRakeDbCliRunFn).toHaveBeenCalledWith(rakeDb);
+  });
+});

--- a/packages/rake-db/src/adapters/bun.ts
+++ b/packages/rake-db/src/adapters/bun.ts
@@ -1,0 +1,30 @@
+import { BunAdapter, BunAdapterOptions } from 'pqb/bun';
+import { AdapterClass, MaybeArray, toArray } from 'pqb/internal';
+import {
+  rakeDbCliWithAdapter,
+  RakeDbFn,
+  setRakeDbCliRunFn,
+  incrementIntermediateCaller,
+} from 'rake-db';
+
+export const rakeDb = ((inputConfig, args = process.argv.slice(2)) => {
+  if (!('__rakeDbConfig' in inputConfig)) {
+    incrementIntermediateCaller();
+  }
+
+  const rakeDb = rakeDbCliWithAdapter(inputConfig, args);
+  return {
+    ...rakeDb,
+    run(options) {
+      const adapters = toArray(options).map((config) => {
+        return new AdapterClass({
+          driverAdapter: BunAdapter,
+          config,
+        });
+      });
+      return rakeDb.run(adapters);
+    },
+  };
+}) as RakeDbFn<MaybeArray<BunAdapterOptions>>;
+
+setRakeDbCliRunFn(rakeDb);

--- a/packages/rake-db/src/commands/new-migration.test.ts
+++ b/packages/rake-db/src/commands/new-migration.test.ts
@@ -32,7 +32,6 @@ const testGenerate = async (name: string, content: string) => {
 
 describe('newMigration', () => {
   beforeEach(() => {
-    jest.useFakeTimers().setSystemTime(new Date(2000, 0, 1, 0, 0, 0));
     jest.clearAllMocks();
     asMock(fs.readdir).mockReturnValue(Promise.resolve([]));
   });

--- a/packages/rake-db/src/common.test.ts
+++ b/packages/rake-db/src/common.test.ts
@@ -5,10 +5,13 @@ import {
   joinWords,
   quoteWithSchema,
 } from './common';
-import { defaultSchemaConfig } from 'pqb/internal';
 import path from 'path';
-import { asMock } from 'test-utils';
-import { getCallerFilePath, getStackTrace } from 'pqb/internal';
+import { asMock, testDefaultColumnTypes } from 'test-utils';
+import {
+  getCallerFilePath,
+  getStackTrace,
+  defaultSchemaConfig,
+} from 'pqb/internal';
 import { RakeDbConfig } from './config';
 import { makeRakeDbConfig, rakeDbCommands } from './config.public';
 import { processMigrateConfig } from './commands/migrate-or-rollback';
@@ -17,7 +20,7 @@ describe('common', () => {
   describe('processRakeDbConfig', () => {
     it('should return config with defaults', () => {
       const result = makeRakeDbConfig({
-        columnTypes: {},
+        columnTypes: testDefaultColumnTypes,
         basePath: __dirname,
         dbScript: 'dbScript.ts',
         migrationsPath: 'custom-path',
@@ -30,12 +33,12 @@ describe('common', () => {
         __rakeDbConfig: true,
         basePath: __dirname,
         dbScript: 'dbScript.ts',
-        columnTypes: {},
+        columnTypes: testDefaultColumnTypes,
         migrationId: { serial: 4 },
         migrationsPath,
         recurrentPath: path.join(migrationsPath, 'recurrent'),
         migrationsTable: 'schemaMigrations',
-        schemaConfig: defaultSchemaConfig,
+        schemaConfig: expect.any(Object),
         snakeCase: false,
         import: expect.any(Function),
         log: true,

--- a/packages/rake-db/src/config.public.ts
+++ b/packages/rake-db/src/config.public.ts
@@ -238,14 +238,14 @@ export const makeRakeDbConfig = <ColumnTypes>(
 
   if ('baseTable' in config && config.baseTable) {
     const { types } = config.baseTable.prototype;
-    result.columnTypes = types || defaultColumnTypes(defaultSchemaConfig);
+    result.columnTypes = types || defaultColumnTypes(defaultSchemaConfig());
   } else {
     const ct = 'columnTypes' in config && config.columnTypes;
     result.columnTypes = ((typeof ct === 'function'
       ? (ct as (t: DefaultColumnTypes<ColumnSchemaConfig>) => unknown)(
-          defaultColumnTypes(defaultSchemaConfig),
+          defaultColumnTypes(defaultSchemaConfig()),
         )
-      : ct) || defaultColumnTypes(defaultSchemaConfig)) as ColumnTypes;
+      : ct) || defaultColumnTypes(defaultSchemaConfig())) as ColumnTypes;
   }
 
   if (config.migrationId === 'serial') {

--- a/packages/rake-db/src/config.ts
+++ b/packages/rake-db/src/config.ts
@@ -3,8 +3,8 @@ import {
   ColumnSchemaConfig,
   DbResult,
   DefaultColumnTypes,
-  DefaultSchemaConfig,
   defaultSchemaConfig,
+  DefaultSchemaConfig,
   MaybePromise,
   NoPrimaryKeyOption,
   QueryLogOptions,
@@ -167,7 +167,7 @@ export interface RakeDbConfig<ColumnTypes = unknown> extends QueryLogOptions {
 
 export const rakeDbConfigDefaults = {
   ...migrateConfigDefaults,
-  schemaConfig: defaultSchemaConfig,
+  schemaConfig: defaultSchemaConfig(),
   snakeCase: false,
   commands: {},
   log: true,

--- a/packages/rake-db/src/generate/ast-to-generate-items.test.ts
+++ b/packages/rake-db/src/generate/ast-to-generate-items.test.ts
@@ -1,10 +1,10 @@
 import { RakeDbAst } from '../ast';
 import { astToGenerateItem, GenerateItem } from './ast-to-generate-items';
-import { defaultSchemaConfig, makeColumnTypes } from 'pqb/internal';
 import { testConfig } from '../rake-db.test-utils';
 import { dbStructureMockFactory } from './db-structure.mockFactory';
+import { testDefaultColumnTypes } from 'test-utils';
 
-const t = makeColumnTypes(defaultSchemaConfig);
+const t = testDefaultColumnTypes;
 
 const tableAst: RakeDbAst.Table = {
   type: 'table',

--- a/packages/rake-db/src/generate/ast-to-migration.test.ts
+++ b/packages/rake-db/src/generate/ast-to-migration.test.ts
@@ -1,18 +1,11 @@
 import { astToMigration } from './ast-to-migration';
-import {
-  makeColumnTypes,
-  raw,
-  defaultSchemaConfig,
-  TableData,
-} from 'pqb/internal';
+import { raw, TableData } from 'pqb/internal';
 import { RakeDbAst } from '../ast';
 import { makeRakeDbConfig } from '../config.public';
 import { dbStructureMockFactory } from './db-structure.mockFactory';
+import { testDefaultColumnTypes } from 'test-utils';
 
-const columnTypes = makeColumnTypes(defaultSchemaConfig);
-const t = {
-  ...columnTypes,
-};
+const t = testDefaultColumnTypes;
 
 const config = makeRakeDbConfig({
   migrationsPath: 'migrations',

--- a/packages/rake-db/src/generate/db-structure.ts
+++ b/packages/rake-db/src/generate/db-structure.ts
@@ -561,15 +561,21 @@ const constraintsSql = `SELECT
         ft.relname,
         'columns',
         (
-          SELECT json_agg(ccu.column_name)
+          SELECT json_agg(ccu.column_name ORDER BY a.attnum)
           FROM information_schema.key_column_usage ccu
+          JOIN pg_catalog.pg_attribute a
+            ON a.attrelid = c.conrelid
+           AND a.attname = ccu.column_name
           WHERE ccu.constraint_name = c.conname
             AND ccu.table_schema = cs.nspname
         ),
         'foreignColumns',
         (
-          SELECT json_agg(ccu.column_name)
+          SELECT json_agg(ccu.column_name ORDER BY a.attnum)
           FROM information_schema.constraint_column_usage ccu
+          JOIN pg_catalog.pg_attribute a
+            ON a.attrelid = c.confrelid
+           AND a.attname = ccu.column_name
           WHERE ccu.constraint_name = c.conname
             AND ccu.table_schema = cs.nspname
         ),
@@ -986,7 +992,6 @@ export async function introspectDbSchema(
 
   const data = await db.query<RawIntrospectedStructure>(sql(version, params));
   const raw = data.rows[0];
-  console.log(raw.constraints);
 
   for (const domain of raw.domains) {
     domain.checks = domain.checks?.filter((check) => check);

--- a/packages/rake-db/src/generate/db-structure.ts
+++ b/packages/rake-db/src/generate/db-structure.ts
@@ -543,8 +543,11 @@ const constraintsSql = `SELECT
   t.relname AS "tableName",
   c.conname AS "name",
   (
-    SELECT json_agg(ccu.column_name)
+    SELECT json_agg(ccu.column_name ORDER BY a.attnum)
     FROM information_schema.constraint_column_usage ccu
+    JOIN pg_catalog.pg_attribute a
+      ON a.attrelid = c.conrelid
+     AND a.attname = ccu.column_name
     WHERE contype = 'p'
       AND ccu.constraint_name = c.conname
       AND ccu.table_schema = s.nspname
@@ -983,6 +986,7 @@ export async function introspectDbSchema(
 
   const data = await db.query<RawIntrospectedStructure>(sql(version, params));
   const raw = data.rows[0];
+  console.log(raw.constraints);
 
   for (const domain of raw.domains) {
     domain.checks = domain.checks?.filter((check) => check);

--- a/packages/rake-db/src/generate/pull.test.ts
+++ b/packages/rake-db/src/generate/pull.test.ts
@@ -3,13 +3,11 @@ import { pullDbStructure } from './pull';
 import { makeFileVersion, writeMigrationFile } from '../commands/new-migration';
 import { saveMigratedVersion } from '../migration/manage-migrated-versions';
 import {
-  makeColumnTypes,
   DefaultColumnTypes,
-  defaultSchemaConfig,
   DefaultSchemaConfig,
   AdapterClass,
 } from 'pqb/internal';
-import { asMock, TestAdapter } from 'test-utils';
+import { asMock, TestAdapter, testDefaultColumnTypes } from 'test-utils';
 import { makeRakeDbConfig } from '../config.public';
 import { RakeDbConfig } from '../config';
 import { dbStructureMockFactory } from './db-structure.mockFactory';
@@ -61,7 +59,7 @@ class BaseTable {
   types!: DefaultColumnTypes<DefaultSchemaConfig>;
   snakeCase?: boolean;
 }
-BaseTable.prototype.types = makeColumnTypes(defaultSchemaConfig);
+BaseTable.prototype.types = testDefaultColumnTypes;
 
 const makeConfig = (config: Partial<RakeDbConfig> = {}) =>
   makeRakeDbConfig({

--- a/packages/rake-db/src/generate/structure-to-ast.test.ts
+++ b/packages/rake-db/src/generate/structure-to-ast.test.ts
@@ -15,7 +15,6 @@ import {
   TimestampTZColumn,
   VarCharColumn,
   DefaultSchemaConfig,
-  defaultSchemaConfig,
   RawSql,
   isRawSQL,
   TemplateLiteralArgs,
@@ -24,7 +23,7 @@ import {
 import { structureToAst, StructureToAstCtx } from './structure-to-ast';
 import { RakeDbAst } from '../ast';
 import { getIndexName, getExcludeName } from '../migration/migration.utils';
-import { asMock, TestAdapter } from 'test-utils';
+import { asMock, TestAdapter, testDefaultSchemaConfig } from 'test-utils';
 import { dbStructureMockFactory } from './db-structure.mockFactory';
 import { testConfig } from '../rake-db.test-utils';
 
@@ -42,8 +41,8 @@ const ctx: StructureToAstCtx = {
   unsupportedTypes: {},
   snakeCase: false,
   currentSchema: 'custom',
-  columnSchemaConfig: defaultSchemaConfig,
-  columnsByType: makeColumnsByType(defaultSchemaConfig),
+  columnSchemaConfig: testDefaultSchemaConfig,
+  columnsByType: makeColumnsByType(testDefaultSchemaConfig),
 };
 
 const structure = {

--- a/packages/rake-db/src/migration/change-table.ts
+++ b/packages/rake-db/src/migration/change-table.ts
@@ -55,7 +55,7 @@ import {
   nameColumnChecks,
   primaryKeyToSql,
 } from './migration.utils';
-import { TableMethods, tableMethods } from './table-methods';
+import { TableMethods } from './table-methods';
 import { TableQuery } from './create-table';
 
 interface ChangeTableData {
@@ -492,7 +492,8 @@ const setName = (
   }
 };
 
-interface TableChangeMethods extends TableMethods, TableDataMethods<string> {
+export interface TableChangeMethods
+  extends TableMethods, TableDataMethods<string> {
   name(name: string): TableChangeMethods;
   add: Add;
   drop: Add;
@@ -826,7 +827,9 @@ function exclude(
   };
 }
 
-const tableChangeMethods: TableChangeMethods = {
+export const makeTableChangeMethods = (
+  tableMethods: TableMethods,
+): TableChangeMethods => ({
   ...tableMethods,
   ...tableDataMethods,
   name(name) {
@@ -898,7 +901,7 @@ const tableChangeMethods: TableChangeMethods = {
   rename(name) {
     return { type: 'rename', name };
   },
-};
+});
 
 export type TableChanger<CT> = MigrationColumnTypes<CT> & TableChangeMethods;
 
@@ -913,6 +916,7 @@ export type TableChangeData = Record<
 
 export const changeTable = async <CT>(
   migration: Migration<CT>,
+  tableChangeMethods: TableChangeMethods,
   up: boolean,
   tableName: string,
   options: ChangeTableOptions,

--- a/packages/rake-db/src/migration/change.ts
+++ b/packages/rake-db/src/migration/change.ts
@@ -1,10 +1,5 @@
 import { DbMigration } from './migration';
-import {
-  DefaultColumnTypes,
-  defaultSchemaConfig,
-  DefaultSchemaConfig,
-  makeColumnTypes,
-} from 'pqb/internal';
+import { RakeDbConfig } from '../config';
 
 export interface RakeDbChangeFnConfig {
   columnTypes: unknown;
@@ -19,17 +14,11 @@ export interface MigrationChangeFn<ColumnTypes> {
   (fn: ChangeCallback<ColumnTypes>): MigrationChange;
 }
 
-export const createMigrationChangeFn = <
-  ColumnTypes = DefaultColumnTypes<DefaultSchemaConfig>,
->(config: {
-  columnTypes?: ColumnTypes;
-}): MigrationChangeFn<ColumnTypes> => {
-  const conf = config.columnTypes
-    ? (config as RakeDbChangeFnConfig)
-    : { columnTypes: makeColumnTypes(defaultSchemaConfig) };
-
+export const createMigrationChangeFn = <ColumnTypes>(
+  config: RakeDbConfig<ColumnTypes>,
+): MigrationChangeFn<ColumnTypes> => {
   return (fn) => {
-    const change: MigrationChange = { fn: fn as never, config: conf };
+    const change: MigrationChange = { fn: fn as never, config };
     pushChange(change);
     return change;
   };

--- a/packages/rake-db/src/migration/create-table.test.ts
+++ b/packages/rake-db/src/migration/create-table.test.ts
@@ -1,11 +1,7 @@
 import { expectSql, getDb, resetDb, toLine } from '../rake-db.test-utils';
-import {
-  setDefaultLanguage,
-  makeColumnTypes,
-  defaultSchemaConfig,
-} from 'pqb/internal';
+import { setDefaultLanguage } from 'pqb/internal';
 import { Db } from 'pqb';
-import { asMock, sql } from 'test-utils';
+import { asMock, sql, testDefaultColumnTypes } from 'test-utils';
 
 const db = getDb();
 
@@ -865,7 +861,7 @@ describe('create and drop table', () => {
       setDefaultLanguage('english');
     });
 
-    const t = makeColumnTypes(defaultSchemaConfig);
+    const t = testDefaultColumnTypes;
     const columns = {
       iD: t.identity().primaryKey(),
       titLe: t.text(),

--- a/packages/rake-db/src/migration/create-table.ts
+++ b/packages/rake-db/src/migration/create-table.ts
@@ -10,7 +10,7 @@ import {
   TableDataItem,
   emptyObject,
   MaybeArray,
-  QueryArraysResult,
+  QueryResult,
   RecordUnknown,
   QuerySchema,
 } from 'pqb/internal';
@@ -40,14 +40,14 @@ import {
   quoteWithSchema,
 } from '../common';
 import { RakeDbAst } from '../ast';
-import { tableMethods } from './table-methods';
+import { TableMethods } from './table-methods';
 import { NoPrimaryKey } from '../errors';
 import { Db } from 'pqb';
 
 export interface TableQuery {
   text: string;
   values?: unknown[];
-  then?(result: QueryArraysResult): void;
+  then?(result: QueryResult): void;
 }
 
 export interface CreateTableResult<
@@ -63,6 +63,7 @@ export const createTable = async <
   Shape extends ColumnsShape,
 >(
   migration: Migration<CT>,
+  tableMethods: TableMethods,
   up: boolean,
   tableName: Table,
   first?: TableOptions | ColumnsShapeCallback<CT, Shape>,

--- a/packages/rake-db/src/migration/manage-migrated-versions.test.ts
+++ b/packages/rake-db/src/migration/manage-migrated-versions.test.ts
@@ -159,6 +159,7 @@ describe('manageMigratedVersions', () => {
   describe('getMigratedVersionsMap', () => {
     const adapter = {
       isInTransaction: () => false,
+      query: jest.fn(),
       arrays: jest.fn(),
       getSchema() {},
     };
@@ -169,7 +170,7 @@ describe('manageMigratedVersions', () => {
       getMigratedVersionsMap(ctx, adapter as unknown as Adapter, testConfig);
 
     it('should throw NoMigrationsTableError if no migration table', async () => {
-      adapter.arrays.mockRejectedValueOnce(
+      adapter.query.mockRejectedValueOnce(
         Object.assign(new Error(), { code: '42P01' }),
       );
 
@@ -179,46 +180,9 @@ describe('manageMigratedVersions', () => {
     it('should rethrow unknown errors', async () => {
       const err = new Error();
 
-      adapter.arrays.mockRejectedValueOnce(err);
+      adapter.query.mockRejectedValueOnce(err);
 
       await expect(act()).rejects.toThrow(err);
-    });
-
-    it('should add the name column and fill it from migrations if the column does not exist', async () => {
-      const rows = [['123'], ['124']];
-
-      adapter.arrays.mockResolvedValueOnce({
-        fields: [{}],
-        rows,
-      });
-
-      ctx.migrationsPromise = Promise.resolve({
-        migrations: [
-          { path: '/path/to/123_a', version: '123', load: async () => {} },
-          { path: '/path/to/124_b', version: '124', load: async () => {} },
-        ],
-      });
-
-      await act();
-
-      expect(adapter.arrays.mock.calls).toEqual([
-        ['SELECT * FROM "schemaMigrations" ORDER BY version'],
-        ['ALTER TABLE "schemaMigrations" ADD COLUMN name TEXT'],
-        [
-          'UPDATE "schemaMigrations" SET name = $2 WHERE version = $1',
-          ['123', 'a'],
-        ],
-        [
-          'UPDATE "schemaMigrations" SET name = $2 WHERE version = $1',
-          ['124', 'b'],
-        ],
-        ['ALTER TABLE "schemaMigrations" ALTER COLUMN name SET NOT NULL'],
-      ]);
-
-      expect(rows).toEqual([
-        ['123', 'a'],
-        ['124', 'b'],
-      ]);
     });
   });
 });

--- a/packages/rake-db/src/migration/manage-migrated-versions.ts
+++ b/packages/rake-db/src/migration/manage-migrated-versions.ts
@@ -2,19 +2,14 @@ import { RakeDbCtx } from '../common';
 import { SilentQueries } from './migration';
 import {
   Adapter,
+  getDriverErrorCode,
   QueryLogger,
   RecordOptionalString,
   RecordString,
-  RecordUnknown,
   TransactionAdapter,
 } from 'pqb/internal';
 import { RakeDbConfig, RakeDbRenameMigrations } from '../config';
-import path from 'node:path';
-import {
-  getDigitsPrefix,
-  getMigrations,
-  getMigrationVersion,
-} from './migrations-set';
+import { getMigrationVersion } from './migrations-set';
 import {
   renameMigrationVersionsInDb,
   RenameMigrationVersionsValue,
@@ -100,7 +95,7 @@ export type RakeDbAppliedVersions = {
 export class NoMigrationsTableError extends Error {}
 
 export const getMigratedVersionsMap = async (
-  ctx: RakeDbCtx,
+  _ctx: RakeDbCtx,
   adapter: Adapter | TransactionAdapter,
   config: Pick<
     MigrateConfigInternal,
@@ -116,7 +111,9 @@ export const getMigratedVersionsMap = async (
   const table = migrationsSchemaTableSql(adapter, config);
 
   const queryVersion = () =>
-    adapter.arrays<[string, string]>(`SELECT * FROM ${table} ORDER BY version`);
+    adapter.query<{ version: string; name: string }>(
+      `SELECT * FROM ${table} ORDER BY version`,
+    );
 
   let result;
   try {
@@ -126,55 +123,22 @@ export const getMigratedVersionsMap = async (
       result = await queryVersion();
     }
   } catch (err) {
-    if ((err as RecordUnknown).code === '42P01') {
+    if (err && typeof err === 'object' && getDriverErrorCode(err) === '42P01') {
       throw new NoMigrationsTableError();
     } else {
       throw err;
     }
   }
 
-  if (!result.fields[1]) {
-    const { migrations } = await getMigrations(ctx, config, true);
-
-    const map: RecordString = {};
-    for (const item of migrations) {
-      const name = path.basename(item.path);
-      map[item.version] = name.slice(getDigitsPrefix(name).length + 1);
-    }
-
-    for (const row of result.rows) {
-      const [version] = row;
-      const name = map[version];
-      if (!name) {
-        throw new Error(
-          `Migration for version ${version} is stored in db but is not found among available migrations`,
-        );
-      }
-
-      row[1] = name;
-    }
-
-    await adapter.arrays(`ALTER TABLE ${table} ADD COLUMN name TEXT`);
-
-    await Promise.all(
-      result.rows.map(([version, name]) =>
-        adapter.arrays(`UPDATE ${table} SET name = $2 WHERE version = $1`, [
-          version,
-          name,
-        ]),
-      ),
-    );
-
-    await adapter.arrays(`ALTER TABLE ${table} ALTER COLUMN name SET NOT NULL`);
-  }
-
-  let versions = Object.fromEntries(result.rows);
+  let versions = Object.fromEntries(
+    result.rows.map(({ version, name }) => [version, name]),
+  );
 
   if (renameTo) {
     versions = await renameMigrations(config, adapter, versions, renameTo);
   }
 
-  return { map: versions, sequence: result.rows.map((row) => +row[0]) };
+  return { map: versions, sequence: result.rows.map((row) => +row.version) };
 };
 
 async function renameMigrations(

--- a/packages/rake-db/src/migration/migration.test.ts
+++ b/packages/rake-db/src/migration/migration.test.ts
@@ -7,7 +7,7 @@ import {
   toLine,
 } from '../rake-db.test-utils';
 import { raw, singleQuote } from 'pqb/internal';
-import { asMock, sql, testAdapter } from 'test-utils';
+import { asMock, sql, testAdapter, testDefaultColumnTypes } from 'test-utils';
 import { createMigrationInterface } from './migration';
 
 const db = getDb();
@@ -24,7 +24,7 @@ describe('migration', () => {
 
     it('should add SQL to the Postgres error class', async () => {
       const db = createMigrationInterface(testAdapter, true, {}).getDb(
-        undefined,
+        testDefaultColumnTypes,
       );
 
       const err = await db.query`invalid`.catch((err) => err);

--- a/packages/rake-db/src/migration/migration.ts
+++ b/packages/rake-db/src/migration/migration.ts
@@ -23,9 +23,16 @@ import {
   toSnakeCase,
   DefaultColumnTypes,
   DefaultSchemaConfig,
+  defaultSchemaConfig,
 } from 'pqb/internal';
 import { createTable, CreateTableResult } from './create-table';
-import { changeTable, TableChangeData, TableChanger } from './change-table';
+import {
+  changeTable,
+  makeTableChangeMethods,
+  TableChangeData,
+  TableChangeMethods,
+  TableChanger,
+} from './change-table';
 import {
   getSchemaAndTableFromName,
   quoteNameFromString,
@@ -56,6 +63,7 @@ import {
   changePolicy as changePolicyRls,
 } from './rls';
 import { changeGrant, GrantMigrationArg } from './grant';
+import { makeTableMethods, TableMethods } from './table-methods';
 
 // Drop mode to use when dropping various database entities.
 export type DropMode = 'CASCADE' | 'RESTRICT';
@@ -211,6 +219,25 @@ export class Migration<CT = unknown> {
   // They are pulled from a `baseTable` or a `columnTypes` option of the `rakeDb` config.
   public columnTypes!: CT;
 
+  private tableMethods: TableMethods | undefined;
+  private getTableMethods() {
+    let { tableMethods } = this;
+    if (!tableMethods) {
+      const schemaConfig = defaultSchemaConfig();
+      tableMethods = makeTableMethods(schemaConfig);
+    }
+    return tableMethods;
+  }
+
+  private tableChangeMethods: TableChangeMethods | undefined;
+  private getTableChangeMethods() {
+    let { tableChangeMethods } = this;
+    if (!tableChangeMethods) {
+      tableChangeMethods = makeTableChangeMethods(this.getTableMethods());
+    }
+    return tableChangeMethods;
+  }
+
   /**
    * `createTable` accepts a string for a table name, optional options, and a callback to specify columns.
    *
@@ -316,7 +343,15 @@ export class Migration<CT = unknown> {
     third?: any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
-    return createTable(this, this.up, tableName, first, second, third);
+    return createTable(
+      this,
+      this.getTableMethods(),
+      this.up,
+      tableName,
+      first,
+      second,
+      third,
+    );
   }
 
   /**
@@ -355,7 +390,15 @@ export class Migration<CT = unknown> {
     third?: any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
-    return createTable(this, !this.up, tableName, first, second, third);
+    return createTable(
+      this,
+      this.getTableMethods(),
+      !this.up,
+      tableName,
+      first,
+      second,
+      third,
+    );
   }
 
   /**
@@ -404,7 +447,14 @@ export class Migration<CT = unknown> {
     const [fn, options] =
       typeof cbOrOptions === 'function' ? [cbOrOptions, {}] : [cb, cbOrOptions];
 
-    return changeTable(this, this.up, tableName, options, fn);
+    return changeTable(
+      this,
+      this.getTableChangeMethods(),
+      this.up,
+      tableName,
+      options,
+      fn,
+    );
   }
 
   /**
@@ -478,7 +528,14 @@ export class Migration<CT = unknown> {
     columnName: string,
     fn: (t: MigrationColumnTypes<CT>) => Column,
   ): Promise<void> {
-    return addColumn(this, this.up, tableName, columnName, fn);
+    return addColumn(
+      this,
+      this.getTableChangeMethods(),
+      this.up,
+      tableName,
+      columnName,
+      fn,
+    );
   }
 
   /**
@@ -493,7 +550,14 @@ export class Migration<CT = unknown> {
     columnName: string,
     fn: (t: MigrationColumnTypes<CT>) => Column,
   ): Promise<void> {
-    return addColumn(this, !this.up, tableName, columnName, fn);
+    return addColumn(
+      this,
+      this.getTableChangeMethods(),
+      !this.up,
+      tableName,
+      columnName,
+      fn,
+    );
   }
 
   /**
@@ -526,7 +590,14 @@ export class Migration<CT = unknown> {
     columns: (string | TableData.Index.ColumnOrExpressionOptions)[],
     ...args: [options?: TableData.Index.OptionsArg]
   ): Promise<void> {
-    return addIndex(this, this.up, tableName, columns, ...args);
+    return addIndex(
+      this,
+      this.getTableChangeMethods(),
+      this.up,
+      tableName,
+      columns,
+      ...args,
+    );
   }
 
   /**
@@ -541,7 +612,14 @@ export class Migration<CT = unknown> {
     columns: (string | TableData.Index.ColumnOrExpressionOptions)[],
     ...args: [options?: TableData.Index.OptionsArg]
   ): Promise<void> {
-    return addIndex(this, !this.up, tableName, columns, ...args);
+    return addIndex(
+      this,
+      this.getTableChangeMethods(),
+      !this.up,
+      tableName,
+      columns,
+      ...args,
+    );
   }
 
   /**
@@ -616,6 +694,7 @@ export class Migration<CT = unknown> {
   ): Promise<void> {
     return addForeignKey(
       this,
+      this.getTableChangeMethods(),
       this.up,
       tableName,
       columns,
@@ -643,6 +722,7 @@ export class Migration<CT = unknown> {
   ): Promise<void> {
     return addForeignKey(
       this,
+      this.getTableChangeMethods(),
       !this.up,
       tableName,
       columns,
@@ -679,7 +759,14 @@ export class Migration<CT = unknown> {
     columns: [string, ...string[]],
     name?: string,
   ): Promise<void> {
-    return addPrimaryKey(this, this.up, tableName, columns, name);
+    return addPrimaryKey(
+      this,
+      this.getTableChangeMethods(),
+      this.up,
+      tableName,
+      columns,
+      name,
+    );
   }
 
   /**
@@ -694,7 +781,14 @@ export class Migration<CT = unknown> {
     columns: [string, ...string[]],
     name?: string,
   ): Promise<void> {
-    return addPrimaryKey(this, !this.up, tableName, columns, name);
+    return addPrimaryKey(
+      this,
+      this.getTableChangeMethods(),
+      !this.up,
+      tableName,
+      columns,
+      name,
+    );
   }
 
   /**
@@ -712,7 +806,13 @@ export class Migration<CT = unknown> {
    * @param check - raw SQL for the check
    */
   addCheck(tableName: string, check: RawSqlBase): Promise<void> {
-    return addCheck(this, this.up, tableName, check);
+    return addCheck(
+      this,
+      this.getTableChangeMethods(),
+      this.up,
+      tableName,
+      check,
+    );
   }
 
   /**
@@ -722,7 +822,13 @@ export class Migration<CT = unknown> {
    * @param check - raw SQL for the check
    */
   dropCheck(tableName: string, check: RawSqlBase): Promise<void> {
-    return addCheck(this, !this.up, tableName, check);
+    return addCheck(
+      this,
+      this.getTableChangeMethods(),
+      !this.up,
+      tableName,
+      check,
+    );
   }
 
   /**
@@ -1559,7 +1665,6 @@ const wrapWithEnhancingError = async <Result>(
       err.message += `\nSQL: ${text}${
         values ? `\nVariables: ${JSON.stringify(values)}` : ''
       }`;
-      throw new (err.constructor as { new (err: unknown): unknown })(err);
     }
     throw err;
   }
@@ -1605,12 +1710,13 @@ const wrapWithLog = async <Result>(
  */
 const addColumn = <CT>(
   migration: Migration<CT>,
+  tableChangeMethods: TableChangeMethods,
   up: boolean,
   tableName: string,
   columnName: string,
   fn: (t: MigrationColumnTypes<CT>) => Column,
 ): Promise<void> => {
-  return changeTable(migration, up, tableName, {}, (t) => ({
+  return changeTable(migration, tableChangeMethods, up, tableName, {}, (t) => ({
     [columnName]: t.add(fn(t)),
   }));
 };
@@ -1620,12 +1726,13 @@ const addColumn = <CT>(
  */
 const addIndex = (
   migration: Migration,
+  tableChangeMethods: TableChangeMethods,
   up: boolean,
   tableName: string,
   columns: (string | TableData.Index.ColumnOrExpressionOptions)[],
   ...args: [options?: TableData.Index.OptionsArg]
 ): Promise<void> => {
-  return changeTable(migration, up, tableName, {}, (t) => ({
+  return changeTable(migration, tableChangeMethods, up, tableName, {}, (t) => ({
     ...t.add(t.index(columns, ...args)),
   }));
 };
@@ -1635,6 +1742,7 @@ const addIndex = (
  */
 const addForeignKey = (
   migration: Migration,
+  tableChangeMethods: TableChangeMethods,
   up: boolean,
   tableName: string,
   columns: [string, ...string[]],
@@ -1642,7 +1750,7 @@ const addForeignKey = (
   foreignColumns: [string, ...string[]],
   options?: TableData.References.Options,
 ): Promise<void> => {
-  return changeTable(migration, up, tableName, {}, (t) => ({
+  return changeTable(migration, tableChangeMethods, up, tableName, {}, (t) => ({
     ...t.add(t.foreignKey(columns, foreignTable, foreignColumns, options)),
   }));
 };
@@ -1652,12 +1760,13 @@ const addForeignKey = (
  */
 const addPrimaryKey = (
   migration: Migration,
+  tableChangeMethods: TableChangeMethods,
   up: boolean,
   tableName: string,
   columns: [string, ...string[]],
   name?: string,
 ): Promise<void> => {
-  return changeTable(migration, up, tableName, {}, (t) => ({
+  return changeTable(migration, tableChangeMethods, up, tableName, {}, (t) => ({
     ...t.add(t.primaryKey(columns, name)),
   }));
 };
@@ -1667,11 +1776,12 @@ const addPrimaryKey = (
  */
 const addCheck = (
   migration: Migration,
+  tableChangeMethods: TableChangeMethods,
   up: boolean,
   tableName: string,
   check: RawSqlBase,
 ): Promise<void> => {
-  return changeTable(migration, up, tableName, {}, (t) => ({
+  return changeTable(migration, tableChangeMethods, up, tableName, {}, (t) => ({
     ...t.add(t.check(check)),
   }));
 };

--- a/packages/rake-db/src/migration/migration.utils.ts
+++ b/packages/rake-db/src/migration/migration.utils.ts
@@ -128,6 +128,13 @@ export const columnToSql = (
   return line.join(' ');
 };
 
+const getDefaultEncode = (column: Column.Pick.Data) => {
+  return (
+    column.data.encode ??
+    ((column as Column).dataType === 'jsonb' ? JSON.stringify : undefined)
+  );
+};
+
 export const encodeColumnDefault = (
   def: unknown,
   values: unknown[],
@@ -137,16 +144,20 @@ export const encodeColumnDefault = (
     if (isRawSQL(def)) {
       return `(${def.toSQL({ values })})`;
     } else {
+      // oxlint-disable-next-line typescript/no-explicit-any
+      let encode: ((input: any) => unknown) | undefined;
+
       return escapeForMigration(
         column instanceof ArrayColumn && Array.isArray(def)
           ? '{' +
-              (column.data.item.data.encode
-                ? def.map((x) => column.data.item.data.encode(x))
+              // oxlint-disable-next-line no-cond-assign
+              ((encode = getDefaultEncode(column.data.item))
+                ? def.map((x) => encode!(x))
                 : def
               ).join(',') +
               '}'
-          : column?.data.encode
-            ? column.data.encode(def)
+          : column && (encode = getDefaultEncode(column))
+            ? encode(def)
             : def,
       );
     }

--- a/packages/rake-db/src/migration/table-methods.ts
+++ b/packages/rake-db/src/migration/table-methods.ts
@@ -1,23 +1,25 @@
 import {
   EnumColumn,
-  defaultSchemaConfig,
-  DefaultSchemaConfig,
+  ColumnTypeSchemaArg,
+  ColumnSchemaConfig,
 } from 'pqb/internal';
 
 export interface TableMethods {
   enum(
     name: string,
-  ): EnumColumn<DefaultSchemaConfig, undefined, [string, ...string[]]>;
+  ): EnumColumn<ColumnTypeSchemaArg, undefined, [string, ...string[]]>;
 }
 
-export const tableMethods = {
+export const makeTableMethods = (
+  schemaConfig: ColumnSchemaConfig,
+): TableMethods => ({
   enum(name: string) {
     // empty array will be filled during the migration by querying db
     return new EnumColumn(
-      defaultSchemaConfig,
+      schemaConfig,
       name,
       [] as unknown as [string, ...string[]],
       undefined,
     );
   },
-};
+});

--- a/packages/rake-db/src/rake-db.test-utils.ts
+++ b/packages/rake-db/src/rake-db.test-utils.ts
@@ -1,9 +1,7 @@
 import { createMigrationInterface, DbMigration } from './migration/migration';
 import {
   DefaultColumnTypes,
-  makeColumnTypes,
   DefaultSchemaConfig,
-  defaultSchemaConfig,
   Adapter,
   MaybeArray,
   noop,
@@ -12,6 +10,7 @@ import {
 } from 'pqb/internal';
 import { join } from 'node:path';
 import { rakeDbConfigDefaults, RakeDbConfig } from './config';
+import { testDefaultColumnTypes } from 'test-utils';
 
 let db: DbMigration<DefaultColumnTypes<DefaultSchemaConfig>> | undefined;
 
@@ -25,7 +24,7 @@ export const testConfig: RakeDbConfig & {
   transaction: 'single',
   basePath: __dirname,
   dbScript: 'dbScript.ts',
-  columnTypes: makeColumnTypes(defaultSchemaConfig),
+  columnTypes: testDefaultColumnTypes,
   log: false,
   logger: {
     log: jest.fn(),

--- a/packages/schemaConfigs/valibot/src/valibot.test.ts
+++ b/packages/schemaConfigs/valibot/src/valibot.test.ts
@@ -30,7 +30,8 @@ import {
   LiteralSchema,
 } from 'valibot';
 
-const t = makeColumnTypes(valibotSchemaConfig);
+const schemaConfig = valibotSchemaConfig();
+const t = makeColumnTypes(schemaConfig);
 
 type TypeBase = {
   inputSchema: BaseSchema;
@@ -104,11 +105,11 @@ describe('valibot schema config', () => {
 
     const klass = {
       prototype: { columns },
-      inputSchema: valibotSchemaConfig.inputSchema,
-      outputSchema: valibotSchemaConfig.outputSchema,
-      querySchema: valibotSchemaConfig.querySchema,
-      pkeySchema: valibotSchemaConfig.pkeySchema,
-      createSchema: valibotSchemaConfig.createSchema,
+      inputSchema: schemaConfig.inputSchema,
+      outputSchema: schemaConfig.outputSchema,
+      querySchema: schemaConfig.querySchema,
+      pkeySchema: schemaConfig.pkeySchema,
+      createSchema: schemaConfig.createSchema,
     };
 
     const type = {
@@ -142,11 +143,11 @@ describe('valibot schema config', () => {
 
       const klass = {
         prototype: { columns },
-        inputSchema: valibotSchemaConfig.inputSchema,
-        outputSchema: valibotSchemaConfig.outputSchema,
-        querySchema: valibotSchemaConfig.querySchema,
-        pkeySchema: valibotSchemaConfig.pkeySchema,
-        createSchema: valibotSchemaConfig.createSchema,
+        inputSchema: schemaConfig.inputSchema,
+        outputSchema: schemaConfig.outputSchema,
+        querySchema: schemaConfig.querySchema,
+        pkeySchema: schemaConfig.pkeySchema,
+        createSchema: schemaConfig.createSchema,
       };
 
       const schema = klass.querySchema();
@@ -179,10 +180,10 @@ describe('valibot schema config', () => {
 
       const klass = {
         prototype: { columns },
-        inputSchema: valibotSchemaConfig.inputSchema,
-        querySchema: valibotSchemaConfig.outputSchema,
-        pkeySchema: valibotSchemaConfig.pkeySchema,
-        createSchema: valibotSchemaConfig.createSchema,
+        inputSchema: schemaConfig.inputSchema,
+        querySchema: schemaConfig.outputSchema,
+        pkeySchema: schemaConfig.pkeySchema,
+        createSchema: schemaConfig.createSchema,
       };
 
       const createSchema = klass.createSchema();
@@ -211,11 +212,11 @@ describe('valibot schema config', () => {
 
       const klass = {
         prototype: { columns },
-        inputSchema: valibotSchemaConfig.inputSchema,
-        querySchema: valibotSchemaConfig.outputSchema,
-        pkeySchema: valibotSchemaConfig.pkeySchema,
-        createSchema: valibotSchemaConfig.createSchema,
-        updateSchema: valibotSchemaConfig.updateSchema,
+        inputSchema: schemaConfig.inputSchema,
+        querySchema: schemaConfig.outputSchema,
+        pkeySchema: schemaConfig.pkeySchema,
+        createSchema: schemaConfig.createSchema,
+        updateSchema: schemaConfig.updateSchema,
       };
 
       const updateSchema = klass.updateSchema();
@@ -243,10 +244,10 @@ describe('valibot schema config', () => {
 
       const klass = {
         prototype: { columns },
-        inputSchema: valibotSchemaConfig.inputSchema,
-        querySchema: valibotSchemaConfig.outputSchema,
-        pkeySchema: valibotSchemaConfig.pkeySchema,
-        createSchema: valibotSchemaConfig.createSchema,
+        inputSchema: schemaConfig.inputSchema,
+        querySchema: schemaConfig.outputSchema,
+        pkeySchema: schemaConfig.pkeySchema,
+        createSchema: schemaConfig.createSchema,
       };
 
       const pkeySchema = klass.pkeySchema();
@@ -1018,7 +1019,7 @@ describe('valibot schema config', () => {
     class Virtual extends VirtualColumn<ValibotSchemaConfig> {}
 
     it('should result in a never type', () => {
-      const type = new Virtual(valibotSchemaConfig);
+      const type = new Virtual(schemaConfig);
 
       assertAllTypes<typeof type, NeverSchema>();
 
@@ -1048,7 +1049,7 @@ describe('valibot schema config', () => {
 
   describe('custom type', () => {
     it('should convert it to a base column', () => {
-      const type = new CustomTypeColumn(valibotSchemaConfig, 'customType').as(
+      const type = new CustomTypeColumn(schemaConfig, 'customType').as(
         t.integer(),
       );
 

--- a/packages/schemaConfigs/valibot/src/valibot.test.ts
+++ b/packages/schemaConfigs/valibot/src/valibot.test.ts
@@ -28,6 +28,7 @@ import {
   UnionSchema,
   literal,
   LiteralSchema,
+  unknown,
 } from 'valibot';
 
 const schemaConfig = valibotSchemaConfig();
@@ -787,13 +788,11 @@ describe('valibot schema config', () => {
     });
   });
 
-  const xml = t.xml();
-  const jsonText = t.jsonText();
-  assertAllTypes<typeof xml | typeof jsonText, StringSchema>();
-
-  describe.each(['xml', 'jsonText'])('%s', (method) => {
+  describe('xml', () => {
     it('should parse to a string without validation', () => {
-      const type = t[method as 'xml']();
+      const type = t.xml();
+
+      assertAllTypes<typeof type, StringSchema>();
 
       expectAllParse(type, 'string', 'string');
 
@@ -898,6 +897,13 @@ describe('valibot schema config', () => {
       );
 
       const expected = object({ bool: boolean() });
+      assertAllTypes<typeof type, typeof expected>();
+    });
+
+    it('should parse jsonText to unknown', () => {
+      const type = t.jsonText();
+
+      const expected = unknown();
       assertAllTypes<typeof type, typeof expected>();
     });
   });

--- a/packages/schemaConfigs/valibot/src/valibot.ts
+++ b/packages/schemaConfigs/valibot/src/valibot.ts
@@ -945,7 +945,7 @@ export interface ValibotSchemaConfig extends ColumnSchemaConfig {
 }
 
 export const valibotSchemaConfig = (
-  options: AdapterSchemaConfigOptions,
+  options?: AdapterSchemaConfigOptions,
 ): ValibotSchemaConfig => {
   const schemaConfig: ValibotSchemaConfig = {
     type: undefined as unknown as BaseSchema,

--- a/packages/schemaConfigs/valibot/src/valibot.ts
+++ b/packages/schemaConfigs/valibot/src/valibot.ts
@@ -29,6 +29,10 @@ import {
   setColumnParseNull,
   setDataValue,
   StringData,
+  ColumnSchemaConfig,
+  AdapterSchemaConfigOptions,
+  getDateAsNumberFn,
+  getDateAsDateFn,
 } from 'pqb/internal';
 import {
   actionIssue,
@@ -99,8 +103,12 @@ class ValibotJSONColumn<Schema extends BaseSchema> extends JSONColumn<
   ValibotSchemaConfig,
   Schema
 > {
-  constructor(schema: Schema) {
-    super(valibotSchemaConfig, schema);
+  constructor(
+    schemaConfig: ValibotSchemaConfig,
+    schema: Schema,
+    jsonEncodedByDriver?: boolean,
+  ) {
+    super(schemaConfig, schema, jsonEncodedByDriver);
   }
 }
 
@@ -203,8 +211,8 @@ class ValibotArrayColumn<Item extends ArrayColumnValue> extends ArrayColumn<
   ArraySchema<Item['outputSchema']>,
   ArraySchema<Item['querySchema']>
 > {
-  constructor(item: Item) {
-    super(valibotSchemaConfig, item, array(item.inputSchema, []));
+  constructor(schemaConfig: ValibotSchemaConfig, item: Item) {
+    super(schemaConfig, item, array(item.inputSchema, []));
   }
 }
 
@@ -697,7 +705,7 @@ type PointSchemaValibot = ObjectSchema<{
 
 let pointSchema: PointSchemaValibot | undefined;
 
-export interface ValibotSchemaConfig {
+export interface ValibotSchemaConfig extends ColumnSchemaConfig {
   type: BaseSchema;
 
   parse<
@@ -936,199 +944,214 @@ export interface ValibotSchemaConfig {
   geographyPointSchema(): PointSchemaValibot;
 }
 
-// parse a date string to date object, with respect to null
-const parseDateToDate = (value: unknown) => new Date(value as string);
+export const valibotSchemaConfig = (
+  options: AdapterSchemaConfigOptions,
+): ValibotSchemaConfig => {
+  const schemaConfig: ValibotSchemaConfig = {
+    type: undefined as unknown as BaseSchema,
+    parse(schema, fn) {
+      return setColumnParse(this as never, fn, schema);
+    },
+    parseNull(schema, fn) {
+      return setColumnParseNull(this as never, fn, schema);
+    },
+    encode(schema, fn) {
+      return setColumnEncode(this as never, fn, schema);
+    },
+    asType(_types) {
+      return this as never;
+    },
+    narrowType(type) {
+      const c = Object.create(this);
+      if ((c as Column.Pick.Data).data.generated) {
+        c.outputSchema = c.querySchema = type;
+      } else {
+        c.inputSchema = c.outputSchema = c.querySchema = type;
+      }
+      return c as never;
+    },
+    narrowAllTypes(types) {
+      const c = Object.create(this);
+      if (types.input) {
+        c.inputSchema = types.input;
+      }
+      if (types.output) {
+        c.outputSchema = types.output;
+      }
+      if (types.query) {
+        c.querySchema = types.query;
+      }
+      return c as never;
+    },
+    dateAsNumber() {
+      return this.parse(number([]), getDateAsNumberFn(this));
+    },
+    dateAsDate() {
+      return this.parse(date([]), getDateAsDateFn(this) as never);
+    },
+    enum(dataType, type) {
+      return new EnumColumn(schemaConfig, dataType, type, picklist(type));
+    },
+    array(item) {
+      return new ValibotArrayColumn(schemaConfig, item);
+    },
+    nullable() {
+      return makeColumnNullable(
+        this as never,
+        nullable(this.inputSchema),
+        this.nullSchema
+          ? union([this.outputSchema, this.nullSchema])
+          : nullable(this.outputSchema),
+        nullable(this.querySchema),
+      ) as never;
+    },
+    json<Schema extends BaseSchema = UnknownSchema>(schema?: Schema) {
+      return new ValibotJSONColumn(
+        schemaConfig,
+        (schema ?? unknown([])) as Schema,
+        options?.jsonEncodedByDriver,
+      );
+    },
+    boolean: () => boolean([]),
+    buffer: () => instance(Buffer, []),
+    unknown: () => unknown([]),
+    never: () => never(),
+    stringSchema: () => string([]),
+    stringMin(min) {
+      return string([minLength(min)]);
+    },
+    stringMax(max) {
+      return string([maxLength(max)]);
+    },
+    stringMinMax(min, max) {
+      return string([minLength(min), maxLength(max)]);
+    },
+    number: () => number([]),
+    int: () => number([integer()]),
 
-export const valibotSchemaConfig: ValibotSchemaConfig = {
-  type: undefined as unknown as BaseSchema,
-  parse(schema, fn) {
-    return setColumnParse(this as never, fn, schema);
-  },
-  parseNull(schema, fn) {
-    return setColumnParseNull(this as never, fn, schema);
-  },
-  encode(schema, fn) {
-    return setColumnEncode(this as never, fn, schema);
-  },
-  asType(_types) {
-    return this as never;
-  },
-  narrowType(type) {
-    const c = Object.create(this);
-    if ((c as Column.Pick.Data).data.generated) {
-      c.outputSchema = c.querySchema = type;
-    } else {
-      c.inputSchema = c.outputSchema = c.querySchema = type;
-    }
-    return c as never;
-  },
-  narrowAllTypes(types) {
-    const c = Object.create(this);
-    if (types.input) {
-      c.inputSchema = types.input;
-    }
-    if (types.output) {
-      c.outputSchema = types.output;
-    }
-    if (types.query) {
-      c.querySchema = types.query;
-    }
-    return c as never;
-  },
-  dateAsNumber() {
-    return this.parse(number([]), Date.parse as never);
-  },
-  dateAsDate() {
-    return this.parse(date([]), parseDateToDate);
-  },
-  enum(dataType, type) {
-    return new EnumColumn(valibotSchemaConfig, dataType, type, picklist(type));
-  },
-  array(item) {
-    return new ValibotArrayColumn(item);
-  },
-  nullable() {
-    return makeColumnNullable(
-      this as never,
-      nullable(this.inputSchema),
-      this.nullSchema
-        ? union([this.outputSchema, this.nullSchema])
-        : nullable(this.outputSchema),
-      nullable(this.querySchema),
-    ) as never;
-  },
-  json<Schema extends BaseSchema = UnknownSchema>(schema?: Schema) {
-    return new ValibotJSONColumn((schema ?? unknown([])) as Schema);
-  },
-  boolean: () => boolean([]),
-  buffer: () => instance(Buffer, []),
-  unknown: () => unknown([]),
-  never: () => never(),
-  stringSchema: () => string([]),
-  stringMin(min) {
-    return string([minLength(min)]);
-  },
-  stringMax(max) {
-    return string([maxLength(max)]);
-  },
-  stringMinMax(min, max) {
-    return string([minLength(min), maxLength(max)]);
-  },
-  number: () => number([]),
-  int: () => number([integer()]),
+    stringNumberDate: () =>
+      coerce(date([]), (input) => new Date(input as string)),
 
-  stringNumberDate: () =>
-    coerce(date([]), (input) => new Date(input as string)),
+    timeInterval: () =>
+      object(
+        {
+          years: optional(number()),
+          months: optional(number()),
+          days: optional(number()),
+          hours: optional(number()),
+          minutes: optional(number()),
+          seconds: optional(number()),
+        },
+        [],
+      ),
 
-  timeInterval: () =>
-    object(
-      {
-        years: optional(number()),
-        months: optional(number()),
-        days: optional(number()),
-        hours: optional(number()),
-        minutes: optional(number()),
-        seconds: optional(number()),
-      },
-      [],
-    ),
+    bit: (max?: number) =>
+      max ? string([maxLength(max), regex(/[10]/g)]) : string([regex(/[10]/g)]),
 
-  bit: (max?: number) =>
-    max ? string([maxLength(max), regex(/[10]/g)]) : string([regex(/[10]/g)]),
+    uuid: () => string([uuid()]),
 
-  uuid: () => string([uuid()]),
+    inputSchema() {
+      return mapSchema(this, 'inputSchema');
+    },
 
-  inputSchema() {
-    return mapSchema(this, 'inputSchema');
-  },
+    outputSchema() {
+      return mapSchema(this, 'outputSchema');
+    },
 
-  outputSchema() {
-    return mapSchema(this, 'outputSchema');
-  },
+    querySchema() {
+      return partial(mapSchema(this, 'querySchema'));
+    },
 
-  querySchema() {
-    return partial(mapSchema(this, 'querySchema'));
-  },
+    createSchema<T extends ColumnSchemaGetterTableClass>(this: T) {
+      const input = this.inputSchema() as ObjectSchema<ObjectEntries>;
 
-  createSchema<T extends ColumnSchemaGetterTableClass>(this: T) {
-    const input = this.inputSchema() as ObjectSchema<ObjectEntries>;
+      const shape: ObjectEntries = {};
+      const { shape: columns } = this.prototype.columns;
 
-    const shape: ObjectEntries = {};
-    const { shape: columns } = this.prototype.columns;
+      for (const key in columns) {
+        const column = columns[key];
+        if (column.dataType && !column.data.primaryKey) {
+          shape[key] = input.entries[key];
 
-    for (const key in columns) {
-      const column = columns[key];
-      if (column.dataType && !column.data.primaryKey) {
-        shape[key] = input.entries[key];
-
-        if (column.data.isNullable || column.data.default !== undefined) {
-          shape[key] = optional(shape[key]);
+          if (column.data.isNullable || column.data.default !== undefined) {
+            shape[key] = optional(shape[key]);
+          }
         }
       }
-    }
 
-    return object(shape) as CreateSchema<T>;
-  },
+      return object(shape) as CreateSchema<T>;
+    },
 
-  updateSchema<T extends ColumnSchemaGetterTableClass>(this: T) {
-    return partial(this.createSchema() as never) as UpdateSchema<T>;
-  },
+    updateSchema<T extends ColumnSchemaGetterTableClass>(this: T) {
+      return partial(this.createSchema() as never) as UpdateSchema<T>;
+    },
 
-  pkeySchema<T extends ColumnSchemaGetterTableClass>(this: T) {
-    const keys: string[] = [];
+    pkeySchema<T extends ColumnSchemaGetterTableClass>(this: T) {
+      const keys: string[] = [];
 
-    const {
-      columns: { shape },
-    } = this.prototype;
-    for (const key in shape) {
-      if (shape[key].data.primaryKey) {
-        keys.push(key);
+      const {
+        columns: { shape },
+      } = this.prototype;
+      for (const key in shape) {
+        if (shape[key].data.primaryKey) {
+          keys.push(key);
+        }
       }
-    }
 
-    return required(
-      pick(this.querySchema() as never, keys as never),
-    ) as PkeySchema<T>;
-  },
+      return required(
+        pick(this.querySchema() as never, keys as never),
+      ) as PkeySchema<T>;
+    },
 
-  error(message: string) {
-    const c = this as Column;
-    c.inputSchema.message =
-      c.outputSchema.message =
-      c.querySchema.message =
-        message;
-    return c as never;
-  },
+    error(message: string) {
+      const c = this as Column;
+      c.inputSchema.message =
+        c.outputSchema.message =
+        c.querySchema.message =
+          message;
+      return c as never;
+    },
 
-  smallint: () => new SmallIntColumnValibot(valibotSchemaConfig),
-  integer: () => new IntegerColumnValibot(valibotSchemaConfig),
-  real: () => new RealColumnValibot(valibotSchemaConfig),
-  smallSerial: () => new SmallSerialColumnValibot(valibotSchemaConfig),
-  serial: () => new SerialColumnValibot(valibotSchemaConfig),
+    smallint: () => new SmallIntColumnValibot(schemaConfig),
+    integer: () => new IntegerColumnValibot(schemaConfig),
+    real: () => new RealColumnValibot(schemaConfig),
+    smallSerial: () => new SmallSerialColumnValibot(schemaConfig),
+    serial: () => new SerialColumnValibot(schemaConfig),
 
-  bigint: () => new BigIntColumnValibot(valibotSchemaConfig),
-  decimal: (precision, scale) =>
-    new DecimalColumnValibot(valibotSchemaConfig, precision, scale),
-  doublePrecision: () => new DoublePrecisionColumnValibot(valibotSchemaConfig),
-  bigSerial: () => new BigSerialColumnValibot(valibotSchemaConfig),
-  money: () => new MoneyColumnValibot(valibotSchemaConfig),
-  varchar: (limit) => new VarCharColumnValibot(valibotSchemaConfig, limit),
-  text: () => new TextColumnValibot(valibotSchemaConfig),
-  string: (limit) => new StringColumnValibot(valibotSchemaConfig, limit),
-  citext: () => new CitextColumnValibot(valibotSchemaConfig),
+    bigint: () => new BigIntColumnValibot(schemaConfig),
+    decimal: (precision, scale) =>
+      new DecimalColumnValibot(schemaConfig, precision, scale),
+    doublePrecision: () => new DoublePrecisionColumnValibot(schemaConfig),
+    bigSerial: () => new BigSerialColumnValibot(schemaConfig),
+    money: () => new MoneyColumnValibot(schemaConfig),
+    varchar: (limit) => new VarCharColumnValibot(schemaConfig, limit),
+    text: () => new TextColumnValibot(schemaConfig),
+    string: (limit) => new StringColumnValibot(schemaConfig, limit),
+    citext: () => new CitextColumnValibot(schemaConfig),
 
-  date: () => new DateColumnValibot(valibotSchemaConfig),
-  timestampNoTZ: (precision) =>
-    new TimestampNoTzColumnValibot(valibotSchemaConfig, precision),
-  timestamp: (precision) =>
-    new TimestampColumnValibot(valibotSchemaConfig, precision),
+    date: () =>
+      new DateColumnValibot(schemaConfig, options?.dateParsedByDriver),
+    timestampNoTZ: (precision) =>
+      new TimestampNoTzColumnValibot(
+        schemaConfig,
+        precision,
+        options?.dateParsedByDriver,
+      ),
+    timestamp: (precision) =>
+      new TimestampColumnValibot(
+        schemaConfig,
+        precision,
+        options?.dateParsedByDriver,
+      ),
 
-  geographyPointSchema: () =>
-    (pointSchema ??= object({
-      srid: optional(number()),
-      lon: number(),
-      lat: number(),
-    })),
+    geographyPointSchema: () =>
+      (pointSchema ??= object({
+        srid: optional(number()),
+        lon: number(),
+        lat: number(),
+      })),
+  };
+  return schemaConfig;
 };
 
 type MapSchema<

--- a/packages/schemaConfigs/zod/src/zod.test.ts
+++ b/packages/schemaConfigs/zod/src/zod.test.ts
@@ -895,13 +895,11 @@ describe('zod schema config', () => {
     });
   });
 
-  const xml = t.xml();
-  const jsonText = t.jsonText();
-  assertAllTypes<typeof xml | typeof jsonText, ZodString>();
-
-  describe.each(['xml', 'jsonText'])('%s', (method) => {
+  describe('xml', () => {
     it('should parse to a string without validation', () => {
-      const type = t[method as 'xml']();
+      const type = t.xml();
+
+      assertAllTypes<typeof type, ZodString>();
 
       expectAllParse(type, 'string', 'string');
 
@@ -1018,6 +1016,13 @@ describe('zod schema config', () => {
       );
 
       const expected = z.object({ bool: z.boolean() });
+      assertAllTypes<typeof type, typeof expected>();
+    });
+
+    it('should parse jsonText to unknown', () => {
+      const type = t.jsonText();
+
+      const expected = z.unknown();
       assertAllTypes<typeof type, typeof expected>();
     });
   });

--- a/packages/schemaConfigs/zod/src/zod.test.ts
+++ b/packages/schemaConfigs/zod/src/zod.test.ts
@@ -19,7 +19,8 @@ import {
 } from 'zod/v4';
 import { AssertEqual, assertType } from 'test-utils';
 
-const t = makeColumnTypes(zodSchemaConfig);
+const schemaConfig = zodSchemaConfig();
+const t = makeColumnTypes(schemaConfig);
 
 type TypeBase = {
   inputSchema: ZodTypeAny;
@@ -105,11 +106,11 @@ describe('zod schema config', () => {
 
     const klass = {
       prototype: { columns },
-      inputSchema: zodSchemaConfig.inputSchema,
-      outputSchema: zodSchemaConfig.outputSchema,
-      querySchema: zodSchemaConfig.querySchema,
-      pkeySchema: zodSchemaConfig.pkeySchema,
-      createSchema: zodSchemaConfig.createSchema,
+      inputSchema: schemaConfig.inputSchema,
+      outputSchema: schemaConfig.outputSchema,
+      querySchema: schemaConfig.querySchema,
+      pkeySchema: schemaConfig.pkeySchema,
+      createSchema: schemaConfig.createSchema,
     };
 
     const type = {
@@ -143,11 +144,11 @@ describe('zod schema config', () => {
 
       const klass = {
         prototype: { columns },
-        inputSchema: zodSchemaConfig.inputSchema,
-        outputSchema: zodSchemaConfig.outputSchema,
-        querySchema: zodSchemaConfig.querySchema,
-        pkeySchema: zodSchemaConfig.pkeySchema,
-        createSchema: zodSchemaConfig.createSchema,
+        inputSchema: schemaConfig.inputSchema,
+        outputSchema: schemaConfig.outputSchema,
+        querySchema: schemaConfig.querySchema,
+        pkeySchema: schemaConfig.pkeySchema,
+        createSchema: schemaConfig.createSchema,
       };
 
       const schema = klass.querySchema();
@@ -180,10 +181,10 @@ describe('zod schema config', () => {
 
       const klass = {
         prototype: { columns },
-        inputSchema: zodSchemaConfig.inputSchema,
-        querySchema: zodSchemaConfig.outputSchema,
-        pkeySchema: zodSchemaConfig.pkeySchema,
-        createSchema: zodSchemaConfig.createSchema,
+        inputSchema: schemaConfig.inputSchema,
+        querySchema: schemaConfig.outputSchema,
+        pkeySchema: schemaConfig.pkeySchema,
+        createSchema: schemaConfig.createSchema,
       };
 
       const createSchema = klass.createSchema();
@@ -212,11 +213,11 @@ describe('zod schema config', () => {
 
       const klass = {
         prototype: { columns },
-        inputSchema: zodSchemaConfig.inputSchema,
-        querySchema: zodSchemaConfig.outputSchema,
-        pkeySchema: zodSchemaConfig.pkeySchema,
-        createSchema: zodSchemaConfig.createSchema,
-        updateSchema: zodSchemaConfig.updateSchema,
+        inputSchema: schemaConfig.inputSchema,
+        querySchema: schemaConfig.outputSchema,
+        pkeySchema: schemaConfig.pkeySchema,
+        createSchema: schemaConfig.createSchema,
+        updateSchema: schemaConfig.updateSchema,
       };
 
       const updateSchema = klass.updateSchema();
@@ -244,10 +245,10 @@ describe('zod schema config', () => {
 
       const klass = {
         prototype: { columns },
-        inputSchema: zodSchemaConfig.inputSchema,
-        querySchema: zodSchemaConfig.outputSchema,
-        pkeySchema: zodSchemaConfig.pkeySchema,
-        createSchema: zodSchemaConfig.createSchema,
+        inputSchema: schemaConfig.inputSchema,
+        querySchema: schemaConfig.outputSchema,
+        pkeySchema: schemaConfig.pkeySchema,
+        createSchema: schemaConfig.createSchema,
       };
 
       const pkeySchema = klass.pkeySchema();
@@ -1133,7 +1134,7 @@ describe('zod schema config', () => {
     class Virtual extends VirtualColumn<ZodSchemaConfig> {}
 
     it('should return ZodNever from columnToZod', () => {
-      const type = new Virtual(zodSchemaConfig);
+      const type = new Virtual(schemaConfig);
 
       assertAllTypes<typeof type, ZodNever>();
 
@@ -1163,7 +1164,7 @@ describe('zod schema config', () => {
 
   describe('custom type', () => {
     it('should convert it to a base column', () => {
-      const type = new CustomTypeColumn(zodSchemaConfig, 'customType').as(
+      const type = new CustomTypeColumn(schemaConfig, 'customType').as(
         t.integer(),
       );
 

--- a/packages/schemaConfigs/zod/src/zod.ts
+++ b/packages/schemaConfigs/zod/src/zod.ts
@@ -31,6 +31,10 @@ import {
   setColumnParseNull,
   setDataValue,
   StringData,
+  ColumnSchemaConfig,
+  AdapterSchemaConfigOptions,
+  getDateAsNumberFn,
+  getDateAsDateFn,
 } from 'pqb/internal';
 import {
   z,
@@ -63,8 +67,12 @@ class ZodJSONColumn<ZodSchema extends ZodTypeAny> extends JSONColumn<
   ZodSchemaConfig,
   ZodSchema
 > {
-  constructor(schema: ZodSchema) {
-    super(zodSchemaConfig, schema);
+  constructor(
+    schemaConfig: ZodSchemaConfig,
+    schema: ZodSchema,
+    encodedByDriver?: boolean,
+  ) {
+    super(schemaConfig, schema, encodedByDriver);
   }
 }
 
@@ -157,8 +165,8 @@ class ZodArrayColumn<Item extends ArrayColumnValue> extends ArrayColumn<
   ZodArray<Item['outputSchema']>,
   ZodArray<Item['querySchema']>
 > {
-  constructor(item: Item) {
-    super(zodSchemaConfig, item, z.array(item.inputSchema));
+  constructor(schemaConfig: ZodSchemaConfig, item: Item) {
+    super(schemaConfig, item, z.array(item.inputSchema));
   }
 }
 
@@ -521,7 +529,7 @@ export interface BareZodType {
   _output: unknown;
 }
 
-export interface ZodSchemaConfig {
+export interface ZodSchemaConfig extends ColumnSchemaConfig {
   type: ZodTypeAny;
 
   parse<
@@ -758,286 +766,302 @@ export interface ZodSchemaConfig {
   geographyPointSchema(): PointSchemaZod;
 }
 
-// parse a date string to date object, with respect to null
-const parseDateToDate = (value: unknown) => new Date(value as string);
-
-export const zodSchemaConfig: ZodSchemaConfig = {
-  type: undefined as unknown as ZodTypeAny,
-  parse(schema, fn) {
-    return setColumnParse(this as never, fn, schema);
-  },
-  parseNull(schema, fn) {
-    return setColumnParseNull(this as never, fn, schema);
-  },
-  encode(schema, fn) {
-    return setColumnEncode(this as never, fn, schema);
-  },
-  asType(_types) {
-    return this as never;
-  },
-  narrowType(type) {
-    const c = Object.create(this);
-    if ((c as Column.Pick.Data).data.generated) {
-      c.outputSchema = c.querySchema = type;
-    } else {
-      c.inputSchema = c.outputSchema = c.querySchema = type;
-    }
-    return c as never;
-  },
-  narrowAllTypes(types) {
-    const c = Object.create(this);
-    if (types.input) {
-      c.inputSchema = types.input;
-    }
-    if (types.output) {
-      c.outputSchema = types.output;
-    }
-    if (types.query) {
-      c.querySchema = types.query;
-    }
-    return c as never;
-  },
-  dateAsNumber() {
-    return this.parse(z.number(), Date.parse as never) as never;
-  },
-  dateAsDate() {
-    return this.parse(z.date(), parseDateToDate) as never;
-  },
-  enum(dataType, type) {
-    return new EnumColumn(
-      zodSchemaConfig,
-      dataType,
-      Object.values(type),
-      z.enum(type),
-    ) as never;
-  },
-  array(item) {
-    return new ZodArrayColumn(item);
-  },
-  nullable() {
-    return makeColumnNullable(
-      this as never,
-      z.nullable(this.inputSchema),
-      this.nullSchema
-        ? this.outputSchema.or(this.nullSchema)
-        : z.nullable(this.outputSchema),
-      z.nullable(this.querySchema),
-    ) as never;
-  },
-  json<ZodSchema extends ZodTypeAny = ZodUnknown>(schema?: ZodSchema) {
-    return new ZodJSONColumn((schema ?? z.unknown()) as ZodSchema);
-  },
-  boolean: () => z.boolean(),
-  buffer: () => z.instanceof(Buffer),
-  unknown: () => z.unknown(),
-  never: () => z.never(),
-  stringSchema: () => z.string(),
-  stringMin(min) {
-    return z.string().min(min);
-  },
-  stringMax(max) {
-    return z.string().max(max);
-  },
-  stringMinMax(min, max) {
-    return z.string().min(min).max(max);
-  },
-  number: () => z.number(),
-  int: () => z.number().int(),
-
-  stringNumberDate: () => z.coerce.date(),
-
-  timeInterval: () =>
-    z.object({
-      years: z.number().optional(),
-      months: z.number().optional(),
-      days: z.number().optional(),
-      hours: z.number().optional(),
-      minutes: z.number().optional(),
-      seconds: z.number().optional(),
-    }),
-
-  bit: (max?: number) =>
-    (max ? z.string().max(max) : z.string()).regex(/[10]/g),
-
-  uuid: () => z.string().uuid(),
-
-  inputSchema() {
-    return mapSchema(this, 'inputSchema');
-  },
-
-  outputSchema() {
-    return mapSchema(this, 'outputSchema');
-  },
-
-  querySchema() {
-    const shape: RecordUnknown = {};
-    const { shape: columns } = this.prototype.columns;
-
-    for (const key in columns) {
-      const column = columns[key] as Column;
-      if (columns[key].dataType) {
-        shape[key] = column.querySchema.optional();
+export const zodSchemaConfig = (
+  options?: AdapterSchemaConfigOptions,
+): ZodSchemaConfig => {
+  const schemaConfig: ZodSchemaConfig = {
+    type: undefined as unknown as ZodTypeAny,
+    parse(schema, fn) {
+      return setColumnParse(this as never, fn, schema);
+    },
+    parseNull(schema, fn) {
+      return setColumnParseNull(this as never, fn, schema);
+    },
+    encode(schema, fn) {
+      return setColumnEncode(this as never, fn, schema);
+    },
+    asType(_types) {
+      return this as never;
+    },
+    narrowType(type) {
+      const c = Object.create(this);
+      if ((c as Column.Pick.Data).data.generated) {
+        c.outputSchema = c.querySchema = type;
+      } else {
+        c.inputSchema = c.outputSchema = c.querySchema = type;
       }
-    }
+      return c as never;
+    },
+    narrowAllTypes(types) {
+      const c = Object.create(this);
+      if (types.input) {
+        c.inputSchema = types.input;
+      }
+      if (types.output) {
+        c.outputSchema = types.output;
+      }
+      if (types.query) {
+        c.querySchema = types.query;
+      }
+      return c as never;
+    },
+    dateAsNumber() {
+      return this.parse(z.number(), getDateAsNumberFn(this)) as never;
+    },
+    dateAsDate() {
+      return this.parse(z.date(), getDateAsDateFn(this)) as never;
+    },
+    enum(dataType, type) {
+      return new EnumColumn(
+        schemaConfig,
+        dataType,
+        Object.values(type),
+        z.enum(type),
+      ) as never;
+    },
+    array(item) {
+      return new ZodArrayColumn(schemaConfig, item);
+    },
+    nullable() {
+      return makeColumnNullable(
+        this as never,
+        z.nullable(this.inputSchema),
+        this.nullSchema
+          ? this.outputSchema.or(this.nullSchema)
+          : z.nullable(this.outputSchema),
+        z.nullable(this.querySchema),
+      ) as never;
+    },
+    json<ZodSchema extends ZodTypeAny = ZodUnknown>(schema?: ZodSchema) {
+      return new ZodJSONColumn(
+        schemaConfig,
+        (schema ?? z.unknown()) as ZodSchema,
+        options?.jsonEncodedByDriver,
+      );
+    },
+    boolean: () => z.boolean(),
+    buffer: () => z.instanceof(Buffer),
+    unknown: () => z.unknown(),
+    never: () => z.never(),
+    stringSchema: () => z.string(),
+    stringMin(min) {
+      return z.string().min(min);
+    },
+    stringMax(max) {
+      return z.string().max(max);
+    },
+    stringMinMax(min, max) {
+      return z.string().min(min).max(max);
+    },
+    number: () => z.number(),
+    int: () => z.number().int(),
 
-    return z.object(shape) as never;
-  },
+    stringNumberDate: () => z.coerce.date(),
 
-  createSchema<T extends ColumnSchemaGetterTableClass>(this: T) {
-    const input = this.inputSchema() as ZodObject<ZodRawShape>;
+    timeInterval: () =>
+      z.object({
+        years: z.number().optional(),
+        months: z.number().optional(),
+        days: z.number().optional(),
+        hours: z.number().optional(),
+        minutes: z.number().optional(),
+        seconds: z.number().optional(),
+      }),
 
-    const shape: ZodShape = {};
-    const { shape: columns } = this.prototype.columns;
+    bit: (max?: number) =>
+      (max ? z.string().max(max) : z.string()).regex(/[10]/g),
 
-    for (const key in columns) {
-      const column = columns[key];
-      if (column.dataType && !column.data.primaryKey) {
-        shape[key] = input.shape[key];
+    uuid: () => z.string().uuid(),
 
-        if (column.data.isNullable || column.data.default !== undefined) {
-          shape[key] = optional(shape[key]);
+    inputSchema() {
+      return mapSchema(this, 'inputSchema');
+    },
+
+    outputSchema() {
+      return mapSchema(this, 'outputSchema');
+    },
+
+    querySchema() {
+      const shape: RecordUnknown = {};
+      const { shape: columns } = this.prototype.columns;
+
+      for (const key in columns) {
+        const column = columns[key] as Column;
+        if (columns[key].dataType) {
+          shape[key] = column.querySchema.optional();
         }
       }
-    }
 
-    return z.object(shape) as unknown as CreateSchema<T>;
-  },
+      return z.object(shape) as never;
+    },
 
-  updateSchema<T extends ColumnSchemaGetterTableClass>(this: T) {
-    return (this.createSchema() as ZodObject<ZodRawShape>).partial() as never;
-  },
+    createSchema<T extends ColumnSchemaGetterTableClass>(this: T) {
+      const input = this.inputSchema() as ZodObject<ZodRawShape>;
 
-  pkeySchema<T extends ColumnSchemaGetterTableClass>(this: T) {
-    const pkeys: Record<string, true> = {};
+      const shape: ZodShape = {};
+      const { shape: columns } = this.prototype.columns;
 
-    const {
-      columns: { shape },
-    } = this.prototype;
-    for (const key in shape) {
-      if (shape[key].dataType && shape[key].data.primaryKey) {
-        pkeys[key] = true;
+      for (const key in columns) {
+        const column = columns[key];
+        if (column.dataType && !column.data.primaryKey) {
+          shape[key] = input.shape[key];
+
+          if (column.data.isNullable || column.data.default !== undefined) {
+            shape[key] = optional(shape[key]);
+          }
+        }
       }
-    }
 
-    return (this.querySchema() as ZodObject<ZodRawShape>)
-      .pick(pkeys)
-      .required() as never;
-  },
+      return z.object(shape) as unknown as CreateSchema<T>;
+    },
 
-  /**
-   * `error` allows to specify two following validation messages:
-   *
-   * ```ts
-   * t.text().error({
-   *   required: 'This column is required',
-   *   invalidType: 'This column must be an integer',
-   * });
-   * ```
-   *
-   * It will be converted into `Zod`'s messages:
-   *
-   * ```ts
-   * z.string({
-   *   required_error: 'This column is required',
-   *   invalid_type_error: 'This column must be an integer',
-   * });
-   * ```
-   *
-   * Each validation method can accept an error message as a string:
-   *
-   * ```ts
-   * t.text().min(5, 'Must be 5 or more characters long');
-   * t.text().max(5, 'Must be 5 or fewer characters long');
-   * t.text().length(5, 'Must be exactly 5 characters long');
-   * t.text().email('Invalid email address');
-   * t.text().url('Invalid url');
-   * t.text().emoji('Contains non-emoji characters');
-   * t.text().uuid('Invalid UUID');
-   * t.text().includes('tuna', 'Must include tuna');
-   * t.text().startsWith('https://', 'Must provide secure URL');
-   * t.text().endsWith('.com', 'Only .com domains allowed');
-   * ```
-   *
-   * Except for `text().datetime()` and `text().ip()`:
-   *
-   * these methods can have their own parameters, so the error message is passed in object.
-   *
-   * ```ts
-   * t.text().datetime({ message: 'Invalid datetime string! Must be UTC.' });
-   * t.text().ip({ message: 'Invalid IP address' });
-   * ```
-   *
-   * Error messages are supported for a JSON schema as well:
-   *
-   * ```ts
-   * t.json((j) =>
-   *   j.object({
-   *     one: j
-   *       .string()
-   *       .error({ required: 'One is required' })
-   *       .min(5, 'Must be 5 or more characters long'),
-   *     two: j
-   *       .string()
-   *       .error({ invalidType: 'Two should be a string' })
-   *       .max(5, 'Must be 5 or fewer characters long'),
-   *     three: j.string().length(5, 'Must be exactly 5 characters long'),
-   *   }),
-   * );
-   * ```
-   *
-   * @param errors - object, key is either 'required' or 'invalidType', value is an error message
-   */
-  error(errors) {
-    const c = this as Column;
-    const { errors: old } = c.data;
-    const newErrors = old ? { ...old, ...errors } : errors;
-    const { required, invalidType } = newErrors;
+    updateSchema<T extends ColumnSchemaGetterTableClass>(this: T) {
+      return (this.createSchema() as ZodObject<ZodRawShape>).partial() as never;
+    },
 
-    const errorMap: $ZodErrorMap = (iss) => {
-      if (iss.code === 'invalid_type') {
-        return iss.input === undefined ? required : invalidType;
+    pkeySchema<T extends ColumnSchemaGetterTableClass>(this: T) {
+      const pkeys: Record<string, true> = {};
+
+      const {
+        columns: { shape },
+      } = this.prototype;
+      for (const key in shape) {
+        if (shape[key].dataType && shape[key].data.primaryKey) {
+          pkeys[key] = true;
+        }
       }
-      // not sure if this is correct to return undefined for other errors,
-      // let's wait for an issue.
-      return;
-    };
 
-    (c.inputSchema as ZodTypeAny).def.error =
-      (c.outputSchema as ZodTypeAny).def.error =
-      (c.querySchema as ZodTypeAny).def.error =
-        errorMap;
+      return (this.querySchema() as ZodObject<ZodRawShape>)
+        .pick(pkeys)
+        .required() as never;
+    },
 
-    return setColumnData(c, 'errors', newErrors as never) as never;
-  },
+    /**
+     * `error` allows to specify two following validation messages:
+     *
+     * ```ts
+     * t.text().error({
+     *   required: 'This column is required',
+     *   invalidType: 'This column must be an integer',
+     * });
+     * ```
+     *
+     * It will be converted into `Zod`'s messages:
+     *
+     * ```ts
+     * z.string({
+     *   required_error: 'This column is required',
+     *   invalid_type_error: 'This column must be an integer',
+     * });
+     * ```
+     *
+     * Each validation method can accept an error message as a string:
+     *
+     * ```ts
+     * t.text().min(5, 'Must be 5 or more characters long');
+     * t.text().max(5, 'Must be 5 or fewer characters long');
+     * t.text().length(5, 'Must be exactly 5 characters long');
+     * t.text().email('Invalid email address');
+     * t.text().url('Invalid url');
+     * t.text().emoji('Contains non-emoji characters');
+     * t.text().uuid('Invalid UUID');
+     * t.text().includes('tuna', 'Must include tuna');
+     * t.text().startsWith('https://', 'Must provide secure URL');
+     * t.text().endsWith('.com', 'Only .com domains allowed');
+     * ```
+     *
+     * Except for `text().datetime()` and `text().ip()`:
+     *
+     * these methods can have their own parameters, so the error message is passed in object.
+     *
+     * ```ts
+     * t.text().datetime({ message: 'Invalid datetime string! Must be UTC.' });
+     * t.text().ip({ message: 'Invalid IP address' });
+     * ```
+     *
+     * Error messages are supported for a JSON schema as well:
+     *
+     * ```ts
+     * t.json((j) =>
+     *   j.object({
+     *     one: j
+     *       .string()
+     *       .error({ required: 'One is required' })
+     *       .min(5, 'Must be 5 or more characters long'),
+     *     two: j
+     *       .string()
+     *       .error({ invalidType: 'Two should be a string' })
+     *       .max(5, 'Must be 5 or fewer characters long'),
+     *     three: j.string().length(5, 'Must be exactly 5 characters long'),
+     *   }),
+     * );
+     * ```
+     *
+     * @param errors - object, key is either 'required' or 'invalidType', value is an error message
+     */
+    error(errors) {
+      const c = this as Column;
+      const { errors: old } = c.data;
+      const newErrors = old ? { ...old, ...errors } : errors;
+      const { required, invalidType } = newErrors;
 
-  smallint: () => new SmallIntColumnZod(zodSchemaConfig),
-  integer: () => new IntegerColumnZod(zodSchemaConfig),
-  real: () => new RealColumnZod(zodSchemaConfig),
-  smallSerial: () => new SmallSerialColumnZod(zodSchemaConfig),
-  serial: () => new SerialColumnZod(zodSchemaConfig),
+      const errorMap: $ZodErrorMap = (iss) => {
+        if (iss.code === 'invalid_type') {
+          return iss.input === undefined ? required : invalidType;
+        }
+        // not sure if this is correct to return undefined for other errors,
+        // let's wait for an issue.
+        return;
+      };
 
-  bigint: () => new BigIntColumnZod(zodSchemaConfig),
-  decimal: (precision, scale) =>
-    new DecimalColumnZod(zodSchemaConfig, precision, scale),
-  doublePrecision: () => new DoublePrecisionColumnZod(zodSchemaConfig),
-  bigSerial: () => new BigSerialColumnZod(zodSchemaConfig),
-  money: () => new MoneyColumnZod(zodSchemaConfig),
-  varchar: (limit) => new VarCharColumnZod(zodSchemaConfig, limit),
-  text: () => new TextColumnZod(zodSchemaConfig),
-  string: (limit) => new StringColumnZod(zodSchemaConfig, limit),
-  citext: () => new CitextColumnZod(zodSchemaConfig),
+      (c.inputSchema as ZodTypeAny).def.error =
+        (c.outputSchema as ZodTypeAny).def.error =
+        (c.querySchema as ZodTypeAny).def.error =
+          errorMap;
 
-  date: () => new DateColumnZod(zodSchemaConfig),
-  timestampNoTZ: (precision) =>
-    new TimestampNoTzColumnZod(zodSchemaConfig, precision),
-  timestamp: (precision) => new TimestampColumnZod(zodSchemaConfig, precision),
+      return setColumnData(c, 'errors', newErrors as never) as never;
+    },
 
-  geographyPointSchema: () =>
-    (pointSchema ??= z.object({
-      srid: z.number().optional(),
-      lon: z.number(),
-      lat: z.number(),
-    })),
+    smallint: () => new SmallIntColumnZod(schemaConfig),
+    integer: () => new IntegerColumnZod(schemaConfig),
+    real: () => new RealColumnZod(schemaConfig),
+    smallSerial: () => new SmallSerialColumnZod(schemaConfig),
+    serial: () => new SerialColumnZod(schemaConfig),
+
+    bigint: () => new BigIntColumnZod(schemaConfig),
+    decimal: (precision, scale) =>
+      new DecimalColumnZod(schemaConfig, precision, scale),
+    doublePrecision: () => new DoublePrecisionColumnZod(schemaConfig),
+    bigSerial: () => new BigSerialColumnZod(schemaConfig),
+    money: () => new MoneyColumnZod(schemaConfig),
+    varchar: (limit) => new VarCharColumnZod(schemaConfig, limit),
+    text: () => new TextColumnZod(schemaConfig),
+    string: (limit) => new StringColumnZod(schemaConfig, limit),
+    citext: () => new CitextColumnZod(schemaConfig),
+
+    date: () => new DateColumnZod(schemaConfig, options?.dateParsedByDriver),
+    timestampNoTZ: (precision) =>
+      new TimestampNoTzColumnZod(
+        schemaConfig,
+        precision,
+        options?.dateParsedByDriver,
+      ),
+    timestamp: (precision) =>
+      new TimestampColumnZod(
+        schemaConfig,
+        precision,
+        options?.dateParsedByDriver,
+      ),
+
+    geographyPointSchema: () =>
+      (pointSchema ??= z.object({
+        srid: z.number().optional(),
+        lon: z.number(),
+        lat: z.number(),
+      })),
+  };
+
+  return schemaConfig;
 };
 
 type MapSchema<

--- a/packages/test-builds/src/test-builds.ts
+++ b/packages/test-builds/src/test-builds.ts
@@ -1,12 +1,14 @@
 import { createBaseTable } from 'orchid-orm';
 import { orchidORM as orchidOrmPostgresJs } from 'orchid-orm/postgres-js';
 import { orchidORM as orchidOrmNodePostgres } from 'orchid-orm/node-postgres';
+import { orchidORM as orchidOrmBun } from 'orchid-orm/bun';
 import { zodSchemaConfig } from 'orchid-orm-schema-to-zod';
 import { valibotSchemaConfig } from 'orchid-orm-valibot';
 import { z } from 'zod/v4';
 import { any } from 'valibot';
 import { rakeDb as rakeDbPostgresJs } from 'orchid-orm/migrations/postgres-js';
 import { rakeDb as rakeDbNodePostgres } from 'orchid-orm/migrations/node-postgres';
+import { rakeDb as rakeDbBun } from 'orchid-orm/migrations/bun';
 import { ormFactory, tableFactory } from 'orchid-orm-test-factory';
 
 /** ORM **/
@@ -63,6 +65,13 @@ export const dbZodNodePostgres = orchidOrmNodePostgres(
   },
 );
 
+export const dbZodBun = orchidOrmBun(
+  {},
+  {
+    table: TableZod,
+  },
+);
+
 export const dbValibotPostgresJs = orchidOrmPostgresJs(
   {},
   {
@@ -87,6 +96,13 @@ export const changePostgresJs = rakeDbPostgresJs({
 });
 
 export const changeNodePostgres = rakeDbNodePostgres({
+  baseTable: BaseTableZod,
+  dbPath: './db',
+  migrationsPath: './migrations',
+  import: (path: string) => import(path),
+});
+
+export const changeBun = rakeDbBun({
   baseTable: BaseTableZod,
   dbPath: './db',
   migrationsPath: './migrations',

--- a/packages/test-factory/package.json
+++ b/packages/test-factory/package.json
@@ -34,8 +34,10 @@
     }
   },
   "scripts": {
-    "test": "jest --watch --verbose false",
+    "test": "jest --watch --reporters default --verbose false",
+    "bun:test": "bun --bun jest --watch --reporters default --verbose false --runInBand",
     "check": "jest",
+    "bun:check": "bun --bun jest --runInBand",
     "check:coverage": "jest --coverage --coverageReporters json-summary",
     "types": "tsc",
     "build": "rimraf ./dist/ && rolldown -c ../../rolldown.config.mjs",

--- a/packages/test-factory/src/factory.test.ts
+++ b/packages/test-factory/src/factory.test.ts
@@ -2,21 +2,18 @@ import { FactoryConfig, ormFactory, tableFactory } from './factory';
 import { db, User, BaseTable, Profile } from './test-utils';
 import { z, ZodObject, ZodRawShape } from 'zod/v4';
 import { orchidORMWithAdapter } from 'orchid-orm';
-import {
-  ColumnsShape,
-  makeColumnTypes,
-  DefaultColumnTypes,
-} from 'pqb/internal';
+import { ColumnsShape, DefaultColumnTypes } from 'pqb/internal';
 import {
   assertType,
   testAdapter,
+  zodColumnTypes,
   testDbOptions,
   useTestDatabase,
 } from 'test-utils';
-import { zodSchemaConfig, ZodSchemaConfig } from 'orchid-orm-schema-to-zod';
+import { ZodSchemaConfig } from 'orchid-orm-schema-to-zod';
 import { faker } from '@faker-js/faker';
 
-const t = makeColumnTypes(zodSchemaConfig);
+const t = zodColumnTypes;
 
 describe('factory', () => {
   useTestDatabase();
@@ -715,8 +712,6 @@ describe('factory', () => {
   });
 
   describe('unique columns', () => {
-    const columnTypes = makeColumnTypes(zodSchemaConfig);
-
     const makeTable = <T extends ColumnsShape>(
       fn: (t: DefaultColumnTypes<ZodSchemaConfig>) => T,
     ) => {
@@ -724,7 +719,7 @@ describe('factory', () => {
         readonly table = 'table';
         columns = this.setColumns((t) => ({
           id: t.identity().primaryKey(),
-          ...fn(columnTypes),
+          ...fn(zodColumnTypes),
         }));
       };
     };

--- a/packages/test-factory/src/factory.ts
+++ b/packages/test-factory/src/factory.ts
@@ -500,7 +500,9 @@ const isoTime = (c: Column.Pick.Data, sequence: number) => {
           from: data.min || new Date(-8640000000000000),
           to: data.max || new Date(8640000000000000),
         })
-      : new Date((fixedTime ??= faker.date.anytime()).getTime() + sequence)
+      : new Date(
+          (fixedTime ??= faker.date.anytime()).getTime() + sequence * 1000,
+        )
   ).toISOString();
 };
 

--- a/packages/test-utils/src/test-db.ts
+++ b/packages/test-utils/src/test-db.ts
@@ -4,10 +4,16 @@ import {
   orchidORMWithAdapter,
 } from 'orchid-orm';
 import { PickQueryQ } from 'pqb/internal';
-import { now, testAdapter, testColumnTypes } from './test-utils';
+import {
+  now,
+  testAdapter,
+  testColumnTypes,
+  testDefaultSchemaConfig,
+} from './test-utils';
 
 export const BaseTable = createBaseTable({
   snakeCase: true,
+  schemaConfig: () => testDefaultSchemaConfig,
   columnTypes: testColumnTypes,
 });
 

--- a/packages/test-utils/src/test-utils.ts
+++ b/packages/test-utils/src/test-utils.ts
@@ -1,5 +1,9 @@
 import { testTransaction, createDbWithAdapter } from 'pqb';
-import { AdapterClass } from 'pqb/internal';
+import {
+  AdapterClass,
+  DriverAdapter,
+  SchemaConfigFnWithOptions,
+} from 'pqb/internal';
 import { Column } from 'pqb/internal';
 import {
   makeColumnTypes,
@@ -15,6 +19,7 @@ import { zodSchemaConfig, ZodSchemaConfig } from 'orchid-orm-schema-to-zod';
 import {
   createDb as nodePostgresCreateDb,
   NodePostgresAdapter,
+  nodePostgresSchemaConfig,
 } from 'pqb/node-postgres';
 import { orchidORM as nodePostgresOrchidORM } from '../../orm/src/adapters/node-postgres';
 import { rakeDb as nodePostgresRakeDb } from '../../rake-db/src/adapters/node-postgres';
@@ -24,8 +29,11 @@ import {
 } from 'pqb/postgres-js';
 import { orchidORM as postgresJsOrchidORM } from '../../orm/src/adapters/postgres-js';
 import { rakeDb as postgresJsRakeDb } from '../../rake-db/src/adapters/postgres-js';
+import { createDb as bunCreateDb, BunAdapter, bunSchemaConfig } from 'pqb/bun';
+import { orchidORM as bunOrchidORM } from '../../orm/src/adapters/bun';
+import { rakeDb as bunsRakeDb } from '../../rake-db/src/adapters/bun';
 
-export type TestAdapterName = 'postgres-js' | 'node-postgres';
+export type TestAdapterName = 'postgres-js' | 'node-postgres' | 'bun';
 
 export const defaultAdapter: TestAdapterName = 'postgres-js';
 
@@ -42,25 +50,56 @@ const adapterSetups = {
     orchidORM: postgresJsOrchidORM,
     rakeDb: postgresJsRakeDb,
   }),
+  bun: () => ({
+    TestAdapter: BunAdapter,
+    createDb: bunCreateDb,
+    orchidORM: bunOrchidORM,
+    rakeDb: bunsRakeDb,
+  }),
 } as const;
 
 const isTestAdapterName = (adapter: string): adapter is TestAdapterName =>
   adapter in adapterSetups;
 
-const adapterName = process.env.ADAPTER || defaultAdapter;
+export const testAdapterName = (process.env.ADAPTER ||
+  defaultAdapter) as TestAdapterName;
 
-if (!isTestAdapterName(adapterName)) {
+if (!isTestAdapterName(testAdapterName)) {
   throw new Error(
-    `Invalid ADAPTER "${adapterName}", expected "postgres-js" or "node-postgres"`,
+    `Invalid ADAPTER "${testAdapterName}", expected "postgres-js" or "node-postgres"`,
   );
 }
 
-const driverItems = adapterSetups[adapterName]();
+const driverItems = adapterSetups[testAdapterName]();
 
-export const allDriverAdapters = {
-  nodePostgres: NodePostgresAdapter,
-  postgresJs: PostgresJsAdapter,
-};
+export const allDriverAdapters: {
+  [K in TestAdapterName]?: {
+    adapter: DriverAdapter;
+    schemaConfig?: SchemaConfigFnWithOptions;
+  };
+} = process.versions.bun
+  ? {
+      bun: {
+        adapter: BunAdapter,
+        schemaConfig: bunSchemaConfig,
+      },
+    }
+  : {
+      'node-postgres': {
+        adapter: NodePostgresAdapter,
+        schemaConfig: nodePostgresSchemaConfig,
+      },
+      'postgres-js': {
+        adapter: PostgresJsAdapter,
+      },
+    };
+
+export const testAdapterConfig =
+  allDriverAdapters[testAdapterName]?.schemaConfig;
+
+export const testJsonValue = (x: unknown): unknown =>
+  !(testAdapterConfig?.jsonEncodedByDriver ?? true) ? JSON.stringify(x) : x;
+
 export const TestAdapter = driverItems.TestAdapter;
 export const createTestDb = driverItems.createDb;
 export const testOrchidORM = driverItems.orchidORM;
@@ -75,22 +114,24 @@ export const testDbOptions = {
   onnotice: noop,
 };
 
-export const testSchemaConfig = zodSchemaConfig;
+export const testSchemaConfig = zodSchemaConfig();
 
 export const testAdapter = new AdapterClass({
   driverAdapter: TestAdapter,
   config: testDbOptions,
 });
 
-export const columnTypes = makeColumnTypes(defaultSchemaConfig);
+export const testDefaultSchemaConfig = defaultSchemaConfig(testAdapterConfig);
+
+export const testDefaultColumnTypes = makeColumnTypes(testDefaultSchemaConfig);
 
 export const testColumnTypes = {
-  ...columnTypes,
+  ...testDefaultColumnTypes,
   timestamp(precision?: number) {
-    return columnTypes.timestamp(precision).asDate();
+    return testDefaultColumnTypes.timestamp(precision).asDate();
   },
   timestampNoTZ(precision?: number) {
-    return columnTypes.timestampNoTZ(precision).asDate();
+    return testDefaultColumnTypes.timestampNoTZ(precision).asDate();
   },
 };
 
@@ -104,7 +145,9 @@ export const testDb = createDbWithAdapter({
 
 export const { sql } = testDb;
 
-const zodColumnTypes = makeColumnTypes(zodSchemaConfig);
+export const zodColumnTypes = makeColumnTypes(
+  zodSchemaConfig(testDefaultSchemaConfig),
+);
 
 export const testZodColumnTypes = {
   ...zodColumnTypes,

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,89 @@
+# Patches
+
+This directory contains pnpm patches for third-party packages.
+
+## `jest-runtime@30.4.2.patch`
+
+`pnpm pqb bun:check bun.test` runs Jest under Bun. Jest 30 copies static properties from Node's `Module` class with direct assignment:
+
+```js
+Module[key] = value;
+```
+
+In Bun, `node:module`.Module exposes `prototype` as an enumerable property. The subclass already has a readonly own `prototype`, so the assignment throws:
+
+```text
+TypeError: Attempted to assign to readonly property.
+```
+
+The patch changes the copy loop to define properties by descriptor. Existing own descriptors on the subclass are preserved, and missing properties are added with writable/enumerable/configurable descriptors.
+
+## `jest-message-util@30.4.1.patch`
+
+`ADAPTER=bun pnpm pqb bun:check string.test` can fail with an assertion error whose useful message is present on `error.message`, but missing from Bun's `error.stack`.
+
+Jest formats test failures from `error.stack` first. In Node, assertion error stacks usually start with the assertion message, so this works. In Bun, the stack for this failure starts with a frame instead:
+
+```text
+@/home/romeo/dev/my/orchid-orm/packages/pqb/src/columns/column-types/string.test.ts:84:36
+processTicksAndRejections@
+```
+
+Jest's stack parser treats the first line as the message and never falls back to `error.message`, so the report loses the important assertion details and prints only the frame.
+
+The patch changes `jest-message-util` to compare the parsed stack message with `error.message`. When the parsed message does not contain the real error message, the parsed line is moved back into the stack and `error.message` is used as the displayed message.
+
+This restores output such as:
+
+```text
+expect(received).toBe(expected) // Object.is equality
+
+Expected: "\\x74657874"
+Received: {"data": [116, 101, 120, 116], "type": "Buffer"}
+```
+
+The patch is registered in the root `package.json` under `pnpm.patchedDependencies`, and the resolved patch hash is recorded in `pnpm-lock.yaml`.
+
+## `jest-util@30.4.1.patch`
+
+`pnpm pqb bun:check bun.test` runs Jest under Bun, and Jest protects copied global objects by recursively reading their properties in `protectProperties`.
+
+That recursion reads properties from constructor prototypes such as:
+
+```js
+Reflect.get(ReadableStreamBYOBReader.prototype, 'closed');
+```
+
+Bun's stream reader and writer prototypes have brand-checked accessors. Those accessors can only be read from real instances, not from the prototype object itself. Reading them during Jest's global cleanup setup reports errors such as:
+
+```text
+TypeError: The ReadableStreamBYOBReader.closed getter can only be used on instances of ReadableStreamBYOBReader
+```
+
+Jest already catches the thrown accessor read, but Bun still prints the error from these brand-checked native getters. The patch makes `protectProperties` inspect the property descriptor before reading a property. If the property is an accessor, Jest skips recursive protection for that property instead of invoking the getter.
+
+This keeps Jest's global cleanup protection for data properties while avoiding side effects from native getters that require a specific receiver.
+
+## `jest-circus@30.4.2.patch`
+
+After the stream accessor issue is avoided, the same Bun test can still fail inside Jest's test timeout handling:
+
+```text
+TypeError: undefined is not an object (evaluating 'timeoutID.unref')
+```
+
+In this runtime combination, `jest-circus` can run with timer globals that are missing or do not return the Node-style timeout handle Jest expects. The unpatched code captures `setTimeout` and `clearTimeout` from `globalThis`, schedules an internal test timeout, and then always calls:
+
+```js
+timeoutID.unref?.();
+```
+
+When the timer binding is unavailable or no timeout handle was created, that cleanup path throws instead of finishing the test.
+
+The patch falls back to `node:timers` when `globalThis.setTimeout` or `globalThis.clearTimeout` is missing, and changes the cleanup call to:
+
+```js
+timeoutID?.unref?.();
+```
+
+This gives Jest a stable timer implementation for its own internal timeout bookkeeping and avoids dereferencing an absent timeout handle.

--- a/patches/jest-circus@30.4.2.patch
+++ b/patches/jest-circus@30.4.2.patch
@@ -1,0 +1,26 @@
+diff --git a/build/jestAdapterInit.js b/build/jestAdapterInit.js
+index 7ea71fc07141d8835a35f81dad73a3689c0dda48..a9760949be2453ef112257167a90400a5575ff97 100644
+--- a/build/jestAdapterInit.js
++++ b/build/jestAdapterInit.js
+@@ -1480,9 +1480,10 @@ const _makeTimeoutMessage = (timeout, isHook, takesDoneCallback) => `Exceeded ti
+ 
+ // Global values can be overwritten by mocks or tests. We'll capture
+ // the original values in the variables before we require any files.
++const nodeTimers = require("node:timers");
+ const {
+-  setTimeout,
+-  clearTimeout
++  setTimeout = nodeTimers.setTimeout,
++  clearTimeout = nodeTimers.clearTimeout
+ } = globalThis;
+ function checkIsError(error) {
+   return !!(error && error.message && error.stack);
+@@ -1585,7 +1586,7 @@ const callAsyncCircusFn = (testOrHook, testContext, {
+     completed = true;
+     // If timeout is not cleared/unrefed the node process won't exit until
+     // it's resolved.
+-    timeoutID.unref?.();
++    timeoutID?.unref?.();
+     clearTimeout(timeoutID);
+   });
+ };

--- a/patches/jest-message-util@30.4.1.patch
+++ b/patches/jest-message-util@30.4.1.patch
@@ -1,0 +1,18 @@
+diff --git a/build/index.js b/build/index.js
+index 5fb9ccc2c3611ee7840c4ea734b3c243916743fc..32db34b8b5f05982f61c3fd5a248db96dd0078b5 100644
+--- a/build/index.js
++++ b/build/index.js
+@@ -292,6 +292,13 @@ function formatErrorStack(errorOrStack, config, options, testPath) {
+     message,
+     stack
+   } = separateMessageFromStack(sourceStack);
++  if (typeof errorOrStack !== 'string' && errorOrStack.message) {
++    const errorMessage = trim(errorOrStack.message);
++    if (!message.includes(errorMessage)) {
++      stack = message ? `${message}\n${stack}` : stack;
++      message = errorOrStack.message;
++    }
++  }
+   stack = options.noStackTrace ? '' : `${STACK_TRACE_COLOR(formatStackTrace(stack, config, options, testPath))}\n`;
+   message = checkForCommonEnvironmentErrors(message);
+   message = indentAllLines(message);

--- a/patches/jest-runtime@30.4.2.patch
+++ b/patches/jest-runtime@30.4.2.patch
@@ -1,0 +1,20 @@
+diff --git a/build/index.js b/build/index.js
+index 4cb3d652eb5112027234ed799f1ba6913654aaa5..925f62f2ea29300d2d83108a10698900a0c10a27 100644
+--- a/build/index.js
++++ b/build/index.js
+@@ -3061,8 +3061,13 @@ class CoreModuleProvider {
+     };
+     class Module extends _nodeModule().default.Module {}
+     for (const [key, value] of Object.entries(_nodeModule().default.Module)) {
+-      // @ts-expect-error: no index signature
+-      Module[key] = value;
++      const desc = Object.getOwnPropertyDescriptor(Module, key) || {
++        value,
++        writable: true,
++        enumerable: true,
++        configurable: true
++      };
++      Object.defineProperty(Module, key, desc);
+     }
+     Module.Module = Module;
+     if ('createRequire' in _nodeModule().default) {

--- a/patches/jest-util@30.4.1.patch
+++ b/patches/jest-util@30.4.1.patch
@@ -1,0 +1,32 @@
+diff --git a/build/index.js b/build/index.js
+index 5bf6efb757332bb7a7108cf8f3f75e39c9b22818..ba2a127c1c6099368fcae27b5fff71a3acbe31cf 100644
+--- a/build/index.js
++++ b/build/index.js
+@@ -480,6 +480,9 @@ function protectProperties(value, properties = [], depth = 2) {
+       });
+       for (const key of getProtectedKeys(value, properties)) {
+         try {
++          if (hasAccessor(value, key)) {
++            continue;
++          }
+           const nested = Reflect.get(value, key);
+           protectProperties(nested, [], depth - 1);
+         } catch {
+@@ -494,6 +497,17 @@ function protectProperties(value, properties = [], depth = 2) {
+     process.emitWarning = originalEmitWarning;
+   }
+ }
++function hasAccessor(value, key) {
++  let current = value;
++  while (current) {
++    const descriptor = Reflect.getOwnPropertyDescriptor(current, key);
++    if (descriptor) {
++      return descriptor.get !== undefined;
++    }
++    current = Reflect.getPrototypeOf(current);
++  }
++  return false;
++}
+ 
+ /**
+  * Whether the given value has properties that can be deleted (regardless of protection).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,20 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  jest-circus@30.4.2:
+    hash: 1d8ed32a9c9ea3251c68315d88a9fdf04c6e50a16abf5140df8de41ed2e9d72c
+    path: patches/jest-circus@30.4.2.patch
+  jest-message-util@30.4.1:
+    hash: 4d4c61a0476d141b78a8d51fd315f9315244bea6227245584b7b63898c0e6975
+    path: patches/jest-message-util@30.4.1.patch
+  jest-runtime@30.4.2:
+    hash: fbae5bb41e8a9b5bffe916395e41f40377d5566e47eb8da988ef2e184f944de7
+    path: patches/jest-runtime@30.4.2.patch
+  jest-util@30.4.1:
+    hash: 4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7
+    path: patches/jest-util@30.4.1.patch
+
 importers:
 
   .:
@@ -243,10 +257,6 @@ importers:
 
 packages:
 
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
-
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
@@ -255,24 +265,12 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.24.7':
-    resolution: {integrity: sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/compat-data@7.29.7':
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.24.7':
-    resolution: {integrity: sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/core@7.29.7':
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.24.7':
-    resolution: {integrity: sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.7':
@@ -283,43 +281,17 @@ packages:
     resolution: {integrity: sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@babel/helper-compilation-targets@7.24.7':
-    resolution: {integrity: sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-compilation-targets@7.29.7':
     resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-environment-visitor@7.24.7':
-    resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-function-name@7.24.7':
-    resolution: {integrity: sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-hoist-variables@7.24.7':
-    resolution: {integrity: sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.24.7':
-    resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-module-imports@7.29.7':
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.24.7':
-    resolution: {integrity: sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
 
   '@babel/helper-module-transforms@7.29.7':
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
@@ -327,24 +299,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-plugin-utils@7.24.7':
-    resolution: {integrity: sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-plugin-utils@7.29.7':
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-simple-access@7.24.7':
-    resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-split-export-declaration@7.24.7':
-    resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-string-parser@7.24.7':
-    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.29.7':
@@ -367,26 +323,13 @@ packages:
     resolution: {integrity: sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@babel/helper-validator-option@7.24.7':
-    resolution: {integrity: sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.24.7':
-    resolution: {integrity: sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.24.7':
-    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
@@ -493,24 +436,12 @@ packages:
     resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.24.7':
-    resolution: {integrity: sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.24.7':
-    resolution: {integrity: sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.24.7':
-    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -1861,11 +1792,6 @@ packages:
   breakword@1.0.6:
     resolution: {integrity: sha512-yjxDAYyK/pBvws9H4xKYpLDpYKEH6CzrBPAuXq3x18I+c/2MkVtT3qAr7Oloi6Dss9qNhPVueAAVU1CSeNDIXw==}
 
-  browserslist@4.23.1:
-    resolution: {integrity: sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -1900,9 +1826,6 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-
-  caniuse-lite@1.0.30001636:
-    resolution: {integrity: sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==}
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
@@ -2084,9 +2007,6 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  electron-to-chromium@1.4.805:
-    resolution: {integrity: sha512-8W4UJwX/w9T0QSzINJckTKG6CYpAUTqsaWcWIsdud3I1FYJcMgW9QqT1/4CBff/pP/TihWh13OmiyY8neto6vw==}
 
   electron-to-chromium@1.5.364:
     resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
@@ -2293,10 +2213,6 @@ packages:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  globals@11.12.0:
-    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
-    engines: {node: '>=4'}
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -2666,11 +2582,6 @@ packages:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
 
-  jsesc@2.5.2:
-    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -2868,9 +2779,6 @@ packages:
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
-
-  node-releases@2.0.14:
-    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
 
   node-releases@2.0.46:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
@@ -3444,10 +3352,6 @@ packages:
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
-  to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -3579,12 +3483,6 @@ packages:
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
-  update-browserslist-db@1.0.16:
-    resolution: {integrity: sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -3698,11 +3596,6 @@ packages:
 
 snapshots:
 
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -3715,29 +3608,7 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.24.7': {}
-
   '@babel/compat-data@7.29.7': {}
-
-  '@babel/core@7.24.7':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.24.7
-      '@babel/helper-compilation-targets': 7.24.7
-      '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.7)
-      '@babel/helpers': 7.24.7
-      '@babel/parser': 7.24.7
-      '@babel/template': 7.24.7
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/core@7.29.7':
     dependencies:
@@ -3759,13 +3630,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.24.7':
-    dependencies:
-      '@babel/types': 7.24.7
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 2.5.2
-
   '@babel/generator@7.29.7':
     dependencies:
       '@babel/parser': 7.29.7
@@ -3783,14 +3647,6 @@ snapshots:
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.24.7':
-    dependencies:
-      '@babel/compat-data': 7.24.7
-      '@babel/helper-validator-option': 7.24.7
-      browserslist: 4.23.1
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
       '@babel/compat-data': 7.29.7
@@ -3799,43 +3655,12 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-environment-visitor@7.24.7':
-    dependencies:
-      '@babel/types': 7.24.7
-
-  '@babel/helper-function-name@7.24.7':
-    dependencies:
-      '@babel/template': 7.24.7
-      '@babel/types': 7.24.7
-
   '@babel/helper-globals@7.29.7': {}
-
-  '@babel/helper-hoist-variables@7.24.7':
-    dependencies:
-      '@babel/types': 7.24.7
-
-  '@babel/helper-module-imports@7.24.7':
-    dependencies:
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.24.7(@babel/core@7.24.7)':
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/helper-validator-identifier': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -3848,22 +3673,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-plugin-utils@7.24.7': {}
-
   '@babel/helper-plugin-utils@7.29.7': {}
-
-  '@babel/helper-simple-access@7.24.7':
-    dependencies:
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-split-export-declaration@7.24.7':
-    dependencies:
-      '@babel/types': 7.24.7
-
-  '@babel/helper-string-parser@7.24.7': {}
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -3875,23 +3685,12 @@ snapshots:
 
   '@babel/helper-validator-identifier@8.0.0-rc.3': {}
 
-  '@babel/helper-validator-option@7.24.7': {}
-
   '@babel/helper-validator-option@7.29.7': {}
-
-  '@babel/helpers@7.24.7':
-    dependencies:
-      '@babel/template': 7.24.7
-      '@babel/types': 7.24.7
 
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-
-  '@babel/parser@7.24.7':
-    dependencies:
-      '@babel/types': 7.24.7
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -3904,22 +3703,22 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -3929,12 +3728,12 @@ snapshots:
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -3944,42 +3743,42 @@ snapshots:
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -3990,32 +3789,11 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@babel/template@7.24.7':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
-
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
-
-  '@babel/traverse@7.24.7':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-function-name': 7.24.7
-      '@babel/helper-hoist-variables': 7.24.7
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
-      debug: 4.4.3
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.29.7':
     dependencies:
@@ -4028,12 +3806,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.24.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.24.7
-      '@babel/helper-validator-identifier': 7.28.5
-      to-fast-properties: 2.0.0
 
   '@babel/types@7.29.7':
     dependencies:
@@ -4409,8 +4181,8 @@ snapshots:
       '@jest/types': 30.4.1
       '@types/node': 18.16.0
       chalk: 4.1.2
-      jest-message-util: 30.4.1
-      jest-util: 30.4.1
+      jest-message-util: 30.4.1(patch_hash=4d4c61a0476d141b78a8d51fd315f9315244bea6227245584b7b63898c0e6975)
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       slash: 3.0.0
 
   '@jest/core@30.4.2(ts-node@10.9.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@18.16.0)(typescript@6.0.2))':
@@ -4431,14 +4203,14 @@ snapshots:
       jest-changed-files: 30.4.1
       jest-config: 30.4.2(@types/node@18.16.0)(ts-node@10.9.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@18.16.0)(typescript@6.0.2))
       jest-haste-map: 30.4.1
-      jest-message-util: 30.4.1
+      jest-message-util: 30.4.1(patch_hash=4d4c61a0476d141b78a8d51fd315f9315244bea6227245584b7b63898c0e6975)
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
       jest-resolve-dependencies: 30.4.2
       jest-runner: 30.4.2
-      jest-runtime: 30.4.2
+      jest-runtime: 30.4.2(patch_hash=fbae5bb41e8a9b5bffe916395e41f40377d5566e47eb8da988ef2e184f944de7)
       jest-snapshot: 30.4.1
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       jest-validate: 30.4.1
       jest-watcher: 30.4.1
       pretty-format: 30.4.1
@@ -4478,9 +4250,9 @@ snapshots:
       '@jest/types': 30.4.1
       '@sinonjs/fake-timers': 15.4.0
       '@types/node': 18.16.0
-      jest-message-util: 30.4.1
+      jest-message-util: 30.4.1(patch_hash=4d4c61a0476d141b78a8d51fd315f9315244bea6227245584b7b63898c0e6975)
       jest-mock: 30.4.1
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
 
   '@jest/get-type@30.1.0': {}
 
@@ -4522,8 +4294,8 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
-      jest-message-util: 30.4.1
-      jest-util: 30.4.1
+      jest-message-util: 30.4.1(patch_hash=4d4c61a0476d141b78a8d51fd315f9315244bea6227245584b7b63898c0e6975)
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       jest-worker: 30.4.1
       slash: 3.0.0
       string-length: 4.0.2
@@ -4578,7 +4350,7 @@ snapshots:
       graceful-fs: 4.2.11
       jest-haste-map: 30.4.1
       jest-regex-util: 30.4.0
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       pirates: 4.0.7
       slash: 3.0.0
       write-file-atomic: 5.0.1
@@ -4945,24 +4717,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.20.6':
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.29.7
 
   '@types/estree@1.0.8': {}
 
@@ -5197,7 +4969,7 @@ snapshots:
 
   babel-plugin-istanbul@7.0.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 6.0.2
@@ -5261,13 +5033,6 @@ snapshots:
     dependencies:
       wcwidth: 1.0.1
 
-  browserslist@4.23.1:
-    dependencies:
-      caniuse-lite: 1.0.30001636
-      electron-to-chromium: 1.4.805
-      node-releases: 2.0.14
-      update-browserslist-db: 1.0.16(browserslist@4.23.1)
-
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.33
@@ -5303,8 +5068,6 @@ snapshots:
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
-
-  caniuse-lite@1.0.30001636: {}
 
   caniuse-lite@1.0.30001793: {}
 
@@ -5464,8 +5227,6 @@ snapshots:
   dts-resolver@2.1.3: {}
 
   eastasianwidth@0.2.0: {}
-
-  electron-to-chromium@1.4.805: {}
 
   electron-to-chromium@1.5.364: {}
 
@@ -5648,9 +5409,9 @@ snapshots:
       '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
       jest-matcher-utils: 30.4.1
-      jest-message-util: 30.4.1
+      jest-message-util: 30.4.1(patch_hash=4d4c61a0476d141b78a8d51fd315f9315244bea6227245584b7b63898c0e6975)
       jest-mock: 30.4.1
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
 
   extendable-error@0.1.7: {}
 
@@ -5788,8 +5549,6 @@ snapshots:
       minimatch: 8.0.7
       minipass: 4.2.8
       path-scurry: 1.11.1
-
-  globals@11.12.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -5970,11 +5729,11 @@ snapshots:
 
   istanbul-lib-instrument@6.0.2:
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/parser': 7.24.7
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.6.2
+      semver: 7.8.1
     transitivePeerDependencies:
       - supports-color
 
@@ -6006,10 +5765,10 @@ snapshots:
   jest-changed-files@30.4.1:
     dependencies:
       execa: 5.1.1
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       p-limit: 3.1.0
 
-  jest-circus@30.4.2:
+  jest-circus@30.4.2(patch_hash=1d8ed32a9c9ea3251c68315d88a9fdf04c6e50a16abf5140df8de41ed2e9d72c):
     dependencies:
       '@jest/environment': 30.4.1
       '@jest/expect': 30.4.1
@@ -6022,10 +5781,10 @@ snapshots:
       is-generator-fn: 2.1.0
       jest-each: 30.4.1
       jest-matcher-utils: 30.4.1
-      jest-message-util: 30.4.1
-      jest-runtime: 30.4.2
+      jest-message-util: 30.4.1(patch_hash=4d4c61a0476d141b78a8d51fd315f9315244bea6227245584b7b63898c0e6975)
+      jest-runtime: 30.4.2(patch_hash=fbae5bb41e8a9b5bffe916395e41f40377d5566e47eb8da988ef2e184f944de7)
       jest-snapshot: 30.4.1
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       p-limit: 3.1.0
       pretty-format: 30.4.1
       pure-rand: 7.0.1
@@ -6044,7 +5803,7 @@ snapshots:
       exit-x: 0.2.2
       import-local: 3.2.0
       jest-config: 30.4.2(@types/node@18.16.0)(ts-node@10.9.2(@swc/core@1.15.24(@swc/helpers@0.5.21))(@types/node@18.16.0)(typescript@6.0.2))
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       jest-validate: 30.4.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -6067,13 +5826,13 @@ snapshots:
       deepmerge: 4.3.1
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-circus: 30.4.2
+      jest-circus: 30.4.2(patch_hash=1d8ed32a9c9ea3251c68315d88a9fdf04c6e50a16abf5140df8de41ed2e9d72c)
       jest-docblock: 30.4.0
       jest-environment-node: 30.4.1
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
       jest-runner: 30.4.2
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       jest-validate: 30.4.1
       parse-json: 5.2.0
       pretty-format: 30.4.1
@@ -6102,7 +5861,7 @@ snapshots:
       '@jest/get-type': 30.1.0
       '@jest/types': 30.4.1
       chalk: 4.1.2
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       pretty-format: 30.4.1
 
   jest-environment-node@30.4.1:
@@ -6112,7 +5871,7 @@ snapshots:
       '@jest/types': 30.4.1
       '@types/node': 18.16.0
       jest-mock: 30.4.1
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       jest-validate: 30.4.1
 
   jest-haste-map@30.4.1:
@@ -6123,7 +5882,7 @@ snapshots:
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
       jest-regex-util: 30.4.0
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       jest-worker: 30.4.1
       picomatch: 4.0.4
       walker: 1.0.8
@@ -6142,14 +5901,14 @@ snapshots:
       jest-diff: 30.4.1
       pretty-format: 30.4.1
 
-  jest-message-util@30.4.1:
+  jest-message-util@30.4.1(patch_hash=4d4c61a0476d141b78a8d51fd315f9315244bea6227245584b7b63898c0e6975):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@jest/types': 30.4.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       picomatch: 4.0.4
       pretty-format: 30.4.1
       slash: 3.0.0
@@ -6159,7 +5918,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.4.1
       '@types/node': 18.16.0
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
     optionalDependencies:
@@ -6182,7 +5941,7 @@ snapshots:
       graceful-fs: 4.2.11
       jest-haste-map: 30.4.1
       jest-pnp-resolver: 1.2.3(jest-resolve@30.4.1)
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       jest-validate: 30.4.1
       slash: 3.0.0
       unrs-resolver: 1.12.2
@@ -6203,10 +5962,10 @@ snapshots:
       jest-environment-node: 30.4.1
       jest-haste-map: 30.4.1
       jest-leak-detector: 30.4.1
-      jest-message-util: 30.4.1
+      jest-message-util: 30.4.1(patch_hash=4d4c61a0476d141b78a8d51fd315f9315244bea6227245584b7b63898c0e6975)
       jest-resolve: 30.4.1
-      jest-runtime: 30.4.2
-      jest-util: 30.4.1
+      jest-runtime: 30.4.2(patch_hash=fbae5bb41e8a9b5bffe916395e41f40377d5566e47eb8da988ef2e184f944de7)
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       jest-watcher: 30.4.1
       jest-worker: 30.4.1
       p-limit: 3.1.0
@@ -6214,7 +5973,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@30.4.2:
+  jest-runtime@30.4.2(patch_hash=fbae5bb41e8a9b5bffe916395e41f40377d5566e47eb8da988ef2e184f944de7):
     dependencies:
       '@jest/environment': 30.4.1
       '@jest/fake-timers': 30.4.1
@@ -6230,12 +5989,12 @@ snapshots:
       glob: 10.5.0
       graceful-fs: 4.2.11
       jest-haste-map: 30.4.1
-      jest-message-util: 30.4.1
+      jest-message-util: 30.4.1(patch_hash=4d4c61a0476d141b78a8d51fd315f9315244bea6227245584b7b63898c0e6975)
       jest-mock: 30.4.1
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
       jest-snapshot: 30.4.1
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
@@ -6259,15 +6018,15 @@ snapshots:
       graceful-fs: 4.2.11
       jest-diff: 30.4.1
       jest-matcher-utils: 30.4.1
-      jest-message-util: 30.4.1
-      jest-util: 30.4.1
+      jest-message-util: 30.4.1(patch_hash=4d4c61a0476d141b78a8d51fd315f9315244bea6227245584b7b63898c0e6975)
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       pretty-format: 30.4.1
       semver: 7.8.1
       synckit: 0.11.13
     transitivePeerDependencies:
       - supports-color
 
-  jest-util@30.4.1:
+  jest-util@30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7):
     dependencies:
       '@jest/types': 30.4.1
       '@types/node': 18.16.0
@@ -6293,14 +6052,14 @@ snapshots:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       string-length: 4.0.2
 
   jest-worker@30.4.1:
     dependencies:
       '@types/node': 18.16.0
       '@ungap/structured-clone': 1.3.1
-      jest-util: 30.4.1
+      jest-util: 30.4.1(patch_hash=4183310fc2d0dfb1d43d3a3c07ac0aa9412317dd6405933660ebc0035e3360a7)
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -6323,8 +6082,6 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-
-  jsesc@2.5.2: {}
 
   jsesc@3.1.0: {}
 
@@ -6421,7 +6178,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.6.2
+      semver: 7.8.1
 
   make-error@1.3.6:
     optional: true
@@ -6492,8 +6249,6 @@ snapshots:
   natural-compare@1.4.0: {}
 
   node-int64@0.4.0: {}
-
-  node-releases@2.0.14: {}
 
   node-releases@2.0.46: {}
 
@@ -7084,8 +6839,6 @@ snapshots:
 
   tmpl@1.0.5: {}
 
-  to-fast-properties@2.0.0: {}
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -7244,12 +6997,6 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.12.2
       '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
-
-  update-browserslist-db@1.0.16(browserslist@4.23.1):
-    dependencies:
-      browserslist: 4.23.1
-      escalade: 3.1.2
-      picocolors: 1.1.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:

--- a/rolldown.utils.mjs
+++ b/rolldown.utils.mjs
@@ -24,12 +24,14 @@ const getCommonOptions = (from, to, options = {}) => {
     /^node:/,
   ];
 
-  const { externalForFiles, forbidImportFrom } = options;
+  const { allowImportFrom, externalForFiles, forbidImportFrom } = options;
 
   const common = {
     input: `${from}.ts`,
     external(id, fromFile) {
-      if (forbidImportFrom && id.startsWith(forbidImportFrom)) {
+      const allowed = allowImportFrom && id.startsWith(allowImportFrom);
+
+      if (forbidImportFrom && !allowed && id.startsWith(forbidImportFrom)) {
         throw new Error(
           `Failed to build ${from}: cannot import ${id} from ${fromFile}`,
         );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "./packages/orm/src/adapters/node-postgres.ts"
       ],
       "orchid-orm/postgres-js": ["./packages/orm/src/adapters/postgres-js.ts"],
+      "orchid-orm/bun": ["./packages/orm/src/adapters/bun.ts"],
       "orchid-orm/migrations": ["./packages/orm/src/migrations/index.ts"],
       "orchid-orm/migrations/node-postgres": [
         "./packages/orm/src/migrations/adapters/node-postgres.ts"
@@ -15,16 +16,21 @@
       "orchid-orm/migrations/postgres-js": [
         "./packages/orm/src/migrations/adapters/postgres-js.ts"
       ],
+      "orchid-orm/migrations/bun": [
+        "./packages/orm/src/migrations/adapters/bun.ts"
+      ],
       "pqb": ["./packages/pqb/src/public.ts"],
       "pqb/index": ["./packages/pqb/src/index.ts"],
       "pqb/internal": ["./packages/pqb/src/internal.ts"],
       "pqb/node-postgres": ["./packages/pqb/src/adapters/node-postgres.ts"],
       "pqb/postgres-js": ["./packages/pqb/src/adapters/postgres-js.ts"],
+      "pqb/bun": ["./packages/pqb/src/adapters/bun.ts"],
       "rake-db": ["./packages/rake-db/src/index.ts"],
       "rake-db/node-postgres": [
         "./packages/rake-db/src/adapters/node-postgres.ts"
       ],
       "rake-db/postgres-js": ["./packages/rake-db/src/adapters/postgres-js.ts"],
+      "rake-db/bun": ["./packages/rake-db/src/adapters/bun.ts"],
       "orchid-orm-schema-to-zod": ["./packages/schemaConfigs/zod/src/index.ts"],
       "test-utils": ["./packages/test-utils/src/index.ts"]
     },

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
     "check": {
       "env": ["ADAPTER"]
     },
+    "bun:check": {},
     "check:coverage": {
       "env": ["ADAPTER"],
       "outputs": ["coverage/**"]


### PR DESCRIPTION
Adding Bun SQL support.

There are some gotchas with Bun, see `Bun SQL` section in docs once it's published.

Both `node-postgres` and `bun` will require providing their `schemaConfig` to the `createBaseTable` - this is to cover up the discrepancies at how they encode/parse certain column types.