### PR TITLE
docs: fix broken connectRetry example (stragegy -> strategy) and a typo

### DIFF
--- a/docs/src/guide/migration-column-methods.md
+++ b/docs/src/guide/migration-column-methods.md
@@ -281,7 +281,7 @@ Possible options are:
 ```ts
 interface IndexOptions {
   name?: string;
-  // NULLS NOT DISTINCT: availabe in Postgres 15+, makes sense only for unique index
+  // NULLS NOT DISTINCT: available in Postgres 15+, makes sense only for unique index
   nullsNotDistinct?: true;
   // create a unique index
   unique?: true;

--- a/docs/src/guide/orm-setup.md
+++ b/docs/src/guide/orm-setup.md
@@ -268,7 +268,7 @@ const options = {
   databaseURL: process.env.DATABASE_URL,
   connectRetry: {
     attempts: 5,
-    stragegy(currentAttempt: number, maxAttempts: number) {
+    strategy(currentAttempt: number, maxAttempts: number) {
       // linear: wait 100ms after 1st attempt, then 200m after 2nd, and so on.
       return setTimeout(currentAttempt * 100);
     },

--- a/packages/pqb/src/adapters/adapter.ts
+++ b/packages/pqb/src/adapters/adapter.ts
@@ -127,7 +127,7 @@ export interface AdapterConfigBase {
    *   databaseURL: process.env.DATABASE_URL,
    *   connectRetry: {
    *     attempts: 5,
-   *     stragegy(currentAttempt: number, maxAttempts: number) {
+   *     strategy(currentAttempt: number, maxAttempts: number) {
    *       // linear: wait 100ms after 1st attempt, then 200m after 2nd, and so on.
    *       return setTimeout(currentAttempt * 100);
    *     },


### PR DESCRIPTION
### The one that matters

The `connectRetry` example passes a custom function as **`stragegy`**:

```ts
connectRetry: {
  attempts: 5,
  stragegy(currentAttempt: number, maxAttempts: number) { ... },
}
```

But the option is `strategy`:

```ts
interface AdapterConfigConnectRetryParam {
  attempts?: number;
  strategy?: AdapterConfigConnectRetryStrategyParam | AdapterConfigConnectRetryStrategy;
}
```

The prose immediately above the example even says "You can pass a custom function to `strategy`". So anyone copy-pasting this gets an unknown key that is silently ignored, and the default backoff is used instead of their function.

`stragegy` occurs exactly twice in the repository, and both are this same example — `docs/src/guide/orm-setup.md:271` and the JSDoc it mirrors in `packages/pqb/src/adapters/adapter.ts:130`. Both are fixed here; it never appears in implementation code, so nothing depends on the misspelling.

### Also

`docs/src/guide/migration-column-methods.md:284` — "NULLS NOT DISTINCT: availabe in Postgres 15+" → "available".