### PR TITLE
Fix named scalar select metadata leaking into source columns

### DIFF
--- a/.changeset/few-teachers-own.md
+++ b/.changeset/few-teachers-own.md
@@ -1,0 +1,6 @@
+---
+'orchid-orm': patch
+'pqb': patch
+---
+
+Fix named scalar select metadata leaking into source column references

--- a/packages/pqb/src/query/basic-features/from/from.ts
+++ b/packages/pqb/src/query/basic-features/from/from.ts
@@ -121,7 +121,9 @@ export function queryFrom<
   if (typeof arg === 'string') {
     data.as ||= arg;
     const w = data.withShapes?.[arg];
-    data.selectShape = (w?.shape ?? anyShape) as ColumnsShape;
+    const shape = (w?.shape ?? anyShape) as ColumnsShape;
+    data.shape = shape;
+    data.selectShape = shape;
     data.runtimeComputeds = w?.computeds;
 
     const parsers: ColumnsParsers = {};
@@ -165,7 +167,9 @@ export function queryFrom<
   } else {
     const q = prepareSubQueryForSql(self as never, arg as never);
     data.as ||= q.q.as || q.table || 't';
-    data.selectShape = getShapeFromSelect(q, true) as ColumnsShape;
+    const shape = getShapeFromSelect(q, true) as ColumnsShape;
+    data.shape = shape;
+    data.selectShape = shape;
     data.defaultParsers = getQueryParsers(q as unknown as Query);
     data.batchParsers = q.q.batchParsers;
   }

--- a/packages/pqb/src/query/basic-features/join/process-join-args.ts
+++ b/packages/pqb/src/query/basic-features/join/process-join-args.ts
@@ -78,6 +78,7 @@ export const processJoinArgs = (
       const j = joinTo.qb.baseQuery.clone();
       j.table = first;
       j.q = {
+        shape: w.shape,
         selectShape: w.shape,
         runtimeComputeds: w.computeds,
         adapter: joinToQ.adapter,
@@ -207,6 +208,7 @@ const makeJoinQueryBuilder = (
   }
 
   if (shape) {
+    q.q.shape = shape as ColumnsShape;
     q.q.selectShape = shape as ColumnsShape;
   }
   return q as never;

--- a/packages/pqb/src/query/basic-features/select/select.test.ts
+++ b/packages/pqb/src/query/basic-features/select/select.test.ts
@@ -360,6 +360,45 @@ describe('select', () => {
       expect(res.updatedAt).toBe(true);
     });
 
+    it('should use table column metadata in where when a named select has the same name', async () => {
+      await User.create(userData);
+
+      const q = User.findByOptional({ name: userData.name }).select({
+        name: (q) => q.get('name').transform((name) => name ?? undefined),
+      });
+
+      assertType<Awaited<typeof q>, { name: string | undefined } | undefined>();
+
+      expectSql(
+        q.toSQL(),
+        `
+          SELECT array["User"."name"] "name" FROM "schema"."user" "User"
+          WHERE "User"."name" = $1
+          LIMIT 1
+        `,
+        [userData.name],
+      );
+
+      expect(await q).toEqual({ name: userData.name });
+    });
+
+    it('should use table column metadata in join and qualified order when a named select has the same name', () => {
+      const q = User.join(Snake, 'snakeName', 'name')
+        .select({
+          name: (q) => q.get('name').transform((name) => name ?? undefined),
+        })
+        .order('User.name');
+
+      expectSql(
+        q.toSQL(),
+        `
+          SELECT array["User"."name"] "name" FROM "schema"."user" "User"
+          JOIN "schema"."snake" "Snake" ON "Snake"."snake_name" = "User"."name"
+          ORDER BY "User"."name" ASC
+        `,
+      );
+    });
+
     describe('loading records', () => {
       beforeEach(insertUserAndProfile);
 

--- a/packages/pqb/src/query/basic-features/where/where.sql.ts
+++ b/packages/pqb/src/query/basic-features/where/where.sql.ts
@@ -66,6 +66,7 @@ export type WhereOnJoinItem = { table?: string; q: { as?: string } } | string;
 interface QueryDataForWhere extends QueryDataAliases {
   and?: QueryData['and'];
   or?: QueryData['or'];
+  shape: QueryData['shape'];
   selectShape: QueryData['selectShape'];
   joinedShapes?: QueryData['joinedShapes'];
   scopes?: { [K: string]: QueryScopeData };
@@ -287,6 +288,7 @@ const processWhere = (
           ? {
               joinedShapes: query.joinedShapes,
               aliases: _getQueryOuterAliases(query),
+              shape: query.shape,
               selectShape: query.selectShape,
             }
           : query;
@@ -373,7 +375,8 @@ const whereExprOrQuery = (
       )} = ${value.toSQL(ctx, quotedAs)}`,
     );
   } else {
-    let column: Column.Pick.QueryColumn | undefined = query.selectShape[key];
+    let column: Column.Pick.QueryColumn | undefined =
+      query.shape[key] || query.selectShape[key];
     if (!column) {
       const index = key.indexOf('.');
       if (index === -1) {
@@ -385,7 +388,7 @@ const whereExprOrQuery = (
 
         column = (
           quotedAs === quoted
-            ? query.selectShape[name]
+            ? query.shape[name] || query.selectShape[name]
             : query.joinedShapes?.[table]?.[name]
         ) as typeof column;
       }
@@ -432,6 +435,7 @@ const whereExprOrQuery = (
 interface OnColumnToSQLQuery {
   joinedShapes?: QueryData['joinedShapes'];
   aliases?: QueryData['aliases'];
+  shape: ColumnsShape;
   selectShape: ColumnsShape;
   select?: SelectItem[];
 }
@@ -450,6 +454,7 @@ const getJoinItemSource = (joinItem: WhereOnJoinItem) => {
 const pushIn = (
   ctx: ToSQLCtx,
   query: {
+    shape: ColumnsShape;
     selectShape: ColumnsShape;
     joinedShapes?: JoinedShapes;
     select?: SelectItem[];

--- a/packages/pqb/src/query/db.ts
+++ b/packages/pqb/src/query/db.ts
@@ -444,6 +444,7 @@ export class Db<
 
     this.q = {
       adapter: adapterNotInTransaction,
+      shape: shape as Column.QueryColumnsInit,
       selectShape: shape as Column.QueryColumnsInit,
       nameInDb: getTableNameInDb(table, options.nameInDb, snakeCase),
       handleResult,

--- a/packages/pqb/src/query/expressions/fn-expression.ts
+++ b/packages/pqb/src/query/expressions/fn-expression.ts
@@ -155,6 +155,7 @@ export class FnExpression<
         {
           and: options.filter ? ([options.filter] as WhereItem[]) : undefined,
           or: options.filterOr?.map((item) => [item]) as WhereItem[][],
+          shape: q.shape,
           selectShape: q.selectShape,
           joinedShapes: q.joinedShapes,
         },

--- a/packages/pqb/src/query/expressions/query-expressions.ts
+++ b/packages/pqb/src/query/expressions/query-expressions.ts
@@ -114,7 +114,7 @@ export class QueryExpressions {
     T['__selectable'][K]['column']['operators'] {
     const q = _clone(this);
 
-    const { selectShape } = q.q;
+    const { shape, selectShape } = q.q;
     let column: Column.Pick.QueryColumn | undefined;
 
     const index = arg.indexOf('.');
@@ -123,12 +123,12 @@ export class QueryExpressions {
       const table = getFullColumnTable(q, arg, index, as);
       const col = arg.slice(index + 1);
       if (table === as) {
-        column = selectShape[col];
+        column = shape[col] || selectShape[col];
       } else {
         column = q.q.joinedShapes?.[table][col];
       }
     } else {
-      column = selectShape[arg];
+      column = shape[arg] || selectShape[arg];
     }
 
     return new RefExpression(column || UnknownColumn.instance, q, arg) as never;

--- a/packages/pqb/src/query/extra-features/merge/merge.ts
+++ b/packages/pqb/src/query/extra-features/merge/merge.ts
@@ -64,6 +64,7 @@ type MergeQueryResult<
   : Q['result'];
 
 const mergableObjects = new Set([
+  'shape',
   'selectShape',
   'withShapes',
   'defaultParsers',

--- a/packages/pqb/src/query/query-data.ts
+++ b/packages/pqb/src/query/query-data.ts
@@ -145,6 +145,8 @@ export interface QueryData
     MutativeQueriesSelectRelationsQueryData {
   type: QueryType;
   adapter: Adapter;
+  // Columns exposed by the query source, without columns added by select.
+  shape: ColumnsShape;
   selectShape: ColumnsShape;
   // Database relation name used when it differs from the query-facing table alias.
   nameInDb?: string;

--- a/packages/pqb/src/query/sql/column-to-sql.ts
+++ b/packages/pqb/src/query/sql/column-to-sql.ts
@@ -8,6 +8,21 @@ import { Expression, SelectableOrExpression } from '../expressions/expression';
 import { getSelectedColumnData, makeRowToJson } from './sql';
 import { SelectItem } from '../basic-features/select/select.sql';
 
+interface ColumnShapesData {
+  shape?: Column.QueryColumns;
+  selectShape?: Column.QueryColumns;
+}
+
+const getColumnFromShape = (
+  data: ColumnShapesData,
+  shape: Column.QueryColumns,
+  key: string,
+  select?: true,
+) =>
+  !select && shape === data.selectShape
+    ? data.shape?.[key] || shape[key]
+    : shape[key];
+
 // Takes a column name without a dot and the optional column object.
 // Handles computed column, uses column.data.name when set, prefixes regular column with `quotedAs`.
 // Returns quoted key if no column is provided.
@@ -116,6 +131,8 @@ export const tableColumnToSql = (
     parsers?: ColumnsParsers;
     select?: SelectItem[];
     getColumn?: Column;
+    shape?: Column.QueryColumns;
+    selectShape?: Column.QueryColumns;
   },
   shape: Column.QueryColumns,
   table: string,
@@ -148,7 +165,7 @@ export const tableColumnToSql = (
     const quoted = `"${table}"`;
 
     const col = (quoted === quotedAs
-      ? shape[key]
+      ? getColumnFromShape(queryData, shape, key, select)
       : queryData.joinedShapes?.[tableName]?.[key]) as unknown as
       | Column.Pick.Data
       | undefined;
@@ -194,6 +211,8 @@ export const columnToSqlNotSelect = (
     joinedShapes?: QueryData['joinedShapes'];
     parsers?: ColumnsParsers;
     select?: SelectItem[];
+    shape?: Column.QueryColumns;
+    selectShape?: Column.QueryColumns;
   },
   shape: Column.QueryColumns,
   column: string,
@@ -221,6 +240,8 @@ export const columnToSql = (
     joinedShapes?: QueryData['joinedShapes'];
     parsers?: ColumnsParsers;
     select?: SelectItem[];
+    shape?: Column.QueryColumns;
+    selectShape?: Column.QueryColumns;
   },
   shape: Column.QueryColumns,
   column: string,
@@ -249,12 +270,14 @@ export const columnToSql = (
     );
   }
 
+  const selectedColumn = getColumnFromShape(data, shape, column, select);
+
   return simpleColumnToSQL(
     ctx,
     data,
     shape,
     column,
-    shape[column],
+    selectedColumn,
     quotedAs,
     select,
     as,
@@ -270,6 +293,8 @@ export const rawOrColumnToSql = (
   data: {
     joinedShapes?: JoinedShapes;
     select?: SelectItem[];
+    shape?: Column.QueryColumns;
+    selectShape?: Column.QueryColumns;
   },
   shape: Column.QueryColumns,
   expr: SelectableOrExpression,


### PR DESCRIPTION
Disclaimer: pure AI slop below in description and in the code. Patch prepared by Sol, I also cross-checked with Opus.

It includes a regression test, and this is a confirmed regression (caused by #722) in a real project.

## Summary

- keep source column metadata separate from metadata added by named selects
- resolve non-select references from the source shape before falling back to selected aliases
- add regression coverage for `WHERE`, `JOIN`, qualified `ORDER`, runtime transforms, and result types

## Problem

Nested scalar selects use a single-element array to distinguish a found SQL `null` from a missing row.

A named select stored its `valueToArray` column metadata in `selectShape`. When the select alias matched a real table column, it replaced that column's metadata. Later non-select expressions therefore treated the real scalar column as an array value.

For example, this query:

```ts
db.tenant
  .findByOptional({ domain: 'example.com' })
  .select({
    domain: (q) =>
      q.get('domain').transform((domain) => domain ?? undefined),
  })
```

compiled its condition as:

```sql
WHERE "tenant"."domain"[1] = $1
```

PostgreSQL then failed with error `42804` because `varchar` does not support subscripting.

## Fix

`QueryData` now keeps the source shape separately from `selectShape`.

Non-select SQL resolution prefers source column metadata when resolving a real table column and falls back to `selectShape` for aliases that only exist in the selected result. This preserves filtering and ordering by nested scalar select aliases while preventing select-only `valueToArray` metadata from leaking into real table-column references.

Source-changing operations such as `from`, join callback builders, and query merging propagate both shapes.

## Testing

- added a regression test for a same-named scalar `.get(...).transform(...)` select and `findByOptional`
- verified the generated `WHERE` references the scalar column without `[1]`
- verified the query executes and preserves its transformed result type
- added coverage for `JOIN` and qualified `ORDER`
- verified the existing nested scalar select tests still distinguish SQL `null` from a missing row
- ran `pnpm verify`