### PR TITLE
Fix `db.$select` generating invalid SQL when a sub-query does `.chain()`

### DIFF
--- a/packages/pqb/src/query/basic-features/join/select-relations.test.ts
+++ b/packages/pqb/src/query/basic-features/join/select-relations.test.ts
@@ -103,4 +103,80 @@ describe('select relations', () => {
 
     expect(res).toEqual({ title: 'title', user: { name: 'name' } });
   });
+
+  // https://github.com/romeerez/orchid-orm/issues/745
+  describe('selecting a relation from a query without a FROM (e.g. `$select`)', () => {
+    const UserTable = defineTable('user', (t) => ({
+      id: t.serial().primaryKey(),
+      name: t.text(),
+      password: t.text(),
+    }));
+
+    const PostTable = defineTable('post', (t) => ({
+      id: t.serial().primaryKey(),
+      userId: t.name('user_id').integer(),
+      title: t.text(),
+      body: t.text(),
+    })).relations((post) => ({
+      user: post('userId').belongsTo(() => UserTable('id')),
+    }));
+
+    const local = orchidORMWithAdapter(ormParams, {
+      user: UserTable,
+      post: PostTable,
+    });
+
+    it('should render a `belongsTo` chain as a scalar sub-query', async () => {
+      await local.post.insert({
+        title: 'title',
+        body: 'body',
+        user: { create: { name: 'name', password: 'password' } },
+      });
+
+      const res = await local.$qb
+        .select({
+          users: () => local.post.chain('user').select('id', 'name'),
+        })
+        .take();
+
+      assertType<typeof res, { users: { id: number; name: string }[] }>();
+
+      expect(res.users).toEqual([{ id: expect.any(Number), name: 'name' }]);
+    });
+
+    it('should coalesce an empty relation result to `[]`', async () => {
+      const res = await local.$qb
+        .select({
+          users: () => local.post.chain('user').select('id', 'name'),
+        })
+        .take();
+
+      expect(res.users).toEqual([]);
+    });
+
+    it('should render a `hasMany`-like chain (pluck) as a scalar sub-query', async () => {
+      await local.post.insertMany([
+        {
+          title: 'a',
+          body: 'body',
+          user: { create: { name: 'name', password: 'password' } },
+        },
+        {
+          title: 'b',
+          body: 'body',
+          user: { create: { name: 'name', password: 'password' } },
+        },
+      ]);
+
+      const res = await local.$qb
+        .select({
+          titles: () => local.post.pluck('title'),
+        })
+        .take();
+
+      assertType<typeof res, { titles: string[] }>();
+
+      expect((res.titles as string[]).sort()).toEqual(['a', 'b']);
+    });
+  });
 });

--- a/packages/pqb/src/query/basic-features/select/select.utils.ts
+++ b/packages/pqb/src/query/basic-features/select/select.utils.ts
@@ -501,66 +501,95 @@ export const processSelectAsArg = <T extends SelectSelf>(
         joinQuery = true;
         setSelectRelation(query.q);
 
-        value = value.joinQuery(value, q as unknown as IsQuery);
+        const outerHasFrom = query.q.from !== undefined || query.table;
 
-        let subQuery;
-        const { returnType, innerJoinLateral } = value.q;
-        if (!returnType || returnType === 'all') {
-          subQuery = value.json(false);
+        if (!outerHasFrom) {
+          const relationQuery = value as unknown as Query;
+          const { returnType } = relationQuery.q;
+          const isSingle = returnType === 'one' || returnType === 'oneOrThrow';
 
-          // no need to coalesce in case of inner lateral join.
-          if (!innerJoinLateral) {
+          if (returnType === 'pluck' && relationQuery.q.select) {
+            value = relationQuery
+              .wrap(cloneQueryBaseUnscoped(relationQuery))
+              .jsonAgg(relationQuery.q.select[0] as never);
+          } else if (!returnType || returnType === 'all' || isSingle) {
+            // wrap rows into json (array for many, object for a single record)
+            value = relationQuery.json(false);
+          } else {
+            value = relationQuery;
+          }
+
+          const column = Object.create(
+            value.q.getColumn || UnknownColumn.instance,
+          );
+          column.data = { ...column.data, skipValueToArray: true };
+          value.q.getColumn = column;
+          // `COALESCE(..., '[]')` for the empty-result case (many/pluck only).
+          if (!isSingle) {
             value.q.coalesceValue = emptyArrSQL;
           }
-        } else if (returnType === 'pluck') {
-          // no select in case of plucking a computed
-          subQuery = value.q.select
-            ? value
-                .wrap(cloneQueryBaseUnscoped(value))
-                .jsonAgg(value.q.select[0])
-            : value.json(false);
-
-          value.q.coalesceValue = emptyArrSQL;
         } else {
-          if (returnType === 'value' || returnType === 'valueOrThrow') {
-            if (value.q.select) {
-              // todo: investigate what is this for
-              if (typeof value.q.select[0] === 'string') {
-                value.q.select[0] = {
-                  selectAs: { r: value.q.select[0] },
-                };
-              }
+          value = value.joinQuery(value, q as unknown as IsQuery);
 
-              subQuery = value;
-            } else {
-              subQuery = value.json(false);
+          let subQuery;
+          const { returnType, innerJoinLateral } = value.q;
+          if (!returnType || returnType === 'all') {
+            subQuery = value.json(false);
+
+            // no need to coalesce in case of inner lateral join.
+            if (!innerJoinLateral) {
+              value.q.coalesceValue = emptyArrSQL;
             }
+          } else if (returnType === 'pluck') {
+            // no select in case of plucking a computed
+            subQuery = value.q.select
+              ? value
+                  .wrap(cloneQueryBaseUnscoped(value))
+                  .jsonAgg(value.q.select[0])
+              : value.json(false);
+
+            value.q.coalesceValue = emptyArrSQL;
           } else {
-            subQuery = value;
+            if (returnType === 'value' || returnType === 'valueOrThrow') {
+              if (value.q.select) {
+                // todo: investigate what is this for
+                if (typeof value.q.select[0] === 'string') {
+                  value.q.select[0] = {
+                    selectAs: { r: value.q.select[0] },
+                  };
+                }
+
+                subQuery = value;
+              } else {
+                subQuery = value.json(false);
+              }
+            } else {
+              subQuery = value;
+            }
           }
-        }
 
-        const joinLateral =
-          innerJoinLateral || query.q.returnType === 'valueOrThrow';
+          const joinLateral =
+            innerJoinLateral || query.q.returnType === 'valueOrThrow';
 
-        const as = _joinLateral(
-          q,
-          joinLateral ? 'JOIN' : 'LEFT JOIN',
-          subQuery,
-          key,
-          // no need for `ON p.r IS NOT NULL` check when joining a single record,
-          // `JOIN` will handle it on itself.
-          innerJoinLateral &&
-            returnType !== 'one' &&
-            returnType !== 'oneOrThrow',
-        );
-
-        if (as) {
-          value.q.joinedForSelect = _copyQueryAliasToQuery(
-            value,
-            q as unknown as Query,
-            as,
+          const as = _joinLateral(
+            q,
+            joinLateral ? 'JOIN' : 'LEFT JOIN',
+            subQuery,
+            key,
+            // no need for `ON p.r IS NOT NULL` check when joining a single record,
+            // `JOIN` will handle it on itself.
+            innerJoinLateral &&
+              returnType !== 'one' &&
+              returnType !== 'oneOrThrow',
           );
+
+          if (as) {
+            value.q.joinedForSelect = _copyQueryAliasToQuery(
+              value,
+              q as unknown as Query,
+              as,
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Root cause

`$select` is `qb.select(selection).take()` on the base query builder, which has **no table and no FROM**. The relation-select path always emitted a `LEFT JOIN LATERAL` and correlated the relation against the outer table. With no outer table, the join was orphaned and the correlation alias resolved to `undefined`.

## The fix

When the outer query has no FROM/table, the selected relation is now rendered as a **scalar sub-query** in the SELECT list (the same shape already used by `pluck`/`count` sub-selects), skipping the lateral join and its correlation. The relation query already carries its own `WHERE EXISTS`. Queries that have a FROM are unchanged.

## Result after the fix

For the exact example above, the generated SQL is now valid:

```sql
SELECT COALESCE(
  (SELECT json_agg(row_to_json(t.*))
   FROM (
     SELECT DISTINCT "author"."id", "author"."name" FROM "author"
     WHERE EXISTS (SELECT 1 FROM "post" WHERE "post"."authorId" = "author"."id")
   ) "t"),
  '[]'
) "authors"
LIMIT 1
```

No orphan `LEFT JOIN`, no `"undefined"` alias.

And the value returned to the end user:

```ts
const result = await db.$select({
  authors: () => db.post.chain("author").select("id", "name").distinct(),
})

// result:
{ authors: [{ id: 1, name: "Alice" }] }
```

An empty relation result returns `[]` (not `null`), thanks to the `COALESCE(..., '[]')`.

## Tests

Added regression tests in `packages/pqb/src/query/basic-features/join/select-relations.test.ts`:

- a `belongsTo` chain selected on a query without a FROM
- an empty result coalescing to `[]`
- a list/`pluck` path

Closes #745 