### PR TITLE
Fix `ref` expressions inheriting source query result parsers

### DIFF
--- a/.changeset/five-zoos-confess.md
+++ b/.changeset/five-zoos-confess.md
@@ -1,0 +1,6 @@
+---
+'orchid-orm': patch
+'pqb': patch
+---
+
+Prevent ref expressions from applying result parsers and transforms inherited from their source query (#735)

--- a/packages/pqb/src/query/expressions/expressions.test.ts
+++ b/packages/pqb/src/query/expressions/expressions.test.ts
@@ -8,6 +8,7 @@ import {
   assertType,
   db,
   expectSql,
+  ProfileData,
   sql,
   testDb,
   UserData,
@@ -196,6 +197,55 @@ describe('expressions', () => {
 
       const res = await q;
       expect(res).toEqual([{ Age: `${Age}` }]);
+    });
+
+    it('should not apply selected relation parsers to a ref', async () => {
+      const user = await db.user.create({
+        ...UserData,
+        profile: { create: ProfileData },
+      });
+
+      const withRelation = db.user.take().select({
+        profile: (q) => q.profile.select('Bio'),
+      });
+
+      const result = await withRelation.select({
+        Id: withRelation.ref('Id'),
+      });
+
+      assertType<
+        typeof result,
+        { profile: { Bio: string | null }; Id: number }
+      >();
+
+      expect(result).toEqual({
+        profile: { Bio: ProfileData.Bio },
+        Id: user.Id,
+      });
+    });
+
+    it('should not apply the source query map to a ref', async () => {
+      const user = await db.user.create(UserData);
+
+      const withMap = db.user
+        .take()
+        .select('Name')
+        .map((user) => ({ ...user, mapped: true }));
+
+      const result = await withMap.select({
+        Id: withMap.ref('Id'),
+      });
+
+      assertType<
+        typeof result,
+        { Name: string; mapped: boolean; Id: number }
+      >();
+
+      expect(result).toEqual({
+        Name: UserData.Name,
+        mapped: true,
+        Id: user.Id,
+      });
     });
   });
 

--- a/packages/pqb/src/query/expressions/query-expressions.ts
+++ b/packages/pqb/src/query/expressions/query-expressions.ts
@@ -131,6 +131,12 @@ export class QueryExpressions {
       column = selectShape[arg];
     }
 
+    // A ref is a scalar expression and must not reuse result processing of the source query.
+    q.q.batchParsers = undefined;
+    q.q.transform = undefined;
+    q.q.hookSelect = undefined;
+    q.q.returnType = undefined;
+
     return new RefExpression(column || UnknownColumn.instance, q, arg) as never;
   }
 


### PR DESCRIPTION
## Summary

- Prevent `ref` expressions from inheriting result parsers and transforms from their source query.
- Add regression coverage for queries with selected relations and `map()`.

## Root cause

`ref()` cloned the complete source query, including its result-processing state.
When the ref was selected under an alias, that state was registered for the ref and incorrectly applied to its scalar value.

## Testing

- `pnpm --filter pqb exec jest src/query/expressions/expressions.test.ts --runInBand` — 15 tests passed.

Fixes #735
