### PR TITLE
Fix parameter encoding for JSON containment operators (#754)

### DIFF
--- a/.changeset/quiet-pandas-compare.md
+++ b/.changeset/quiet-pandas-compare.md
@@ -1,0 +1,5 @@
+---
+'pqb': patch
+---
+
+Fix parameter encoding for JSON containment operators (#754).

--- a/packages/pqb/src/columns/operators.test.ts
+++ b/packages/pqb/src/columns/operators.test.ts
@@ -1574,8 +1574,26 @@ describe('operators', () => {
             SELECT ${UserSelectAll} FROM "schema"."user" "User"
             WHERE "User"."data" ${sql} $1
           `,
-          [JSON.stringify({ a: 'b' })],
+          [testJsonValue({ a: 'b' })],
         );
+      });
+
+      it('should compare JSON values', async () => {
+        const value = { a: 'b' };
+
+        await jsonTable.insert({
+          name: 'name',
+          password: 'password',
+          data: value,
+        });
+
+        const count = await jsonTable
+          .where({
+            data: { [method]: value },
+          })
+          .count();
+
+        expect(count).toBe(1);
       });
 
       it('should handle sub query', () => {

--- a/packages/pqb/src/columns/operators.ts
+++ b/packages/pqb/src/columns/operators.ts
@@ -640,8 +640,10 @@ const jsonPathQueryOp = (
         : ''
   })`;
 
-const shouldEncodeJson = (ctx: ToSQLCtx) =>
-  ctx.q.adapter.driverAdapter.schemaConfig?.jsonEncodedByDriver === false;
+const encodeJsonIfNeeded = (ctx: ToSQLCtx, value: unknown) =>
+  ctx.q.adapter.driverAdapter.schemaConfig?.jsonEncodedByDriver === false
+    ? JSON.stringify(value)
+    : value;
 
 const quoteJsonOperand = (
   arg: unknown,
@@ -650,7 +652,7 @@ const quoteJsonOperand = (
 ): string =>
   isExpression(arg) || isQuery(arg)
     ? quoteValue(arg, ctx, quotedAs)
-    : addValue(ctx.values, shouldEncodeJson(ctx) ? JSON.stringify(arg) : arg);
+    : addValue(ctx.values, encodeJsonIfNeeded(ctx, arg));
 
 const quoteJsonValue = (
   arg: unknown,
@@ -661,18 +663,12 @@ const quoteJsonValue = (
   if (arg && typeof arg === 'object') {
     if (IN && Array.isArray(arg)) {
       return `(${arg
-        .map((value) =>
-          shouldEncodeJson(ctx)
-            ? addValue(ctx.values, JSON.stringify(value))
-            : addValue(ctx.values, value),
-        )
+        .map((value) => addValue(ctx.values, encodeJsonIfNeeded(ctx, value)))
         .join(', ')})`;
     }
 
     if (Array.isArray(arg)) {
-      return shouldEncodeJson(ctx)
-        ? addValue(ctx.values, JSON.stringify(arg))
-        : addValue(ctx.values, arg);
+      return addValue(ctx.values, encodeJsonIfNeeded(ctx, arg));
     }
 
     if (isExpression(arg)) {
@@ -684,9 +680,7 @@ const quoteJsonValue = (
     }
   }
 
-  return shouldEncodeJson(ctx)
-    ? addValue(ctx.values, JSON.stringify(arg))
-    : addValue(ctx.values, arg);
+  return addValue(ctx.values, encodeJsonIfNeeded(ctx, arg));
 };
 
 const serializeJsonValue = (

--- a/packages/pqb/src/columns/operators.ts
+++ b/packages/pqb/src/columns/operators.ts
@@ -1,4 +1,9 @@
-import { IsQuery, Query, SetQueryReturnsColumnOrThrow } from '../query/query';
+import {
+  isQuery,
+  IsQuery,
+  Query,
+  SetQueryReturnsColumnOrThrow,
+} from '../query/query';
 import { Column } from './column';
 import { ToSQLCtx } from '../query/sql/to-sql';
 import { MoveMutativeQueryToCte } from '../query/basic-features/cte/cte.sql';
@@ -206,7 +211,7 @@ const quoteValue = (
       return arg.toSQL(ctx, quotedAs);
     }
 
-    if ('toSQL' in arg) {
+    if (isQuery(arg)) {
       return `(${moveMutativeQueryToCte(ctx, arg as never)})`;
     }
 
@@ -233,7 +238,7 @@ const quoteLikeValue = (
       return arg.toSQL(ctx, quotedAs);
     }
 
-    if ('toSQL' in arg) {
+    if (isQuery(arg)) {
       return `replace(replace((${moveMutativeQueryToCte(
         ctx,
         arg as never,
@@ -638,6 +643,15 @@ const jsonPathQueryOp = (
 const shouldEncodeJson = (ctx: ToSQLCtx) =>
   ctx.q.adapter.driverAdapter.schemaConfig?.jsonEncodedByDriver === false;
 
+const quoteJsonOperand = (
+  arg: unknown,
+  ctx: ToSQLCtx,
+  quotedAs: string | undefined,
+): string =>
+  isExpression(arg) || isQuery(arg)
+    ? quoteValue(arg, ctx, quotedAs)
+    : addValue(ctx.values, shouldEncodeJson(ctx) ? JSON.stringify(arg) : arg);
+
 const quoteJsonValue = (
   arg: unknown,
   ctx: ToSQLCtx,
@@ -665,7 +679,7 @@ const quoteJsonValue = (
       return 'to_jsonb(' + arg.toSQL(ctx, quotedAs) + ')';
     }
 
-    if ('toSQL' in arg) {
+    if (isQuery(arg)) {
       return `to_jsonb((${moveMutativeQueryToCte(ctx, arg as never)}))`;
     }
   }
@@ -685,7 +699,7 @@ const serializeJsonValue = (
       return 'to_jsonb(' + arg.toSQL(ctx, quotedAs) + ')';
     }
 
-    if ('toSQL' in arg) {
+    if (isQuery(arg)) {
       return `to_jsonb((${moveMutativeQueryToCte(ctx, arg as never)}))`;
     }
   }
@@ -760,11 +774,11 @@ const json = {
   ) as never,
   jsonSupersetOf: make(
     (key, value, ctx, quotedAs) =>
-      `${key} @> ${quoteValue(value, ctx, quotedAs)}`,
+      `${key} @> ${quoteJsonOperand(value, ctx, quotedAs)}`,
   ),
   jsonSubsetOf: make(
     (key, value, ctx, quotedAs) =>
-      `${key} <@ ${quoteValue(value, ctx, quotedAs)}`,
+      `${key} <@ ${quoteJsonOperand(value, ctx, quotedAs)}`,
   ),
   jsonSet: makeVarArg(
     (key, [path, value], ctx, quotedAs) =>


### PR DESCRIPTION
Fix for #754. Tests pass for both postgres-js and node-postgres.

Besides, this includes two smaller improvements in the involved code:

- Replaced `'toSQL' in arg` with `isQuery()`.
- Replaced `shouldEncodeJson()` ternaries with `encodeJsonIfNeeded` (separate commit).